### PR TITLE
fix(security): add Redis authentication to docker-compose and config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,8 @@ POSTGRES_DB=soc360
 DATABASE_URL=postgresql+asyncpg://soc360_app:cambia-esto@localhost:5432/soc360
 
 # Redis
-REDIS_URL=redis://localhost:6379/0
+REDIS_PASSWORD=soc360_redis_dev_password
+REDIS_URL=redis://:soc360_redis_dev_password@localhost:6379/0
 
 # JWT
 JWT_SECRET_KEY=cambia-esto-por-otra-clave-secreta-larga

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -50,6 +50,7 @@ class Settings(BaseSettings):
     HUGGINGFACE_API_KEY: str | None = None
     
     #Redis
+    REDIS_PASSWORD: str | None = None
     REDIS_URL: str = "redis://localhost:6379/0"
     REDIS_MAX_CONNECTIONS: int = 20
     
@@ -99,6 +100,9 @@ class Settings(BaseSettings):
     @classmethod
     def redis_auth_in_production(cls, v: str, info) -> str:
         environment = info.data.get("ENVIRONMENT", "development")
+        redis_password = info.data.get("REDIS_PASSWORD")
+        if redis_password and "@" not in v:
+            raise ValueError("REDIS_URL debe incluir autenticación cuando REDIS_PASSWORD está configurado")
         if environment == "production" and "@" not in v:
             raise ValueError("REDIS_URL debe incluir autenticación en producción")
         return v

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,13 +21,18 @@ services:
   redis:
     image: redis:7-alpine
     container_name: soc360_redis
-    command: redis-server --maxmemory 256mb --maxmemory-policy allkeys-lru
+    command: >
+      redis-server
+      --maxmemory 256mb
+      --maxmemory-policy allkeys-lru
+      --requirepass ${REDIS_PASSWORD:-soc360_redis_dev_password}
+    # Host port mapping for local dev ONLY — do not expose in staging/production
     ports:
       - "6379:6379"
     volumes:
       - ./docker/redis-data:/data
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD:-soc360_redis_dev_password}", "ping"]
       interval: 10s
       timeout: 6s
       retries: 5


### PR DESCRIPTION
## Summary

- 🔴 Closes #15 — Redis was exposed on host port 6379 with NO authentication
- Added `--requirepass` to redis-server command in docker-compose
- Updated healthcheck to authenticate with password
- Added `REDIS_PASSWORD` config field with validation
- Updated `.env.example` with proper auth URL format

## Changes

| File | Change |
|------|--------|
| `docker-compose.yml` | Added `--requirepass ${REDIS_PASSWORD:-soc360_redis_dev_password}` |
| `.env.example` | Added `REDIS_PASSWORD`, updated `REDIS_URL` with auth |
| `app/core/config.py` | Added `REDIS_PASSWORD` field + validator |

## Risk

Low — backward compatible for dev (default password). Production must set `REDIS_PASSWORD` and include it in `REDIS_URL`.