### PR TITLE
fix(auth): revoke all sessions on user/tenant deactivation

### DIFF
--- a/app/modules/auth/service.py
+++ b/app/modules/auth/service.py
@@ -155,6 +155,21 @@ async def _revoke_all_user_tokens(
     )
 
 
+async def _revoke_all_user_tokens_for_tenant(
+    tenant_id: UUID,
+    db: AsyncSession,
+) -> None:
+    """Revoca todos los refresh tokens activos de un tenant en una sola query"""
+    await db.execute(
+        update(RefreshToken)
+        .where(RefreshToken.user_id.in_(
+            select(User.id).where(User.tenant_id == tenant_id)
+        ))
+        .where(RefreshToken.revoked_at.is_(None))
+        .values(revoked_at=datetime.now(timezone.utc))
+    )
+
+
 async def login(
     email: str,
     password: str,

--- a/app/modules/tenants/router.py
+++ b/app/modules/tenants/router.py
@@ -5,7 +5,7 @@ from uuid import UUID
 from fastapi import APIRouter, HTTPException, status, Query
 
 from app.core.exceptions import TenantError
-from app.dependencies import DBDep, CurrentUserDep, SuperadminDep
+from app.dependencies import DBDep, CurrentUserDep, SuperadminDep, RedisDep
 from app.modules.tenants import schemas, service
 
 
@@ -108,11 +108,12 @@ async def update_tenant(
 async def deactivate_tenant(
     tenant_id: UUID,
     db: DBDep,
+    redis: RedisDep,
     current_user: SuperadminDep,
 ) -> None:
-    """Desactiva un tenant.No borra datos"""
+    """Desactiva un tenant, sus usuarios, y revoca todas las sesiones"""
     try:
-        await service.deactivate_tenant(tenant_id, db)
+        await service.deactivate_tenant(tenant_id, db, redis)
     except TenantError as exc:
         raise HTTPException(
             status_code=exc.status_code,

--- a/app/modules/tenants/service.py
+++ b/app/modules/tenants/service.py
@@ -5,10 +5,14 @@ import uuid
 import unicodedata
 from typing import Any
 
+from redis.asyncio import Redis
 from sqlalchemy import select, func, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import settings
 from app.core.exceptions import TenantError
+from app.core.security import revoke_all_user_access_tokens
+from app.modules.auth.service import _revoke_all_user_tokens_for_tenant
 from app.modules.tenants.models import Tenant
 from app.modules.tenants.schemas import TenantCreate, TenantUpdate, TenantSettings
 from app.modules.users.models import User
@@ -150,19 +154,40 @@ async def update_tenant(
     return tenant
 
 
-async def deactivate_tenant(tenant_id: uuid.UUID, db: AsyncSession) -> Tenant:
-    """Desactiva el tenant"""
+async def deactivate_tenant(
+    tenant_id: uuid.UUID,
+    db: AsyncSession,
+    redis: Redis,
+) -> Tenant:
+    """Desactiva el tenant, sus usuarios, y revoca todas las sesiones"""
     tenant = await get_tenant_by_id(tenant_id, db)
     if tenant is None:
         raise TenantError("Tenant no encontrado", status_code=404)
     if not tenant.is_active:
         raise TenantError("El tenant ya esta desactivado", status_code=409)
     tenant.is_active = False
+
+    # Desactivar todos los usuarios del tenant
     await db.execute(
         update(User)
         .where(User.tenant_id == tenant_id)
         .values(is_active=False)
     )
+
+    # Revocar todos los refresh tokens de los usuarios del tenant (DB)
+    await _revoke_all_user_tokens_for_tenant(tenant_id, db)
+
+    # Revocar todos los access tokens de los usuarios del tenant (Redis denylist)
+    user_ids = await db.scalars(
+        select(User.id).where(User.tenant_id == tenant_id)
+    )
+    for uid in user_ids:
+        await revoke_all_user_access_tokens(
+            user_id=str(uid),
+            redis=redis,
+            ttl_seconds=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60,
+        )
+
     await db.flush()
     await db.refresh(tenant)
     return tenant

--- a/app/modules/users/router.py
+++ b/app/modules/users/router.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from app.core.exceptions import UserError
 from app.core.logging import get_logger
 from app.core.security import has_minimum_role
-from app.dependencies import DBWithTenantDep, CurrentUserDep, require_role
+from app.dependencies import DBWithTenantDep, CurrentUserDep, require_role, RedisDep
 from app.modules.users import service
 from app.modules.users.models import User
 from app.modules.users.schemas import RoleEnum, UserCreate, UserResponse, UserUpdate
@@ -187,9 +187,10 @@ async def update_user(
 async def deactivate_user(
     user_id: uuid.UUID,
     db: DBWithTenantDep,
+    redis: RedisDep,
     current_user: User = Depends(require_role("admin")),
 ) -> None:
-    """Desactiva un usuario"""
+    """Desactiva un usuario y revoca todas sus sesiones"""
     if user_id == current_user.id:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
@@ -221,7 +222,7 @@ async def deactivate_user(
             )
 
     try:
-        await service.deactivate_user(user_id=user_id, db=db)
+        await service.deactivate_user(user_id=user_id, db=db, redis=redis)
     except UserError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail)
 

--- a/app/modules/users/service.py
+++ b/app/modules/users/service.py
@@ -2,11 +2,14 @@ from __future__ import annotations
 
 import uuid
 
+from redis.asyncio import Redis
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import settings
 from app.core.exceptions import UserError
-from app.core.security import hash_password
+from app.core.security import hash_password, revoke_all_user_access_tokens
+from app.modules.auth.service import _revoke_all_user_tokens
 from app.modules.tenants.models import Tenant
 from app.modules.users.models import User
 from app.modules.users.schemas import UserCreate, UserUpdate
@@ -140,8 +143,9 @@ async def update_user(
 async def deactivate_user(
     user_id: uuid.UUID,
     db: AsyncSession,
+    redis: Redis,
 ) -> None:
-    """Desactiva el usuario"""
+    """Desactiva el usuario y revoca todas sus sesiones activas"""
     user = await get_user_by_id(user_id, db)
     if user is None:
         raise UserError("Usuario no encontrado", status_code=404)
@@ -149,3 +153,13 @@ async def deactivate_user(
         raise UserError("El usuario ya está desactivado", status_code=409)
     user.is_active = False
     await db.flush()
+
+    # Revocar todos los refresh tokens del usuario (DB)
+    await _revoke_all_user_tokens(user_id, db)
+
+    # Revocar todos los access tokens del usuario (Redis denylist)
+    await revoke_all_user_access_tokens(
+        user_id=str(user_id),
+        redis=redis,
+        ttl_seconds=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60,
+    )


### PR DESCRIPTION
Closes #17

## Summary
- Fix session resurrection: deactivated users and tenants now have all access and refresh tokens revoked immediately
- `deactivate_user()`: revokes refresh tokens (DB) + access tokens (Redis denylist)
- `deactivate_tenant()`: revokes all tokens for all users in the tenant
- Added `_revoke_all_user_tokens_for_tenant()` helper for bulk revocation

## Changes
| File | Change |
|------|--------|
| `app/modules/auth/service.py` | Add `_revoke_all_user_tokens_for_tenant()` helper |
| `app/modules/users/service.py` | `deactivate_user()` now receives Redis and revokes all tokens |
| `app/modules/users/router.py` | Inject `RedisDep` into deactivate endpoint |
| `app/modules/tenants/service.py` | `deactivate_tenant()` now receives Redis and revokes all tokens for all users |
| `app/modules/tenants/router.py` | Inject `RedisDep` into deactivate endpoint |

## Test Plan
- [ ] Deactivate a user → verify all their refresh tokens are revoked in DB
- [ ] Deactivate a user → verify all their access tokens are in Redis denylist
- [ ] Deactivate a tenant → verify all users' tokens are revoked
- [ ] Reactivate a user → verify they must re-login (no stale tokens work)
- [ ] Existing auth tests still pass

## Deferred
- None

## Checklist
- [x] Linked issue #17
- [x] Same API contract (no breaking changes)
- [x] ruff check passes
- [x] Follows existing revocation pattern from `change_password()`