### PR TITLE
fix(security): block admin PATCH is_active escalation

### DIFF
--- a/app/modules/auth/router.py
+++ b/app/modules/auth/router.py
@@ -51,7 +51,6 @@ async def login(
             email=body.email,
             password=body.password,
             request_ip=request.client.host if request.client else None,
-            request_headers=dict(request.headers),
             db=db,
             redis=redis,
         )

--- a/app/modules/users/router.py
+++ b/app/modules/users/router.py
@@ -167,6 +167,11 @@ async def update_user(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="No puedes elegir un rol igual o superior al tuyo",
             )
+        if body.is_active is not None and has_minimum_role(target.role, "admin"):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Un admin no puede cambiar el estado de activación de otro admin",
+            )
 
     else:
         raise HTTPException(

--- a/tests/integration/test_users_integration.py
+++ b/tests/integration/test_users_integration.py
@@ -572,6 +572,89 @@ async def test_email_unique_globally_returns_409(
 
 
 # ---------------------------------------------------------------------------
+# ISSUE #18: ADMIN CANNOT CHANGE is_active OF ANOTHER ADMIN VIA PATCH
+# ---------------------------------------------------------------------------
+
+async def test_admin_cannot_deactivate_another_admin_via_patch(
+    client: AsyncClient, admin_a_headers, superadmin_headers, seed_data
+):
+    """Admin no puede desactivar a otro admin del mismo tenant via PATCH.
+
+    Issue #18: El PATCH endpoint bloquea cambios de role y modifica superadmins,
+    pero no bloquea cambios de is_active cuando el target es otro admin.
+    El endpoint DELETE sí tiene esta protección (línea 218-222 del router).
+    """
+    # Superadmin crea un segundo admin en tenant A
+    resp = await client.post(
+        "/api/v1/users/",
+        json={
+            "email": "second-admin@alpha.test",
+            "password": "Password123!",
+            "full_name": "Second Admin",
+            "role": "admin",
+            "tenant_id": TENANT_A_ID,
+        },
+        headers=superadmin_headers,
+    )
+    assert resp.status_code == 201
+    second_admin_id = resp.json()["id"]
+    assert resp.json()["role"] == "admin"
+
+    # Admin A intenta desactivar al segundo admin via PATCH
+    resp = await client.patch(
+        f"/api/v1/users/{second_admin_id}",
+        json={"is_active": False},
+        headers=admin_a_headers,
+    )
+    assert resp.status_code == 403, (
+        f"Admin no deberia poder desactivar a otro admin via PATCH. "
+        f"Got {resp.status_code}: {resp.text}"
+    )
+
+
+async def test_admin_cannot_deactivate_superadmin_via_patch(
+    client: AsyncClient, admin_a_headers, seed_data
+):
+    """Admin no puede desactivar a un superadmin via PATCH.
+
+    Ya existe protección contra modificar superadmins (línea 160-163),
+    pero este test verifica explícitamente el caso de is_active=False.
+    """
+    from tests.conftest import SUPERADMIN_ID
+
+    resp = await client.patch(
+        f"/api/v1/users/{SUPERADMIN_ID}",
+        json={"is_active": False},
+        headers=admin_a_headers,
+    )
+    assert resp.status_code == 403, (
+        f"Admin no deberia poder desactivar superadmin via PATCH. "
+        f"Got {resp.status_code}: {resp.text}"
+    )
+
+
+async def test_admin_can_deactivate_analyst_via_patch(
+    client: AsyncClient, admin_a_headers, seed_data
+):
+    """Admin SÍ puede desactivar usuarios de rol inferior via PATCH.
+
+    Verifica que la protección no bloquea casos legítimos.
+    """
+    from tests.conftest import ANALYST_A_ID
+
+    resp = await client.patch(
+        f"/api/v1/users/{ANALYST_A_ID}",
+        json={"is_active": False},
+        headers=admin_a_headers,
+    )
+    assert resp.status_code == 200, (
+        f"Admin debe poder desactivar analyst via PATCH. "
+        f"Got {resp.status_code}: {resp.text}"
+    )
+    assert resp.json()["is_active"] is False
+
+
+# ---------------------------------------------------------------------------
 # MASS ASSIGNMENT PROTECTION
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- block tenant admins from changing `is_active` for admin-level users via PATCH
- add integration coverage for peer-admin, superadmin, and lower-role PATCH scenarios
- include the small auth router compatibility cleanup needed for the issue #18 test path

## Testing
- .venv/bin/pytest tests/integration/test_users_integration.py -v

## Notes
- Closes #18
- Full-suite baseline failures remain outside this slice and were not introduced by this branch