### PR TITLE
fix(auth): serialize session cap per user

### DIFF
--- a/app/modules/auth/service.py
+++ b/app/modules/auth/service.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone, timedelta
 from uuid import UUID
 
 from redis.asyncio import Redis
-from sqlalchemy import select, update, func
+from sqlalchemy import select, update, func, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
@@ -105,12 +105,36 @@ async def _check_tenant_active(user: User, db: AsyncSession) -> None:
         )
 
 
+# PostgreSQL advisory lock SQL — serializes session-cap checks per user.
+# Uses pg_advisory_xact_lock so the lock is held for the transaction duration
+# and released automatically on commit or rollback.
+_ADVISORY_LOCK_SQL = text(
+    "SELECT pg_advisory_xact_lock(hashtextextended(CAST(:user_id AS text), 0))"
+)
+
+
+async def _acquire_session_cap_lock(user_id: UUID, db: AsyncSession) -> None:
+    """Acquire a transaction-scoped advisory lock for session-cap serialization.
+
+    Must be called inside an active transaction (db.in_transaction() == True).
+    The lock blocks concurrent calls for the same user_id until the holding
+    transaction commits or rolls back, preventing race conditions in the
+    session-cap check + insert sequence.
+    """
+    if not db.in_transaction():
+        raise RuntimeError(
+            "_acquire_session_cap_lock requires an active transaction"
+        )
+    await db.execute(_ADVISORY_LOCK_SQL, {"user_id": str(user_id)})
+
+
 async def _create_refresh_token(
     user_id: UUID,
     db: AsyncSession,
     created_from_ip: str | None = None,
 ) -> str:
     """Genera un refresh token seguro, lo hashea y guarda en BD"""
+    await _acquire_session_cap_lock(user_id, db)
     active_count = await db.scalar(
         select(func.count()).select_from(RefreshToken)
         .where(RefreshToken.user_id == user_id)
@@ -175,7 +199,8 @@ async def login(
     password: str,
     db: AsyncSession,
     redis: Redis,
-    request_ip: str | None = None
+    request_ip: str | None = None,
+    request_headers: dict | None = None,
 ) -> tuple[TokenResponse, str]:
     """Autentica al usuario y delvuelve el access token + refresh token"""
     await _check_account_lockout(email, redis)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,46 +87,70 @@ async def db_session():
 @pytest_asyncio.fixture
 async def seed_data(db_session: AsyncSession):
     from uuid import UUID
+    from sqlalchemy.dialects.postgresql import insert as pg_insert
 
-    tenant_a = Tenant(
-        id=UUID(TENANT_A_ID), name="Empresa Alpha", slug="empresa-alpha",
-        plan="starter", is_active=True, max_assets=50,
-    )
-    tenant_b = Tenant(
-        id=UUID(TENANT_B_ID), name="Empresa Beta", slug="empresa-beta",
-        plan="free", is_active=True, max_assets=10,
-    )
-    superadmin = User(
-        id=UUID(SUPERADMIN_ID), tenant_id=None,
-        email="superadmin@soc360.test", hashed_password=hash_password("SuperAdmin123!"),
-        full_name="Super Admin", role="superadmin", is_active=True, is_superadmin=True,
-    )
-    admin_a = User(
-        id=UUID(ADMIN_A_ID), tenant_id=UUID(TENANT_A_ID),
-        email="admin@alpha.test", hashed_password=hash_password("AdminAlpha123!"),
-        full_name="Admin Alpha", role="admin", is_active=True, is_superadmin=False,
-    )
-    analyst_a = User(
-        id=UUID(ANALYST_A_ID), tenant_id=UUID(TENANT_A_ID),
-        email="analyst@alpha.test", hashed_password=hash_password("AnalystAlpha123!"),
-        full_name="Analyst Alpha", role="analyst", is_active=True, is_superadmin=False,
-    )
-    viewer_a = User(
-        id=UUID(VIEWER_A_ID), tenant_id=UUID(TENANT_A_ID),
-        email="viewer@alpha.test", hashed_password=hash_password("ViewerAlpha123!"),
-        full_name="Viewer Alpha", role="viewer", is_active=True, is_superadmin=False,
-    )
-    admin_b = User(
-        id=UUID(ADMIN_B_ID), tenant_id=UUID(TENANT_B_ID),
-        email="admin@beta.test", hashed_password=hash_password("AdminBeta123!"),
-        full_name="Admin Beta", role="admin", is_active=True, is_superadmin=False,
-    )
-
+    # Idempotent tenant inserts — concurrency tests may have already committed these
     await db_session.execute(text("SET LOCAL app.is_superadmin = 'true'"))
-    db_session.add_all([tenant_a, tenant_b])
+    await db_session.execute(
+        pg_insert(Tenant).values(
+            id=UUID(TENANT_A_ID), name="Empresa Alpha", slug="empresa-alpha",
+            plan="starter", is_active=True, max_assets=50,
+        ).on_conflict_do_nothing(index_elements=["id"])
+    )
+    await db_session.execute(
+        pg_insert(Tenant).values(
+            id=UUID(TENANT_B_ID), name="Empresa Beta", slug="empresa-beta",
+            plan="free", is_active=True, max_assets=10,
+        ).on_conflict_do_nothing(index_elements=["id"])
+    )
     await db_session.flush()
-    db_session.add_all([superadmin, admin_a, analyst_a, viewer_a, admin_b])
+
+    # Idempotent user inserts
+    await db_session.execute(
+        pg_insert(User).values(
+            id=UUID(SUPERADMIN_ID), tenant_id=None,
+            email="superadmin@soc360.test", hashed_password=hash_password("SuperAdmin123!"),
+            full_name="Super Admin", role="superadmin", is_active=True, is_superadmin=True,
+        ).on_conflict_do_nothing(index_elements=["id"])
+    )
+    await db_session.execute(
+        pg_insert(User).values(
+            id=UUID(ADMIN_A_ID), tenant_id=UUID(TENANT_A_ID),
+            email="admin@alpha.test", hashed_password=hash_password("AdminAlpha123!"),
+            full_name="Admin Alpha", role="admin", is_active=True, is_superadmin=False,
+        ).on_conflict_do_nothing(index_elements=["id"])
+    )
+    await db_session.execute(
+        pg_insert(User).values(
+            id=UUID(ANALYST_A_ID), tenant_id=UUID(TENANT_A_ID),
+            email="analyst@alpha.test", hashed_password=hash_password("AnalystAlpha123!"),
+            full_name="Analyst Alpha", role="analyst", is_active=True, is_superadmin=False,
+        ).on_conflict_do_nothing(index_elements=["id"])
+    )
+    await db_session.execute(
+        pg_insert(User).values(
+            id=UUID(VIEWER_A_ID), tenant_id=UUID(TENANT_A_ID),
+            email="viewer@alpha.test", hashed_password=hash_password("ViewerAlpha123!"),
+            full_name="Viewer Alpha", role="viewer", is_active=True, is_superadmin=False,
+        ).on_conflict_do_nothing(index_elements=["id"])
+    )
+    await db_session.execute(
+        pg_insert(User).values(
+            id=UUID(ADMIN_B_ID), tenant_id=UUID(TENANT_B_ID),
+            email="admin@beta.test", hashed_password=hash_password("AdminBeta123!"),
+            full_name="Admin Beta", role="admin", is_active=True, is_superadmin=False,
+        ).on_conflict_do_nothing(index_elements=["id"])
+    )
     await db_session.flush()
+
+    # Fetch persisted records for test use
+    tenant_a = await db_session.get(Tenant, UUID(TENANT_A_ID))
+    tenant_b = await db_session.get(Tenant, UUID(TENANT_B_ID))
+    superadmin = await db_session.get(User, UUID(SUPERADMIN_ID))
+    admin_a = await db_session.get(User, UUID(ADMIN_A_ID))
+    analyst_a = await db_session.get(User, UUID(ANALYST_A_ID))
+    viewer_a = await db_session.get(User, UUID(VIEWER_A_ID))
+    admin_b = await db_session.get(User, UUID(ADMIN_B_ID))
 
     return {
         "tenant_a": tenant_a, "tenant_b": tenant_b,
@@ -208,3 +232,50 @@ async def viewer_a_headers(viewer_a_token: str) -> dict:
 @pytest_asyncio.fixture
 async def admin_b_headers(admin_b_token: str) -> dict:
     return {"Authorization": f"Bearer {admin_b_token}"}
+
+
+# ---------------------------------------------------------------------------
+# Concurrency test infrastructure — real pooled connections for parallel tests
+# ---------------------------------------------------------------------------
+
+@pytest_asyncio.fixture(scope="function")
+async def pooled_engine():
+    """Engine with a real connection pool for concurrency tests.
+
+    Unlike the default NullPool fixture, this allows multiple concurrent
+    sessions to obtain separate DB connections, which is required to prove
+    advisory-lock serialization under parallel load.
+    """
+    engine = create_async_engine(
+        TEST_DATABASE_URL,
+        echo=False,
+        pool_size=10,
+        max_overflow=10,
+    )
+    yield engine
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture(scope="function")
+async def isolated_db_session(pooled_engine):
+    """Factory that yields function-scoped AsyncSession instances from a pooled engine.
+
+    Usage in concurrency tests:
+        session1 = await isolated_db_session()
+        session2 = await isolated_db_session()
+    Each call returns a fresh session with its own DB connection.
+    """
+    session_factory = async_sessionmaker(
+        bind=pooled_engine, class_=AsyncSession, expire_on_commit=False
+    )
+    sessions: list[AsyncSession] = []
+
+    def _make_session() -> AsyncSession:
+        s = session_factory()
+        sessions.append(s)
+        return s
+
+    yield _make_session
+
+    for s in sessions:
+        await s.close()

--- a/tests/modules/auth/test_refresh_token_race.py
+++ b/tests/modules/auth/test_refresh_token_race.py
@@ -3,14 +3,23 @@ from __future__ import annotations
 import asyncio
 import hashlib
 from datetime import datetime, timedelta, timezone
+from typing import Callable
 from uuid import UUID
 
-from httpx import AsyncClient, Response
-from sqlalchemy import func, select
+from fakeredis.aioredis import FakeRedis
+from httpx import AsyncClient, ASGITransport, Response
+from sqlalchemy import func, select, text, insert, update
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.redis import get_redis
+from app.core.security import hash_password
+from app.dependencies import get_db, get_db_with_tenant
+from app.main import create_app
 from app.modules.auth.models import RefreshToken
-from tests.conftest import ADMIN_A_ID
+from app.modules.tenants.models import Tenant
+from app.modules.users.models import User
+from tests.conftest import ADMIN_A_ID, TENANT_A_ID
 
 
 def _hash_refresh_token(raw_token: str) -> str:
@@ -57,27 +66,115 @@ async def _get_refresh_record(db_session: AsyncSession, raw_token: str) -> Refre
     )
 
 
-async def test_refresh_token_concurrent_race(client: AsyncClient, seed_data, db_session: AsyncSession):
-    refresh_token = await _login_and_get_refresh_token(client)
-    user_id = UUID(ADMIN_A_ID)
-    before_total = await _count_refresh_tokens(db_session, user_id)
+ADMIN_A_EMAIL = "admin@alpha.test"
+ADMIN_A_PASSWORD = "AdminAlpha123!"
 
-    responses = await asyncio.gather(
-        _refresh_with_cookie(client, refresh_token),
-        _refresh_with_cookie(client, refresh_token),
+
+async def _ensure_user_exists(db: AsyncSession) -> None:
+    """Seed tenant + user if not present (idempotent, conflict-safe)."""
+    tenant_exists = await db.scalar(
+        select(func.count()).select_from(Tenant).where(Tenant.id == UUID(TENANT_A_ID))
+    )
+    if not tenant_exists:
+        await db.execute(
+            pg_insert(Tenant).values(
+                id=UUID(TENANT_A_ID), name="Empresa Alpha", slug="empresa-alpha",
+                plan="starter", is_active=True, max_assets=50,
+            ).on_conflict_do_nothing(index_elements=["id"])
+        )
+        await db.flush()
+
+    user_exists = await db.scalar(
+        select(func.count()).select_from(User).where(User.id == UUID(ADMIN_A_ID))
+    )
+    if not user_exists:
+        await db.execute(text("SET LOCAL app.is_superadmin = 'true'"))
+        await db.execute(
+            pg_insert(User).values(
+                id=UUID(ADMIN_A_ID), tenant_id=UUID(TENANT_A_ID),
+                email=ADMIN_A_EMAIL, hashed_password=hash_password(ADMIN_A_PASSWORD),
+                full_name="Admin Alpha", role="admin", is_active=True, is_superadmin=False,
+            ).on_conflict_do_nothing(index_elements=["id"])
+        )
+        await db.flush()
+
+
+def _make_client_with_session(
+    session_factory: Callable[[], AsyncSession],
+) -> AsyncClient:
+    """Create an AsyncClient whose requests use a fresh DB session.
+
+    Each call produces a client backed by its own AsyncSession, which gets
+    a separate DB connection from the pooled engine. This is required to
+    prove real concurrency rather than shared-session fake concurrency.
+    """
+    app = create_app()
+    fake_redis = FakeRedis()
+    _session = session_factory()
+
+    async def _override_get_db():
+        async with _session.begin():
+            yield _session
+
+    async def _override_get_db_with_tenant():
+        async with _session.begin():
+            yield _session
+
+    async def _override_get_redis():
+        yield fake_redis
+
+    app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[get_db_with_tenant] = _override_get_db_with_tenant
+    app.dependency_overrides[get_redis] = _override_get_redis
+
+    return AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
     )
 
-    successful = [response for response in responses if response.status_code == 200]
-    unauthorized = [response for response in responses if response.status_code == 401]
 
-    assert len(successful) == 1
-    assert len(unauthorized) == 1
+async def test_refresh_token_concurrent_race(isolated_db_session):
+    """Two concurrent refresh requests with same token → exactly 1 succeeds.
 
-    after_total = await _count_refresh_tokens(db_session, user_id)
-    after_active = await _count_active_refresh_tokens(db_session, user_id)
+    Uses isolated DB sessions per request (via pooled engine) to prove real
+    concurrency. The shared client/db_session fixture fakes concurrency by
+    routing all requests through a single NullPool connection.
+    """
+    user_id = UUID(ADMIN_A_ID)
 
-    assert after_total == before_total + 1
-    assert after_active == 1
+    # Seed user (committed so login queries can find it)
+    seed = isolated_db_session()
+    async with seed.begin():
+        await _ensure_user_exists(seed)
+        await seed.commit()
+
+    # Login to obtain a refresh token
+    login_client = _make_client_with_session(isolated_db_session)
+    async with login_client:
+        refresh_token = await _login_and_get_refresh_token(login_client)
+
+    # Two concurrent refresh requests, each with its own DB session/connection
+    async def _do_refresh() -> Response:
+        client = _make_client_with_session(isolated_db_session)
+        async with client:
+            return await _refresh_with_cookie(client, refresh_token)
+
+    responses = await asyncio.gather(_do_refresh(), _do_refresh())
+
+    successful = [r for r in responses if r.status_code == 200]
+    unauthorized = [r for r in responses if r.status_code == 401]
+
+    assert len(successful) == 1, f"Expected 1 success, got {len(successful)}: {[r.status_code for r in responses]}"
+    assert len(unauthorized) == 1, f"Expected 1 unauthorized, got {len(unauthorized)}"
+
+    # Verify final state: login token + rotated token = 2 total, 1 active
+    verify = isolated_db_session()
+    async with verify.begin():
+        after_total = await _count_refresh_tokens(verify, user_id)
+        after_active = await _count_active_refresh_tokens(verify, user_id)
+
+    assert after_total == 2, f"Expected 2 total tokens (login + rotated), got {after_total}"
+    assert after_active == 1, f"Expected 1 active token, got {after_active}"
 
 
 async def test_refresh_token_revoked_after_lock(client: AsyncClient, seed_data, db_session: AsyncSession):
@@ -113,8 +210,17 @@ async def test_refresh_token_expired(client: AsyncClient, seed_data, db_session:
 
 
 async def test_refresh_token_happy_path_preserved(client: AsyncClient, seed_data, db_session: AsyncSession):
-    old_refresh_token = await _login_and_get_refresh_token(client)
     user_id = UUID(ADMIN_A_ID)
+
+    # Clean up any leftover tokens from concurrency tests that committed data
+    await db_session.execute(
+        update(RefreshToken)
+        .where(RefreshToken.user_id == user_id)
+        .values(revoked_at=datetime.now(timezone.utc))
+    )
+    await db_session.flush()
+
+    old_refresh_token = await _login_and_get_refresh_token(client)
     before_total = await _count_refresh_tokens(db_session, user_id)
 
     response = await _refresh_with_cookie(client, old_refresh_token)

--- a/tests/modules/auth/test_session_cap_advisory_lock.py
+++ b/tests/modules/auth/test_session_cap_advisory_lock.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.modules.auth.service import _acquire_session_cap_lock
+
+ADMIN_A = UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+
+
+@pytest.mark.asyncio
+async def test_advisory_lock_emits_correct_sql():
+    """Verify _acquire_session_cap_lock emits pg_advisory_xact_lock SQL."""
+    mock_db = MagicMock(spec=AsyncSession)
+    mock_db.in_transaction.return_value = True
+    mock_db.execute = AsyncMock()
+
+    await _acquire_session_cap_lock(ADMIN_A, mock_db)
+
+    mock_db.execute.assert_awaited_once()
+    call_args = mock_db.execute.call_args
+    sql_text = str(call_args[0][0])
+    assert "pg_advisory_xact_lock" in sql_text
+    assert "hashtextextended" in sql_text
+    params = call_args[0][1]
+    assert params["user_id"] == str(ADMIN_A)
+
+
+@pytest.mark.asyncio
+async def test_advisory_lock_raises_outside_transaction():
+    """Advisory lock must refuse to run outside an active transaction."""
+    mock_db = MagicMock(spec=AsyncSession)
+    mock_db.in_transaction.return_value = False
+
+    with pytest.raises(RuntimeError, match="active transaction"):
+        await _acquire_session_cap_lock(ADMIN_A, mock_db)

--- a/tests/modules/auth/test_session_cap_concurrency.py
+++ b/tests/modules/auth/test_session_cap_concurrency.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+from datetime import datetime, timedelta, timezone
+from typing import Callable
+from uuid import UUID
+
+import pytest
+from fakeredis.aioredis import FakeRedis
+from httpx import AsyncClient, ASGITransport
+from sqlalchemy import func, select, text, update
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.core.database import Base
+from app.core.redis import get_redis
+from app.core.security import hash_password
+from app.dependencies import get_db, get_db_with_tenant
+from app.main import create_app
+from app.modules.auth.models import RefreshToken
+from app.modules.auth.service import MAX_ACTIVE_SESSIONS
+from app.modules.tenants.models import Tenant
+from app.modules.users.models import User
+from tests.conftest import (
+    ADMIN_A_ID,
+    TENANT_A_ID,
+    TEST_DATABASE_URL,
+)
+
+ADMIN_A_EMAIL = "admin@alpha.test"
+ADMIN_A_PASSWORD = "AdminAlpha123!"
+
+
+def _hash_token(raw: str) -> str:
+    return hashlib.sha256(raw.encode()).hexdigest()
+
+
+async def _count_active(db: AsyncSession, user_id: UUID) -> int:
+    return await db.scalar(
+        select(func.count())
+        .select_from(RefreshToken)
+        .where(RefreshToken.user_id == user_id)
+        .where(RefreshToken.revoked_at.is_(None))
+        .where(RefreshToken.expires_at > datetime.now(timezone.utc))
+    ) or 0
+
+
+async def _ensure_user_exists(db: AsyncSession) -> None:
+    """Seed tenant + user if not present (idempotent for concurrency tests)."""
+    exists = await db.scalar(
+        select(func.count()).select_from(User).where(User.id == UUID(ADMIN_A_ID))
+    )
+    if exists:
+        return
+
+    tenant = Tenant(
+        id=UUID(TENANT_A_ID), name="Empresa Alpha", slug="empresa-alpha",
+        plan="starter", is_active=True, max_assets=50,
+    )
+    user = User(
+        id=UUID(ADMIN_A_ID), tenant_id=UUID(TENANT_A_ID),
+        email=ADMIN_A_EMAIL, hashed_password=hash_password(ADMIN_A_PASSWORD),
+        full_name="Admin Alpha", role="admin", is_active=True, is_superadmin=False,
+    )
+    await db.execute(text("SET LOCAL app.is_superadmin = 'true'"))
+    db.add(tenant)
+    await db.flush()
+    db.add(user)
+    await db.flush()
+
+
+async def _cleanup_user_tokens(db: AsyncSession, user_id: UUID) -> None:
+    """Revoke all refresh tokens for a user to ensure clean test state."""
+    await db.execute(
+        update(RefreshToken)
+        .where(RefreshToken.user_id == user_id)
+        .values(revoked_at=datetime.now(timezone.utc))
+    )
+    await db.flush()
+
+
+async def _seed_active_tokens(
+    db: AsyncSession, user_id: UUID, count: int
+) -> list[str]:
+    """Insert `count` active refresh tokens and return raw token strings."""
+    tokens: list[str] = []
+    for i in range(count):
+        raw = f"seed_{user_id}_{i}_{datetime.now(timezone.utc).isoformat()}"
+        db.add(RefreshToken(
+            user_id=user_id,
+            token_hash=_hash_token(raw),
+            expires_at=datetime.now(timezone.utc) + timedelta(days=7),
+        ))
+        tokens.append(raw)
+    await db.flush()
+    return tokens
+
+
+async def _login_via_client(client: AsyncClient) -> str | None:
+    """POST /login and return the refresh_token cookie value."""
+    resp = await client.post(
+        "/api/v1/auth/login",
+        json={"email": ADMIN_A_EMAIL, "password": ADMIN_A_PASSWORD},
+    )
+    assert resp.status_code == 200, f"Login failed: {resp.text}"
+    return resp.cookies.get("refresh_token")
+
+
+def _make_client_with_session(
+    session_factory: Callable[[], AsyncSession],
+) -> AsyncClient:
+    """Create an AsyncClient whose /auth requests use a fresh DB session."""
+    app = create_app()
+    fake_redis = FakeRedis()
+    _session = session_factory()
+
+    async def _override_get_db():
+        async with _session.begin():
+            yield _session
+
+    async def _override_get_db_with_tenant():
+        async with _session.begin():
+            yield _session
+
+    async def _override_get_redis():
+        yield fake_redis
+
+    app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[get_db_with_tenant] = _override_get_db_with_tenant
+    app.dependency_overrides[get_redis] = _override_get_redis
+
+    return AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    )
+
+
+@pytest.mark.asyncio
+async def test_session_cap_burst_from_zero_active(isolated_db_session):
+    """6 parallel logins from 0 active sessions → exactly 5 active after."""
+    user_id = UUID(ADMIN_A_ID)
+
+    # Seed user (committed so login queries can find it)
+    seed = isolated_db_session()
+    async with seed.begin():
+        await _ensure_user_exists(seed)
+        await _cleanup_user_tokens(seed, user_id)
+        await seed.commit()
+
+    # Verify starting state: 0 active
+    verify = isolated_db_session()
+    async with verify.begin():
+        start_count = await _count_active(verify, user_id)
+    assert start_count == 0, f"Expected 0 active, got {start_count}"
+
+    # Fire 6 parallel logins, each with its own DB session
+    async def _do_login():
+        client = _make_client_with_session(isolated_db_session)
+        async with client:
+            return await _login_via_client(client)
+
+    results = await asyncio.gather(*[_do_login() for _ in range(6)])
+    assert all(r is not None for r in results), "All logins should succeed"
+
+    # Verify final state: exactly MAX_ACTIVE_SESSIONS
+    check = isolated_db_session()
+    async with check.begin():
+        final_count = await _count_active(check, user_id)
+    assert final_count == MAX_ACTIVE_SESSIONS, (
+        f"Expected {MAX_ACTIVE_SESSIONS} active sessions, got {final_count}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_session_cap_burst_from_four_active(isolated_db_session):
+    """6 parallel logins from 4 active sessions → exactly 5 active after."""
+    user_id = UUID(ADMIN_A_ID)
+
+    # Seed user + 4 active tokens (committed)
+    seed = isolated_db_session()
+    async with seed.begin():
+        await _ensure_user_exists(seed)
+        await _cleanup_user_tokens(seed, user_id)
+        await _seed_active_tokens(seed, user_id, 4)
+        await seed.commit()
+
+    # Fire 6 parallel logins
+    async def _do_login():
+        client = _make_client_with_session(isolated_db_session)
+        async with client:
+            return await _login_via_client(client)
+
+    results = await asyncio.gather(*[_do_login() for _ in range(6)])
+    assert all(r is not None for r in results)
+
+    # Verify: exactly 5
+    check = isolated_db_session()
+    async with check.begin():
+        final_count = await _count_active(check, user_id)
+    assert final_count == MAX_ACTIVE_SESSIONS, (
+        f"Expected {MAX_ACTIVE_SESSIONS} active sessions, got {final_count}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_session_cap_burst_from_five_active(isolated_db_session):
+    """6 parallel logins from 5 active sessions → exactly 5 active after."""
+    user_id = UUID(ADMIN_A_ID)
+
+    # Seed user + 5 active tokens (committed)
+    seed = isolated_db_session()
+    async with seed.begin():
+        await _ensure_user_exists(seed)
+        await _cleanup_user_tokens(seed, user_id)
+        await _seed_active_tokens(seed, user_id, 5)
+        await seed.commit()
+
+    # Fire 6 parallel logins
+    async def _do_login():
+        client = _make_client_with_session(isolated_db_session)
+        async with client:
+            return await _login_via_client(client)
+
+    results = await asyncio.gather(*[_do_login() for _ in range(6)])
+    assert all(r is not None for r in results)
+
+    # Verify: exactly 5
+    check = isolated_db_session()
+    async with check.begin():
+        final_count = await _count_active(check, user_id)
+    assert final_count == MAX_ACTIVE_SESSIONS, (
+        f"Expected {MAX_ACTIVE_SESSIONS} active sessions, got {final_count}"
+    )


### PR DESCRIPTION
## Summary
- serialize session-cap enforcement per user with a PostgreSQL advisory lock in `_create_refresh_token()`
- add real concurrency evidence for start states 0, 4, and 5 active sessions using isolated pooled DB sessions
- repair the pre-existing refresh-token race test so it proves real DB contention instead of shared-session fake concurrency

## Testing
- .venv/bin/pytest tests/modules/auth -v

## Notes
- Closes #20
- Verify passed for issue behavior and auth-module evidence; remaining SDD traceability gaps are in engram artifacts, not repo code