### PR TITLE
fix(auth): harden login lockout privacy

### DIFF
--- a/app/modules/auth/service.py
+++ b/app/modules/auth/service.py
@@ -38,14 +38,17 @@ def _login_attempts_key(email: str) -> str:
 
 
 async def _check_account_lockout(email: str, redis: Redis) -> None:
-    """Verifica si la cuenta esta bloqueada por demasiados intentos fallidos"""
+    """Verifica si la cuenta esta bloqueada por demasiados intentos fallidos.
+
+    El lockout se rastrea internamente (Redis) pero el response PUBLICO
+    devuelve 401 generico para no revelar existencia de la cuenta.
+    """
     key = _login_attempts_key(email)
     attempts = await redis.get(key)
     if attempts and int(attempts) >= LOGIN_ATTEMPTS_MAX:
-        ttl = await redis.ttl(key)
         raise AuthError(
-            status_code=429,
-            detail=f"Cuenta bloqueada temporalmente. Intenta de nuevo en {ttl} segundos.",
+            status_code=401,
+            detail="Credenciales incorrectas",
         )
 
 
@@ -211,7 +214,7 @@ async def login(
         await _record_failed_attempt(email, redis)
         raise AuthError(
             status_code=401,
-            detail="Credenciales incorrectas.",
+            detail="Credenciales incorrectas",
         )
     
     await _check_tenant_active(user, db)

--- a/migrations/versions/20260425_1000_add_last_login_at_to_users_b5e9d8c4a123.py
+++ b/migrations/versions/20260425_1000_add_last_login_at_to_users_b5e9d8c4a123.py
@@ -1,0 +1,28 @@
+"""add last_login_at to users
+
+Revision ID: b5e9d8c4a123
+Revises: 70dc591dac68
+Create Date: 2026-04-25 10:00:00.000000
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b5e9d8c4a123'
+down_revision: Union[str, None] = '70dc591dac68'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('users', sa.Column('last_login_at', sa.DateTime(timezone=True), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('users', 'last_login_at')

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,6 @@
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = function
 testpaths = tests
+markers =
+    integration: Integration tests requiring real PostgreSQL and Alembic migrations
+    unit: Unit tests using mocks and fakeredis (default, no marker needed)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,14 +1,181 @@
-"""Override session-scoped DB fixture for integration tests.
+"""Integration test configuration using real PostgreSQL + Alembic migrations.
 
-These integration tests use fakeredis (not real Redis) and mocks (not real DB),
-so the autouse prepare_database from tests/conftest.py must be a no-op here.
+This conftest is loaded ONLY for tests under tests/integration/.
+It overrides the session-scoped prepare_database fixture to use real
+Alembic migrations instead of the Base.metadata.create_all() approach.
+
+Gate 0: tests must run against real schema (not no-op) so that functional
+failures are real bugs, not missing schema.
 """
 from __future__ import annotations
 
+import asyncio
+import os
+import re
+import subprocess
+import sys
+
 import pytest
 
+# Global marker for all tests in this directory
+pytestmark = pytest.mark.integration
+
+
+def pytest_collection_modifyitems(items):
+    """Forcefully mark all tests in tests/integration/ with the integration marker.
+
+    This ensures `pytest -m integration` works even when pytestmark in conftest
+    alone doesn't reliably propagate to the test collection.
+    """
+    integration_path = "tests/integration"
+    for item in items:
+        if integration_path in str(item.fspath):
+            item.add_marker(pytest.mark.integration)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — safe logging (never print credentials)
+# ---------------------------------------------------------------------------
+
+def _db_url_for_log(url: str) -> str:
+    """Mask password in DATABASE_URL for error messages."""
+    if not url:
+        return "<not set>"
+    parts = url.split("@")
+    if len(parts) == 2:
+        creds = parts[0].replace("postgresql+asyncpg://", "")
+        return f"postgresql+asyncpg://{creds.split(':')[0]}:***@{parts[1]}"
+    return url
+
+
+def _sanitize_output(text: str, db_url: str = "") -> str:
+    """Remove database URLs and credentials from Alembic output.
+
+    Prevents accidental credential leakage via stderr/stdout in error messages
+    or logs. Strips the full postgresql+asyncpg://user:pass@host:port/db format.
+    """
+    if not text:
+        return text
+    # Remove DATABASE_URL in all its forms (postgresql+asyncpg, postgresql, etc.)
+    text = re.sub(
+        r"postgresql(?:\+asyncpg)?://[^@]+@[^/\s]+/[^\s]*",
+        "[DB_URL_REDACTED]",
+        text,
+        flags=re.IGNORECASE,
+    )
+    # Fallback: if db_url was provided, mask it explicitly
+    if db_url:
+        text = text.replace(db_url, "[DB_URL_REDACTED]")
+    return text
+
+
+def _run_alembic_upgrade(dry_run: bool = False, db_url: str = "") -> None:
+    """Apply Alembic migrations via subprocess (avoids import-time side-effects).
+
+    Raises RuntimeError if alembic fails or DB is unreachable.
+    """
+    # project_root is the repo root where alembic.ini lives
+    project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    cmd = [
+        sys.executable, "-m", "alembic", "upgrade", "head",
+    ]
+    env = {**os.environ, "PYTHONPATH": project_root}
+
+    try:
+        result = subprocess.run(
+            cmd,
+            cwd=project_root,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    except subprocess.TimeoutExpired:
+        raise RuntimeError(
+            "Alembic upgrade timed out after 60s. "
+            "Check if PostgreSQL is reachable."
+        )
+    except Exception as e:
+        raise RuntimeError(f"Failed to run alembic: {e}")
+
+    if result.returncode != 0:
+        stderr = _sanitize_output(result.stderr.strip(), db_url)
+        safe_db_url = _db_url_for_log(db_url)
+        raise RuntimeError(
+            f"Alembic upgrade failed (exit {result.returncode}).\n"
+            f"DB URL (safe): {safe_db_url}\n"
+            f"stderr: {stderr}"
+        )
+
+    if dry_run:
+        stdout = _sanitize_output(result.stdout.strip(), db_url)
+        safe_db_url = _db_url_for_log(db_url)
+        print(f"[prepare_database] Alembic dry-run OK for {safe_db_url}")
+        if stdout:
+            print(f"[prepare_database] stdout: {stdout}")
+
+
+# ---------------------------------------------------------------------------
+# Session-scoped fixture — runs ONCE per test session
+# ---------------------------------------------------------------------------
 
 @pytest.fixture(scope="session", autouse=True)
 def prepare_database():
-    # No-op: integration tests use mocks, no PostgreSQL needed
+    """Apply Alembic migrations to the test database.
+
+    Fails fast with a clear message if:
+    - DATABASE_URL is not set
+    - PostgreSQL is unreachable
+    - Alembic upgrade fails
+    """
+    db_url = os.environ.get("DATABASE_URL", "")
+
+    if not db_url:
+        raise RuntimeError(
+            "DATABASE_URL not set. Cannot run integration tests. "
+            "Set it to a test PostgreSQL instance."
+        )
+
+    # Quick connectivity check before trying migrations
+    try:
+        import asyncpg
+        import re
+        # Extract connection params from DATABASE_URL
+        # Format: postgresql+asyncpg://user:pass@host:port/dbname
+        match = re.match(
+            r"postgresql\+asyncpg://([^:]+):([^@]+)@([^:]+):(\d+)/(.+)",
+            db_url,
+        )
+        if match:
+            user, password, host, port, dbname = match.groups()
+            async def _ping():
+                conn = await asyncpg.connect(
+                    user=user, password=password,
+                    host=host, port=int(port), database=dbname,
+                    timeout=5,
+                )
+                await conn.close()
+            asyncio.run(_ping())
+        else:
+            # Fallback: try via SQLAlchemy
+            from sqlalchemy.ext.asyncio import create_async_engine
+            from sqlalchemy import text
+            engine = create_async_engine(db_url, echo=False)
+            async def _ping():
+                async with engine.begin() as conn:
+                    await conn.execute(text("SELECT 1"))
+            asyncio.run(_ping())
+            asyncio.run(engine.dispose())
+    except Exception as e:
+        raise RuntimeError(
+            f"Cannot connect to test database. "
+            f"DB URL (safe): {_db_url_for_log(db_url)}. "
+            f"Error: {e}"
+        )
+
+    _run_alembic_upgrade(db_url=db_url)
+
     yield
+
+    # Teardown: run alembic downgrade to base (optional, CI may handle this)
+    # Skipped by default to preserve DB state for post-mortem inspection.

--- a/tests/integration/test_auth_integration.py
+++ b/tests/integration/test_auth_integration.py
@@ -10,7 +10,11 @@ from tests.conftest import ADMIN_A_ID, TENANT_A_ID
 # ---------------------------------------------------------------------------
 
 async def test_account_lockout_after_10_failed_attempts(client: AsyncClient, seed_data):
-    """Después de 10 intentos fallidos de login, la cuenta se bloquea con 429."""
+    """Después de 10 intentos fallidos de login, la cuenta se bloquea con 401 público.
+
+    Internamente el lockout se rastrea (Redis) pero el response público es 401
+    genérico para no revelar que la cuenta existe.
+    """
     # 10 intentos fallidos
     for i in range(10):
         resp = await client.post(
@@ -18,14 +22,16 @@ async def test_account_lockout_after_10_failed_attempts(client: AsyncClient, see
             json={"email": "admin@alpha.test", "password": f"WrongPassword{i}!"},
         )
         assert resp.status_code == 401, f"Intento {i+1} debería fallar con 401"
-    
-    # El intento 11 debe devolver 429 (cuenta bloqueada)
+
+    # El intento 11 devuelve 401 genérico (NO 429) para evitar enumeración
     resp = await client.post(
         "/api/v1/auth/login",
         json={"email": "admin@alpha.test", "password": "WrongPassword11!"},
     )
-    assert resp.status_code == 429, "La cuenta debería estar bloqueada después de 10 intentos"
-    assert "bloqueada" in resp.json()["detail"].lower()
+    assert resp.status_code == 401, "Lockout debe devolver 401 público, no 429"
+    # El mensaje debe ser genérico — no revela lockout
+    assert "bloqueada" not in resp.json()["detail"].lower()
+    assert "429" not in resp.json()["detail"]
 
 
 async def test_account_lockout_reset_after_successful_login(client: AsyncClient, seed_data):
@@ -53,12 +59,130 @@ async def test_account_lockout_reset_after_successful_login(client: AsyncClient,
         )
         assert resp.status_code == 401, f"Intento {i+1} después del reset debería fallar con 401"
     
-    # El 11 debería dar 429 (lockout)
+    # El 11 devuelve 401 genérico (lockout interno, respuesta pública uniforme)
     resp = await client.post(
         "/api/v1/auth/login",
         json={"email": "admin@alpha.test", "password": "WrongPasswordFinal!"},
     )
-    assert resp.status_code == 429, "Lockout debería ocurrir después de 10 intentos fallidos después del reset"
+    assert resp.status_code == 401, "Lockout debe devolver 401 público"
+    assert "bloqueada" not in resp.json()["detail"].lower()
+
+
+# ---------------------------------------------------------------------------
+# LOGIN ENUMERATION RESISTANCE (#19)
+# ---------------------------------------------------------------------------
+
+async def test_login_unknown_user_returns_401_generic_message(client: AsyncClient, seed_data):
+    """Email que no existe devuelve 401 con mensaje genérico no-enumerante."""
+    resp = await client.post(
+        "/api/v1/auth/login",
+        json={"email": "noexiste@test.test", "password": "AnyPassword123!"},
+    )
+    assert resp.status_code == 401
+    # El mensaje no debe revelar si el usuario existe o no
+    detail = resp.json()["detail"].lower()
+    assert "no existe" not in detail
+    assert "no encontrado" not in detail
+    assert "not found" not in detail
+    assert "locked" not in detail
+    assert "bloqueada" not in detail
+
+
+async def test_login_wrong_password_returns_same_401_as_unknown_user(client: AsyncClient, seed_data):
+    """Password incorrecto devuelve el MISMO 401 que usuario desconocido.
+
+    Un atacante no puede distinguir.
+    """
+    # Caso A: usuario desconocido
+    resp_unknown = await client.post(
+        "/api/v1/auth/login",
+        json={"email": "noexiste@test.test", "password": "WrongPass!"},
+    )
+    assert resp_unknown.status_code == 401
+    detail_unknown = resp_unknown.json()["detail"]
+
+    # Caso B: password incorrecto (usuario existe)
+    resp_wrong = await client.post(
+        "/api/v1/auth/login",
+        json={"email": "admin@alpha.test", "password": "WrongPassword!"},
+    )
+    assert resp_wrong.status_code == 401
+    detail_wrong = resp_wrong.json()["detail"]
+
+    # Deben ser IDENTICOS
+    assert detail_unknown == detail_wrong, \
+        f"Unknown user and wrong password must return identical body. Got: {detail_unknown!r} vs {detail_wrong!r}"
+
+
+async def test_login_locked_account_returns_same_401_as_unknown_user(client: AsyncClient, seed_data):
+    """Cuenta bloqueada devuelve el MISMO 401 que usuario desconocido.
+
+    El 429 delata que la cuenta existe y está bloqueada.
+    Por eso se возвращает 401 genérico.
+    """
+    # Trigger lockout: 10 intentos fallidos
+    for i in range(10):
+        await client.post(
+            "/api/v1/auth/login",
+            json={"email": "analyst@alpha.test", "password": f"BadPass{i}!"},
+        )
+
+    # Caso A: usuario desconocido (para comparar)
+    resp_unknown = await client.post(
+        "/api/v1/auth/login",
+        json={"email": "noexiste@test.test", "password": "WrongPass!"},
+    )
+    assert resp_unknown.status_code == 401
+    detail_unknown = resp_unknown.json()["detail"]
+
+    # Caso B: cuenta bloqueada (intento 11)
+    resp_locked = await client.post(
+        "/api/v1/auth/login",
+        json={"email": "analyst@alpha.test", "password": "BadPassFinal!"},
+    )
+    assert resp_locked.status_code == 401, "Lockout debe retornar 401 público, no 429"
+    detail_locked = resp_locked.json()["detail"]
+
+    # Deben ser IDENTICOS
+    assert detail_unknown == detail_locked, \
+        f"Unknown user and locked account must return identical body. Got: {detail_unknown!r} vs {detail_locked!r}"
+    # No debe revelar lockout
+    assert "bloqueada" not in detail_locked.lower()
+    assert "locked" not in detail_locked.lower()
+
+
+async def test_login_all_three_failures_identical_401(client: AsyncClient, seed_data):
+    """Unknown user, wrong password, locked account → mismo {status_code, detail}.
+
+    Este es el test de enumeración resistencia más estricto:
+    todas las respuestas públicas deben ser indistinguibles.
+    """
+    # Trigger lockout en analyst@alpha.test
+    for i in range(10):
+        await client.post(
+            "/api/v1/auth/login",
+            json={"email": "analyst@alpha.test", "password": f"BadPass{i}!"},
+        )
+
+    # Caso 1: usuario desconocido
+    r1 = await client.post(
+        "/api/v1/auth/login",
+        json={"email": "noexiste@test.test", "password": "WrongPass!"},
+    )
+    # Caso 2: password incorrecto
+    r2 = await client.post(
+        "/api/v1/auth/login",
+        json={"email": "admin@alpha.test", "password": "WrongPassword!"},
+    )
+    # Caso 3: cuenta bloqueada
+    r3 = await client.post(
+        "/api/v1/auth/login",
+        json={"email": "analyst@alpha.test", "password": "BadPassFinal!"},
+    )
+
+    assert r1.status_code == r2.status_code == r3.status_code == 401
+    assert r1.json()["detail"] == r2.json()["detail"] == r3.json()["detail"], \
+        f"All three must return identical body. Got: {r1.json()['detail']!r}, {r2.json()['detail']!r}, {r3.json()['detail']!r}"
 
 
 async def test_login_inactive_user_returns_401(client: AsyncClient, seed_data):

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -163,12 +163,206 @@ class TestAuthRouterHelpers:
 
 class TestTokenResponseSchema:
     """Test TokenResponse schema."""
-    
+
     def test_token_response_defaults(self):
         """Test TokenResponse has correct defaults."""
         from app.modules.auth.schemas import TokenResponse
-        
+
         response = TokenResponse(access_token="test_token", expires_in=900)
         assert response.access_token == "test_token"
         assert response.token_type == "bearer"
         assert response.expires_in == 900
+
+
+class TestLoginEnumerationResistance:
+    """#19 — Login failures MUST be indistinguishable.
+
+    Unknown user, wrong password, and locked account must return the same
+    public 401 shape so an attacker cannot enumerate valid accounts.
+    """
+
+    GENERIC_AUTH_FAILURE_MSG = "Credenciales incorrectas"
+
+    @pytest.mark.asyncio
+    async def test_login_unknown_user_returns_generic_401(self):
+        """Unknown email returns 401 with generic non-enumerating message."""
+        from app.modules.auth import service
+        from app.core.exceptions import AuthError
+
+        mock_db = AsyncMock()
+        mock_redis = AsyncMock()
+
+        # User does not exist
+        with patch.object(service, '_check_account_lockout', return_value=None):
+            with patch.object(service, '_get_active_user', side_effect=AuthError(
+                    status_code=401, detail="Credenciales incorrectas"
+            )):
+                with pytest.raises(AuthError) as exc_info:
+                    await service.login(
+                        email="noexiste@test.test",
+                        password="AnyPassword123!",
+                        db=mock_db,
+                        redis=mock_redis,
+                    )
+
+        assert exc_info.value.status_code == 401
+        # Message must NOT reveal whether user exists
+        assert "no existe" not in exc_info.value.detail.lower()
+        assert "no encontrado" not in exc_info.value.detail.lower()
+        assert "locked" not in exc_info.value.detail.lower()
+        assert "bloqueada" not in exc_info.value.detail.lower()
+
+    @pytest.mark.asyncio
+    async def test_login_wrong_password_returns_generic_401(self):
+        """Wrong password returns 401 with same generic message as unknown user."""
+        from app.modules.auth import service
+        from app.core.exceptions import AuthError
+
+        mock_user = MagicMock()
+        mock_user.is_active = True
+        mock_user.hashed_password = "hashed_password"
+
+        mock_db = AsyncMock()
+        mock_redis = AsyncMock()
+
+        with patch.object(service, '_check_account_lockout', return_value=None):
+            with patch.object(service, '_get_active_user', return_value=mock_user):
+                with patch('app.modules.auth.service.verify_password', return_value=False):
+                    with patch.object(service, '_record_failed_attempt', return_value=None):
+                        with pytest.raises(AuthError) as exc_info:
+                            await service.login(
+                                email="admin@alpha.test",
+                                password="WrongPassword!",
+                                db=mock_db,
+                                redis=mock_redis,
+                            )
+
+        assert exc_info.value.status_code == 401
+        # Message must NOT reveal it was a password problem specifically
+        assert "password" not in exc_info.value.detail.lower()
+        assert "contraseña" not in exc_info.value.detail.lower()
+        assert "incorrecta" in exc_info.value.detail.lower() or \
+               "inválidas" in exc_info.value.detail.lower()
+
+    @pytest.mark.asyncio
+    async def test_login_locked_account_returns_401_not_429(self):
+        """Locked account returns 401 (NOT 429) to avoid account-existence enumeration.
+
+        A 429 tells the attacker "this account IS locked, hence it EXISTS".
+        A 401 is indistinguishable from wrong password / unknown user.
+        Internal lockout tracking remains intact.
+        """
+        from app.modules.auth import service
+        from app.core.exceptions import AuthError
+
+        mock_db = AsyncMock()
+        mock_redis = AsyncMock()
+
+        # Simulate lockout triggered — must NOT return 429 publicly
+        with patch.object(
+            service, '_check_account_lockout', side_effect=AuthError(
+                status_code=401, detail="Credenciales incorrectas"
+            )
+        ):
+            with pytest.raises(AuthError) as exc_info:
+                await service.login(
+                    email="admin@alpha.test",
+                    password="AnyPassword123!",
+                    db=mock_db,
+                    redis=mock_redis,
+                )
+
+        # Critical: must be 401, not 429
+        assert exc_info.value.status_code == 401, \
+            "Lockout must return 401 to avoid enumeration"
+        # Must be same generic message
+        assert "locked" not in exc_info.value.detail.lower()
+        assert "bloqueada" not in exc_info.value.detail.lower()
+        assert "429" not in str(exc_info.value.detail)
+
+    @pytest.mark.asyncio
+    async def test_login_all_failures_return_identical_public_shape(self):
+        """Unknown user, wrong password, and locked account return identical 401 body.
+
+        The public {status_code, detail} tuple must be identical across all three
+        failure modes so no information about account state leaks.
+        """
+        from app.modules.auth import service
+        from app.core.exceptions import AuthError
+
+        mock_user = MagicMock()
+        mock_user.is_active = True
+        mock_user.hashed_password = "hashed_password"
+
+        mock_db = AsyncMock()
+        mock_redis = AsyncMock()
+
+        # --- Case 1: Unknown user ---
+        unknown_user_exc = AuthError(status_code=401, detail="Credenciales incorrectas")
+        with patch.object(service, '_check_account_lockout', return_value=None):
+            with patch.object(service, '_get_active_user', side_effect=unknown_user_exc):
+                with pytest.raises(AuthError) as exc1:
+                    await service.login(
+                        email="noexiste@test.test",
+                        password="WrongPass!",
+                        db=mock_db,
+                        redis=mock_redis,
+                    )
+
+        # --- Case 2: Wrong password ---
+        with patch.object(service, '_check_account_lockout', return_value=None):
+            with patch.object(service, '_get_active_user', return_value=mock_user):
+                with patch('app.modules.auth.service.verify_password', return_value=False):
+                    with patch.object(service, '_record_failed_attempt', return_value=None):
+                        with pytest.raises(AuthError) as exc2:
+                            await service.login(
+                                email="admin@alpha.test",
+                                password="WrongPass!",
+                                db=mock_db,
+                                redis=mock_redis,
+                            )
+
+        # --- Case 3: Locked account ---
+        locked_exc = AuthError(status_code=401, detail="Credenciales incorrectas")
+        with patch.object(service, '_check_account_lockout', side_effect=locked_exc):
+            with pytest.raises(AuthError) as exc3:
+                await service.login(
+                    email="admin@alpha.test",
+                    password="AnyPass!",
+                    db=mock_db,
+                    redis=mock_redis,
+                )
+
+        # All three must be 401
+        assert exc1.value.status_code == 401
+        assert exc2.value.status_code == 401
+        assert exc3.value.status_code == 401
+
+        # All three must have identical public shape
+        assert exc1.value.detail == exc2.value.detail == exc3.value.detail, \
+            f"All failures must return identical detail. Got: {exc1.value.detail}, {exc2.value.detail}, {exc3.value.detail}"
+
+    @pytest.mark.asyncio
+    async def test_login_inactive_user_returns_same_generic_401(self):
+        """Inactive (soft-deleted) user returns same generic 401 as unknown user."""
+        from app.modules.auth import service
+        from app.core.exceptions import AuthError
+
+        mock_db = AsyncMock()
+        mock_redis = AsyncMock()
+
+        # User exists but is_active=False — same generic message as unknown
+        inactive_exc = AuthError(status_code=401, detail="Credenciales incorrectas")
+        with patch.object(service, '_check_account_lockout', return_value=None):
+            with patch.object(service, '_get_active_user', side_effect=inactive_exc):
+                with pytest.raises(AuthError) as exc_info:
+                    await service.login(
+                        email="inactive@alpha.test",
+                        password="AnyPassword!",
+                        db=mock_db,
+                        redis=mock_redis,
+                    )
+
+        assert exc_info.value.status_code == 401
+        assert "inactivo" not in exc_info.value.detail.lower()
+        assert "activo" not in exc_info.value.detail.lower()


### PR DESCRIPTION
Fixes #19

## Summary
- make unknown user, wrong password, and locked account return the same public 401 response
- add integration bootstrap and migration support needed to verify auth behavior against PostgreSQL
- expand auth tests so lockout privacy is verified in unit and integration paths

## Changes
| File | Change |
|------|--------|
| `app/modules/auth/service.py` | unify login failure responses to a generic 401 contract |
| `tests/unit/test_auth.py` | add enumeration-resistance coverage |
| `tests/integration/test_auth_integration.py` | verify auth behavior against real integration flows |
| `tests/integration/conftest.py` | bootstrap integration DB with Alembic and safe masking |
| `pytest.ini` | register integration/unit markers |
| `migrations/versions/20260425_1000_add_last_login_at_to_users_b5e9d8c4a123.py` | add missing `users.last_login_at` column |

## Test Plan
- [x] `pytest tests/unit/test_auth.py -q`
- [x] `pytest tests/integration/test_auth_integration.py -q`
- [x] `pytest -m integration --collect-only`