### PR TITLE
fix(config): require environment and gate postgres

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Aplicación
-APP_ENV=development
+ENVIRONMENT=development
 SECRET_KEY=cambia-esto-por-una-clave-secreta-larga
 APP_NAME=SOC 360 PYMEs
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -11,7 +11,7 @@ class Settings(BaseSettings):
     )
     
     #Aplicacion
-    ENVIRONMENT: str = "development"
+    ENVIRONMENT: str
     APP_NAME: str = "SOC 360 PYMEs"
     SECRET_KEY: str
     

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,10 +3,14 @@ services:
   postgres:
     image: postgres:16-alpine
     container_name: soc360_postgres
+    profiles: [dev]
+    # Only starts with: docker compose --profile dev up
+    # Does NOT expose port to host by default
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
+    # Host port mapping — only active when --profile dev is used (postgres service)
     ports:
       - "5433:5432"
     volumes:


### PR DESCRIPTION
Fixes #21
Fixes #22

## Summary
- make `ENVIRONMENT` mandatory so runtime cannot silently fall back to development mode
- align `.env.example` with the real settings key used by the application
- expose PostgreSQL only behind the Docker `dev` profile instead of publishing it by default

## Changes
| File | Change |
|------|--------|
| `app/core/config.py` | remove insecure default from `ENVIRONMENT` |
| `.env.example` | rename `APP_ENV` to `ENVIRONMENT` |
| `docker-compose.yml` | gate postgres service behind `profiles: [dev]` |

## Test Plan
- [x] `docker compose config`
- [x] reviewed config validator behavior for allowed environment values
- [x] confirmed compose stays valid with postgres profile gating