### PR TITLE
fix(security): disable swagger docs in production and add security headers

### DIFF
--- a/app/core/middleware.py
+++ b/app/core/middleware.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import RedirectResponse, Response
+
+from app.core.config import settings
+
+NOSNIFF = "nosniff"
+XFRAME_DENY = "DENY"
+CSP_SELF_ONLY = "default-src 'self'"
+HSTS_MAX_AGE = "max-age=31536000; includeSubDomains"
+
+
+class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next) -> Response:
+        response = await call_next(request)
+        response.headers["X-Content-Type-Options"] = NOSNIFF
+        response.headers["X-Frame-Options"] = XFRAME_DENY
+        response.headers["Content-Security-Policy"] = CSP_SELF_ONLY
+        if settings.ENVIRONMENT == "production":
+            response.headers["Strict-Transport-Security"] = HSTS_MAX_AGE
+        return response
+
+
+class HTTPSRedirectMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next) -> Response:
+        if settings.ENVIRONMENT != "production":
+            return await call_next(request)
+
+        proto = request.headers.get("x-forwarded-proto", request.url.scheme)
+        if proto == "http":
+            https_url = str(request.url.replace(scheme="https"))
+            return RedirectResponse(url=https_url, status_code=307)
+
+        return await call_next(request)

--- a/app/main.py
+++ b/app/main.py
@@ -7,6 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.core.config import settings
 from app.core.logging import setup_logging, get_logger
+from app.core.middleware import HTTPSRedirectMiddleware, SecurityHeadersMiddleware
 from app.core.redis import ping_redis, close_pool, get_redis_client
 from app.event_bus import EventConsumer
 from app.modules.auth.router import router as auth_router
@@ -70,7 +71,7 @@ def create_app() -> FastAPI:
         title=settings.APP_NAME,
         description="SOC as a Service para pequeñas y medianas empresas",
         version=APP_VERSION,
-        docs_url="/api/docs",
+        docs_url="/api/docs" if settings.ENVIRONMENT != "production" else None,
         redoc_url="/api/redoc" if settings.ENVIRONMENT != "production" else None,
         lifespan=lifespan,
     )
@@ -89,6 +90,8 @@ def create_app() -> FastAPI:
         allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE"],
         allow_headers=["Authorization", "Content-Type"],
     )
+    app.add_middleware(HTTPSRedirectMiddleware)
+    app.add_middleware(SecurityHeadersMiddleware)
     
     #Routers
     app.include_router(auth_router, prefix="/api/v1")

--- a/tests/integration/test_security_headers_integration.py
+++ b/tests/integration/test_security_headers_integration.py
@@ -1,0 +1,33 @@
+"""Integration tests for security headers — requires live app."""
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+from app.core.config import settings
+from app.main import create_app
+
+
+class TestSecurityHeadersIntegration:
+    """End-to-end security header verification via TestClient."""
+
+    @pytest.mark.asyncio
+    async def test_security_headers_present_in_development(self):
+        """Even in dev mode, nosniff/XFO/CSP headers should appear."""
+        app = create_app()
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get("/health")
+        assert resp.status_code == 200
+        assert resp.headers.get("x-content-type-options") == "nosniff"
+        assert resp.headers.get("x-frame-options") == "DENY"
+        assert resp.headers.get("content-security-policy") == "default-src 'self'"
+        # HSTS should NOT be present in development
+        assert "strict-transport-security" not in resp.headers
+
+    @pytest.mark.asyncio
+    async def test_docs_available_in_development(self):
+        """Swagger docs should be accessible in development."""
+        app = create_app()
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get("/api/docs")
+        assert resp.status_code == 200

--- a/tests/unit/test_https_redirect_middleware.py
+++ b/tests/unit/test_https_redirect_middleware.py
@@ -1,0 +1,139 @@
+"""Tests for app/core/middleware.py — HTTPSRedirectMiddleware."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.core.config import settings
+
+
+class TestHTTPSRedirectMiddleware:
+    """Verify HTTPSRedirectMiddleware redirects conditionally."""
+
+    @pytest.fixture
+    def mock_app(self):
+        async def _app(scope, receive, send):
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 200,
+                    "headers": [],
+                }
+            )
+            await send(
+                {
+                    "type": "http.response.body",
+                    "body": b"ok",
+                }
+            )
+
+        return _app
+
+    @pytest.fixture
+    def middleware(self, mock_app):
+        from app.core.middleware import HTTPSRedirectMiddleware
+
+        return HTTPSRedirectMiddleware(mock_app)
+
+    @pytest.mark.asyncio
+    async def test_redirects_http_to_https_in_production(self, middleware, monkeypatch: pytest.MonkeyPatch):
+        """HTTP requests in production MUST receive 307 redirect to HTTPS."""
+        monkeypatch.setattr(settings, "ENVIRONMENT", "production")
+
+        calls = []
+
+        async def _send(message):
+            calls.append(message)
+
+        scope = {
+            "type": "http",
+            "scheme": "http",
+            "method": "GET",
+            "path": "/api/v1/users",
+            "headers": [[b"host", b"api.example.com"]],
+        }
+
+        await middleware(scope, AsyncMock(), _send)
+
+        start = calls[0]
+        assert start["type"] == "http.response.start"
+        assert start["status"] == 307
+
+        headers = {k.decode().lower(): v.decode() for k, v in start["headers"]}
+        assert headers["location"].startswith("https://")
+
+    @pytest.mark.asyncio
+    async def test_no_redirect_when_https(self, middleware, monkeypatch: pytest.MonkeyPatch):
+        """Requests already using HTTPS MUST NOT be redirected."""
+        monkeypatch.setattr(settings, "ENVIRONMENT", "production")
+
+        calls = []
+
+        async def _send(message):
+            calls.append(message)
+
+        scope = {
+            "type": "http",
+            "scheme": "https",
+            "method": "GET",
+            "path": "/api/v1/users",
+            "headers": [[b"host", b"api.example.com"]],
+        }
+
+        await middleware(scope, AsyncMock(), _send)
+
+        start = calls[0]
+        assert start["type"] == "http.response.start"
+        assert start["status"] == 200
+
+    @pytest.mark.asyncio
+    async def test_no_redirect_in_development(self, middleware, monkeypatch: pytest.MonkeyPatch):
+        """HTTP requests in development MUST NOT be redirected."""
+        monkeypatch.setattr(settings, "ENVIRONMENT", "development")
+
+        calls = []
+
+        async def _send(message):
+            calls.append(message)
+
+        scope = {
+            "type": "http",
+            "scheme": "http",
+            "method": "GET",
+            "path": "/api/v1/users",
+            "headers": [[b"host", b"localhost"]],
+        }
+
+        await middleware(scope, AsyncMock(), _send)
+
+        start = calls[0]
+        assert start["type"] == "http.response.start"
+        assert start["status"] == 200
+
+    @pytest.mark.asyncio
+    async def test_respects_x_forwarded_proto_https(self, middleware, monkeypatch: pytest.MonkeyPatch):
+        """Requests with X-Forwarded-Proto: https MUST NOT be redirected."""
+        monkeypatch.setattr(settings, "ENVIRONMENT", "production")
+
+        calls = []
+
+        async def _send(message):
+            calls.append(message)
+
+        scope = {
+            "type": "http",
+            "scheme": "http",
+            "method": "GET",
+            "path": "/api/v1/users",
+            "headers": [
+                [b"host", b"api.example.com"],
+                [b"x-forwarded-proto", b"https"],
+            ],
+        }
+
+        await middleware(scope, AsyncMock(), _send)
+
+        start = calls[0]
+        assert start["type"] == "http.response.start"
+        assert start["status"] == 200

--- a/tests/unit/test_main_security_integration.py
+++ b/tests/unit/test_main_security_integration.py
@@ -1,0 +1,29 @@
+"""Tests for app/main.py — security integration guards."""
+from __future__ import annotations
+
+import pytest
+
+from app.core.config import settings
+from app.main import create_app
+
+
+class TestMainSecurityIntegration:
+    """Validate production vs development guards in FastAPI bootstrap."""
+
+    def test_docs_url_none_in_production(self, monkeypatch: pytest.MonkeyPatch):
+        """docs_url MUST be None when ENVIRONMENT=production."""
+        monkeypatch.setattr(settings, "ENVIRONMENT", "production")
+        app = create_app()
+        assert app.docs_url is None
+
+    def test_docs_url_present_in_development(self, monkeypatch: pytest.MonkeyPatch):
+        """docs_url MUST retain its configured value when ENVIRONMENT=development."""
+        monkeypatch.setattr(settings, "ENVIRONMENT", "development")
+        app = create_app()
+        assert app.docs_url == "/api/docs"
+
+    def test_redoc_url_none_in_production(self, monkeypatch: pytest.MonkeyPatch):
+        """redoc_url MUST be None when ENVIRONMENT=production."""
+        monkeypatch.setattr(settings, "ENVIRONMENT", "production")
+        app = create_app()
+        assert app.redoc_url is None

--- a/tests/unit/test_security_headers_middleware.py
+++ b/tests/unit/test_security_headers_middleware.py
@@ -1,0 +1,149 @@
+"""Tests for app/core/middleware.py — SecurityHeadersMiddleware."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.core.config import settings
+
+
+class TestSecurityHeadersMiddleware:
+    """Verify SecurityHeadersMiddleware injects hardening headers conditionally."""
+
+    @pytest.fixture
+    def mock_app(self):
+        async def _app(scope, receive, send):
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 200,
+                    "headers": [[b"content-type", b"application/json"]],
+                }
+            )
+            await send(
+                {
+                    "type": "http.response.body",
+                    "body": b'{"ok": true}',
+                }
+            )
+
+        return _app
+
+    @pytest.fixture
+    def middleware(self, mock_app):
+        from app.core.middleware import SecurityHeadersMiddleware
+
+        return SecurityHeadersMiddleware(mock_app)
+
+    @pytest.mark.asyncio
+    async def test_injects_x_content_type_options_nosniff(self, middleware):
+        """Response MUST include X-Content-Type-Options: nosniff."""
+        calls = []
+
+        async def _send(message):
+            calls.append(message)
+
+        await middleware(
+            {"type": "http", "method": "GET", "path": "/", "headers": []},
+            AsyncMock(),
+            _send,
+        )
+
+        start = calls[0]
+        headers = {k.decode().lower(): v.decode() for k, v in start["headers"]}
+        assert headers["x-content-type-options"] == "nosniff"
+
+    @pytest.mark.asyncio
+    async def test_injects_x_frame_options_deny(self, middleware):
+        """Response MUST include X-Frame-Options: DENY."""
+        calls = []
+
+        async def _send(message):
+            calls.append(message)
+
+        await middleware(
+            {"type": "http", "method": "GET", "path": "/", "headers": []},
+            AsyncMock(),
+            _send,
+        )
+
+        start = calls[0]
+        headers = {k.decode().lower(): v.decode() for k, v in start["headers"]}
+        assert headers["x-frame-options"] == "DENY"
+
+    @pytest.mark.asyncio
+    async def test_injects_csp_default_src_self(self, middleware):
+        """Response MUST include Content-Security-Policy: default-src 'self'."""
+        calls = []
+
+        async def _send(message):
+            calls.append(message)
+
+        await middleware(
+            {"type": "http", "method": "GET", "path": "/", "headers": []},
+            AsyncMock(),
+            _send,
+        )
+
+        start = calls[0]
+        headers = {k.decode().lower(): v.decode() for k, v in start["headers"]}
+        assert headers["content-security-policy"] == "default-src 'self'"
+
+    @pytest.mark.asyncio
+    async def test_injects_hsts_in_production(self, middleware, monkeypatch: pytest.MonkeyPatch):
+        """Response MUST include Strict-Transport-Security when ENVIRONMENT=production."""
+        monkeypatch.setattr(settings, "ENVIRONMENT", "production")
+
+        calls = []
+
+        async def _send(message):
+            calls.append(message)
+
+        await middleware(
+            {"type": "http", "method": "GET", "path": "/", "headers": []},
+            AsyncMock(),
+            _send,
+        )
+
+        start = calls[0]
+        headers = {k.decode().lower(): v.decode() for k, v in start["headers"]}
+        assert "strict-transport-security" in headers
+
+    @pytest.mark.asyncio
+    async def test_no_hsts_in_development(self, middleware, monkeypatch: pytest.MonkeyPatch):
+        """Response MUST NOT include Strict-Transport-Security when ENVIRONMENT=development."""
+        monkeypatch.setattr(settings, "ENVIRONMENT", "development")
+
+        calls = []
+
+        async def _send(message):
+            calls.append(message)
+
+        await middleware(
+            {"type": "http", "method": "GET", "path": "/", "headers": []},
+            AsyncMock(),
+            _send,
+        )
+
+        start = calls[0]
+        headers = {k.decode().lower(): v.decode() for k, v in start["headers"]}
+        assert "strict-transport-security" not in headers
+
+    @pytest.mark.asyncio
+    async def test_preserves_response_body(self, middleware):
+        """Middleware MUST NOT alter the response body."""
+        calls = []
+
+        async def _send(message):
+            calls.append(message)
+
+        await middleware(
+            {"type": "http", "method": "GET", "path": "/", "headers": []},
+            AsyncMock(),
+            _send,
+        )
+
+        body_msg = calls[1]
+        assert body_msg["type"] == "http.response.body"
+        assert body_msg["body"] == b'{"ok": true}'


### PR DESCRIPTION
## Summary
- Swagger `/api/docs` ahora se desactiva en producción (mismo patrón que Redoc)
- Nuevo middleware `SecurityHeadersMiddleware`: X-Content-Type-Options, X-Frame-Options, CSP en todos los entornos; HSTS solo en producción
- Nuevo middleware `HTTPSRedirectMiddleware`: redirige HTTP→HTTPS en producción con soporte para `X-Forwarded-Proto` (compatible con proxies)
- 15 tests nuevos: 6 unitarios para SecurityHeaders, 4 para HTTPSRedirect, 3 de integración en main, 2 de integración E2E

## Closes
Closes #24

## Checklist
- [x] RED: tests escritos primero
- [x] GREEN: implementación pasa todos los tests
- [x] REFACTOR: constantes extraídas
- [x] VERIFY: suite completa sin regresiones