### PR TITLE
test(auth): add dedicated tests for Redis fail-closed behavior

### DIFF
--- a/tests/unit/test_redis_fail_closed.py
+++ b/tests/unit/test_redis_fail_closed.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from uuid import uuid4
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+
+class TestRedisFailClosed:
+    """PR #69 — When Redis is down, auth functions MUST fail closed (503)."""
+
+    @pytest.mark.asyncio
+    async def test_login_raises_service_unavailable_when_redis_down(self):
+        """login() MUST raise ServiceUnavailableError when Redis is unhealthy."""
+        from app.modules.auth import service
+        from app.core.exceptions import ServiceUnavailableError
+
+        mock_redis = AsyncMock()
+        mock_db = AsyncMock()
+
+        with patch("app.modules.auth.service.check_redis_healthy", return_value=False):
+            with pytest.raises(ServiceUnavailableError) as exc_info:
+                await service.login(
+                    email="test@example.com",
+                    password="any_password",
+                    db=mock_db,
+                    redis=mock_redis,
+                )
+
+        assert exc_info.value.status_code == 503
+        assert "no disponible" in exc_info.value.detail.lower()
+
+    @pytest.mark.asyncio
+    async def test_refresh_tokens_raises_service_unavailable_when_redis_down(self):
+        """refresh_tokens() MUST raise ServiceUnavailableError when Redis is unhealthy."""
+        from app.modules.auth import service
+        from app.core.exceptions import ServiceUnavailableError
+
+        mock_redis = AsyncMock()
+        mock_db = AsyncMock()
+
+        with patch("app.modules.auth.service.check_redis_healthy", return_value=False):
+            with pytest.raises(ServiceUnavailableError) as exc_info:
+                await service.refresh_tokens(
+                    refresh_token="some_refresh_token",
+                    db=mock_db,
+                    redis=mock_redis,
+                )
+
+        assert exc_info.value.status_code == 503
+        assert "no disponible" in exc_info.value.detail.lower()
+
+    @pytest.mark.asyncio
+    async def test_logout_raises_service_unavailable_when_redis_down(self):
+        """logout() MUST raise ServiceUnavailableError when Redis is unhealthy."""
+        from app.modules.auth import service
+        from app.core.exceptions import ServiceUnavailableError
+
+        mock_redis = AsyncMock()
+        mock_db = AsyncMock()
+
+        with patch("app.modules.auth.service.check_redis_healthy", return_value=False):
+            with pytest.raises(ServiceUnavailableError) as exc_info:
+                await service.logout(
+                    jti="jti-123",
+                    refresh_token="some_refresh_token",
+                    user_id="user-123",
+                    db=mock_db,
+                    redis=mock_redis,
+                )
+
+        assert exc_info.value.status_code == 503
+        assert "no disponible" in exc_info.value.detail.lower()
+
+    @pytest.mark.asyncio
+    async def test_change_password_raises_service_unavailable_when_redis_down(self):
+        """change_password() MUST raise ServiceUnavailableError when Redis is unhealthy."""
+        from app.modules.auth import service
+        from app.core.exceptions import ServiceUnavailableError
+
+        mock_redis = AsyncMock()
+        mock_db = AsyncMock()
+
+        with patch("app.modules.auth.service.check_redis_healthy", return_value=False):
+            with pytest.raises(ServiceUnavailableError) as exc_info:
+                await service.change_password(
+                    user_id=uuid4(),
+                    current_password="old_password",
+                    new_password="NewPassword123!",
+                    current_jti="jti-123",
+                    db=mock_db,
+                    redis=mock_redis,
+                )
+
+        assert exc_info.value.status_code == 503
+        assert "no disponible" in exc_info.value.detail.lower()
+
+    @pytest.mark.asyncio
+    async def test_get_current_user_returns_503_when_redis_down(self):
+        """get_current_user() MUST raise HTTPException(503) when Redis is unhealthy."""
+        from app.core.security import create_access_token
+
+        token, _ = create_access_token(
+            user_id=str(uuid4()),
+            tenant_id=str(uuid4()),
+            role="admin",
+            is_superadmin=False,
+        )
+
+        mock_redis = AsyncMock()
+        mock_db = AsyncMock()
+
+        with patch("app.dependencies.check_redis_healthy", return_value=False):
+            from app.dependencies import get_current_user
+
+            with pytest.raises(HTTPException) as exc_info:
+                await get_current_user(
+                    token=token,
+                    db=mock_db,
+                    redis=mock_redis,
+                )
+
+        assert exc_info.value.status_code == 503
+        assert "no disponible" in exc_info.value.detail.lower()

--- a/tests/unit/test_redis_fail_closed.py
+++ b/tests/unit/test_redis_fail_closed.py
@@ -30,6 +30,9 @@ class TestRedisFailClosed:
 
         assert exc_info.value.status_code == 503
         assert "no disponible" in exc_info.value.detail.lower()
+        # Verify guard prevented any downstream operations
+        mock_db.scalar.assert_not_called()
+        mock_redis.get.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_refresh_tokens_raises_service_unavailable_when_redis_down(self):
@@ -50,6 +53,9 @@ class TestRedisFailClosed:
 
         assert exc_info.value.status_code == 503
         assert "no disponible" in exc_info.value.detail.lower()
+        # Verify guard prevented any downstream operations
+        mock_db.scalar.assert_not_called()
+        mock_redis.get.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_logout_raises_service_unavailable_when_redis_down(self):
@@ -72,6 +78,9 @@ class TestRedisFailClosed:
 
         assert exc_info.value.status_code == 503
         assert "no disponible" in exc_info.value.detail.lower()
+        # Verify guard prevented any downstream operations
+        mock_db.scalar.assert_not_called()
+        mock_redis.get.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_change_password_raises_service_unavailable_when_redis_down(self):
@@ -95,6 +104,9 @@ class TestRedisFailClosed:
 
         assert exc_info.value.status_code == 503
         assert "no disponible" in exc_info.value.detail.lower()
+        # Verify guard prevented any downstream operations
+        mock_db.scalar.assert_not_called()
+        mock_redis.get.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_get_current_user_returns_503_when_redis_down(self):
@@ -123,3 +135,5 @@ class TestRedisFailClosed:
 
         assert exc_info.value.status_code == 503
         assert "no disponible" in exc_info.value.detail.lower()
+        # Verify guard prevented DB user lookup
+        mock_db.execute.assert_not_called()


### PR DESCRIPTION
## Summary

Agrega 5 tests unitarios que verifican el comportamiento fail-closed cuando Redis esta caido (PR #69):

| Test | Verifica |
|------|----------|
| `test_login_raises_service_unavailable_when_redis_down` | login() → 503 |
| `test_refresh_tokens_raises_service_unavailable_when_redis_down` | refresh_tokens() → 503 |
| `test_logout_raises_service_unavailable_when_redis_down` | logout() → 503 |
| `test_change_password_raises_service_unavailable_when_redis_down` | change_password() → 503 |
| `test_get_current_user_returns_503_when_redis_down` | get_current_user() → 503 |

Cada test tambien verifica que NO se ejecuten operaciones downstream (DB/Redis) despues del health check.