### PR TITLE
fix(config): require REDIS_PASSWORD in production

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -113,6 +113,8 @@ class Settings(BaseSettings):
             raise ValueError("REDIS_URL debe incluir autenticación cuando REDIS_PASSWORD está configurado")
         if environment == "production" and "@" not in v:
             raise ValueError("REDIS_URL debe incluir autenticación en producción")
+        if environment == "production" and not redis_password:
+            raise ValueError("REDIS_PASSWORD es requerido en producción")
         return v
     
     @field_validator("GROQ_API_KEY")


### PR DESCRIPTION
## Summary

Issue #56 — El validador de Redis ya chequeaba que la URL tenga autenticacion en produccion, pero NO forzaba que REDIS_PASSWORD estuviera seteada.

Se agrega:
```python
if environment == "production" and not redis_password:
    raise ValueError("REDIS_PASSWORD es requerido en produccion")
```

Esto evita que alguien deploye a production con la password default hardcodeada de docker-compose.

Closes #56