### PR TITLE
fix(core): set RLS tenant context in get_current_user — Issue #40

### DIFF
--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -115,6 +115,18 @@ async def get_current_user(
                 detail="Tenant inactivo o no encontrado",
                 headers={"WWW-Authenticate": "Bearer"},
             )
+    if user.is_superadmin:
+        await set_tenant_context(db, user.tenant_id, True)
+    elif user.tenant_id is None:
+        logger.warning("auth_failed", reason="missing_tenant_id", user_id=str(user_uuid))
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Usuario no encontrado o inactivo",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    else:
+        await set_tenant_context(db, user.tenant_id, False)
+
     user.current_jti = jti
     return user
 

--- a/tests/unit/test_dependencies.py
+++ b/tests/unit/test_dependencies.py
@@ -1,10 +1,116 @@
 """Tests for app/dependencies.py — T3.1: EventBus dependency injection."""
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+from uuid import UUID, uuid4
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from fastapi import HTTPException
 from fakeredis.aioredis import FakeRedis
+
+
+class TestGetCurrentUserTenantContext:
+    """#40 — get_current_user MUST set RLS tenant context after validation."""
+
+    @pytest.fixture
+    def valid_token_payload(self):
+        return {"sub": str(uuid4()), "jti": "jti-123"}
+
+    @pytest.fixture
+    def mock_db_and_row(self):
+        mock_user = MagicMock()
+        mock_user.is_active = True
+        mock_user.is_superadmin = False
+        mock_user.tenant_id = uuid4()
+        mock_user.id = uuid4()
+
+        mock_tenant = MagicMock()
+        mock_tenant.is_active = True
+
+        mock_row = MagicMock()
+        mock_row.User = mock_user
+        mock_row.Tenant = mock_tenant
+
+        mock_result = MagicMock()
+        mock_result.one_or_none.return_value = mock_row
+
+        mock_db = AsyncMock()
+        mock_db.execute.return_value = mock_result
+        return mock_db, mock_user, mock_tenant
+
+    @pytest.mark.asyncio
+    async def test_superadmin_sets_tenant_context_with_is_superadmin_true(
+        self, valid_token_payload, mock_db_and_row
+    ):
+        """T2: Superadmin → set_tenant_context called with is_superadmin=True."""
+        mock_db, mock_user, _ = mock_db_and_row
+        mock_user.is_superadmin = True
+        mock_user.tenant_id = uuid4()
+
+        with patch("app.dependencies.decode_access_token", return_value=valid_token_payload), \
+             patch("app.dependencies.check_redis_healthy", AsyncMock(return_value=True)), \
+             patch("app.dependencies.is_token_revoked", AsyncMock(return_value=False)), \
+             patch("app.dependencies.set_tenant_context", AsyncMock()) as mock_set_ctx:
+            from app.dependencies import get_current_user
+            result = await get_current_user(
+                token="Bearer token",
+                db=mock_db,
+                redis=AsyncMock(),
+            )
+
+        mock_set_ctx.assert_awaited_once_with(
+            mock_db, mock_user.tenant_id, True
+        )
+        assert result is mock_user
+
+    @pytest.mark.asyncio
+    async def test_normal_user_sets_tenant_context_with_tenant_id(
+        self, valid_token_payload, mock_db_and_row
+    ):
+        """T3: Normal user → set_tenant_context called with correct tenant_id."""
+        mock_db, mock_user, _ = mock_db_and_row
+        mock_user.is_superadmin = False
+        mock_user.tenant_id = uuid4()
+
+        with patch("app.dependencies.decode_access_token", return_value=valid_token_payload), \
+             patch("app.dependencies.check_redis_healthy", AsyncMock(return_value=True)), \
+             patch("app.dependencies.is_token_revoked", AsyncMock(return_value=False)), \
+             patch("app.dependencies.set_tenant_context", AsyncMock()) as mock_set_ctx:
+            from app.dependencies import get_current_user
+            result = await get_current_user(
+                token="Bearer token",
+                db=mock_db,
+                redis=AsyncMock(),
+            )
+
+        mock_set_ctx.assert_awaited_once_with(
+            mock_db, mock_user.tenant_id, False
+        )
+        assert result is mock_user
+
+    @pytest.mark.asyncio
+    async def test_non_superadmin_without_tenant_id_returns_401(
+        self, valid_token_payload, mock_db_and_row
+    ):
+        """T4: Non-superadmin with tenant_id=None → 401, no set_tenant_context call."""
+        mock_db, mock_user, _ = mock_db_and_row
+        mock_user.is_superadmin = False
+        mock_user.tenant_id = None
+
+        with patch("app.dependencies.decode_access_token", return_value=valid_token_payload), \
+             patch("app.dependencies.check_redis_healthy", AsyncMock(return_value=True)), \
+             patch("app.dependencies.is_token_revoked", AsyncMock(return_value=False)), \
+             patch("app.dependencies.set_tenant_context", AsyncMock()) as mock_set_ctx:
+            from app.dependencies import get_current_user
+            with pytest.raises(HTTPException) as exc_info:
+                await get_current_user(
+                    token="Bearer token",
+                    db=mock_db,
+                    redis=AsyncMock(),
+                )
+
+        assert exc_info.value.status_code == 401
+        mock_set_ctx.assert_not_awaited()
 
 
 class TestGetEventBus:


### PR DESCRIPTION
## 🔴 CRITICAL: CurrentUserDep no setea tenant context (RLS roto)

Closes #40

### El problema
`get_current_user()` usaba `get_db()` que nunca setea tenant context. Los endpoints que usaban `CurrentUserDep` + `DBDep` (sin `DBWithTenantDep`) ejecutaban queries sin RLS activo, y PostgreSQL filtraba silenciosamente todas las filas.

**Endpoints afectados**:
- `POST /auth/logout`
- `POST /auth/change-password`
- `GET /tenants/{tenant_id}`

### El fix
`get_current_user()` ahora llama a `set_tenant_context(db, tenant_id, is_superadmin)` después de validar al usuario:

- **Superadmin** → `app.is_superadmin = true` (RLS bypass)
- **Usuario normal** → `app.current_tenant = <uuid>` (RLS activo)
- **Usuario sin tenant** → 401 si no es superadmin

FastAPI cachea la misma `AsyncSession` para toda la request, así que cuando el endpoint recibe `DBDep`, la transacción ya tiene el SET LOCAL ejecutado por `get_current_user()`.

### Cambios
- `app/dependencies.py` — 1 bloque agregado en `get_current_user()`
- `tests/unit/test_dependencies.py` — 3 tests nuevos

### Tests
- ✅ `pytest tests/unit/test_dependencies.py -vv` — 6/6 pass
- ✅ Superadmin → `set_tenant_context` con `is_superadmin=True`
- ✅ Usuario normal → con su `tenant_id`
- ✅ tenant_id=None → 401
- ⚠️ Tests de integración requieren PostgreSQL corriendo