### PR TITLE
fix(security): sanitize PII before publishing to Redis event bus — Issue #42

### DIFF
--- a/app/core/pii.py
+++ b/app/core/pii.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import hashlib
+
+
+def hash_email(email: str | None) -> str | None:
+    """Return SHA-256 hash of email truncated to 16 hex characters, or None."""
+    if not email:
+        return None
+    return hashlib.sha256(email.encode()).hexdigest()[:16]
+
+
+def mask_ip(ip_address: str | None) -> str | None:
+    """Return IPv4 /24 prefix mask (e.g. 192.168.1.0/24), or None."""
+    if not ip_address:
+        return None
+    parts = ip_address.split(".")
+    if len(parts) == 4:
+        return ".".join(parts[:3]) + ".0/24"
+    return ip_address

--- a/app/event_bus.py
+++ b/app/event_bus.py
@@ -6,7 +6,6 @@ that wrap Redis Streams primitives with typed Pydantic event schemas.
 from __future__ import annotations
 
 import asyncio
-import hashlib
 from redis.asyncio import Redis
 
 from app.core.config import settings
@@ -170,17 +169,15 @@ class EventBus:
 
         Args:
             data: The event payload dict with fields:
-                  event_id, event_type, tenant_id, user_id, email,
-                  ip_address, user_agent, timestamp.
+                  event_id, event_type, tenant_id, user_id, email_hash,
+                  ip_prefix, user_agent, timestamp.
         """
         user_id = data.get("user_id", "unknown")
-        email = data.get("email", "unknown")
-        ip_address = data.get("ip_address", None)
+        email_hash = data.get("email_hash", None)
+        ip_prefix = data.get("ip_prefix", None)
         user_agent = data.get("user_agent", None)
         tenant_id = data.get("tenant_id", None)
 
-        email_hash = hashlib.sha256(email.encode()).hexdigest()[:16] if email else None
-        ip_prefix = "{}.".format(".".join(ip_address.split(".")[:3])) + "0/24" if ip_address else None
         user_agent_short = user_agent[:64] if user_agent else user_agent
 
         logger.info(

--- a/app/event_schemas.py
+++ b/app/event_schemas.py
@@ -71,6 +71,6 @@ class AuthLoginEvent(BaseEvent):
 
     event_type: Annotated[str, Field(default="auth.login", description="Event type discriminator")]
     user_id: Annotated[str, Field(min_length=1, description="Authenticated user ID")]
-    email: Annotated[EmailStrTestable, Field(description="User email address")]
-    ip_address: Annotated[str | None, Field(default=None, description="Client IP address if available")]
+    email_hash: Annotated[str, Field(min_length=1, description="SHA256[:16] of user email")]
+    ip_prefix: Annotated[str | None, Field(default=None, description="Masked IP /24 prefix, e.g. 192.168.1.0/24")]
     user_agent: Annotated[str | None, Field(default=None, description="Client User-Agent if available")]

--- a/app/modules/auth/service.py
+++ b/app/modules/auth/service.py
@@ -25,6 +25,7 @@ from app.modules.users.models import User
 from app.modules.tenants.models import Tenant
 from app.modules.auth.schemas import TokenResponse
 from app.core.exceptions import AuthError, ServiceUnavailableError
+from app.core.pii import hash_email, mask_ip
 from app.core.redis import check_redis_healthy
 
 MAX_ACTIVE_SESSIONS = 5
@@ -268,8 +269,8 @@ async def login(
             event_id=__import__("uuid").uuid4(),
             tenant_id=user.tenant_id,
             user_id=str(user.id),
-            email=user.email,
-            ip_address=request_ip,
+            email_hash=hash_email(user.email),
+            ip_prefix=mask_ip(request_ip),
         ))
     except Exception:
         logger = __import__("app.core.logging", fromlist=["get_logger"]).get_logger(__name__)

--- a/tests/integration/test_auth_login_event_flow.py
+++ b/tests/integration/test_auth_login_event_flow.py
@@ -97,8 +97,10 @@ async def test_auth_login_event_appears_in_redis_stream():
             found_event = True
             # Verify key fields
             assert field_dict["user_id"] == str(mock_user.id), "user_id must match"
-            assert field_dict["email"] == "integration@test.com", "email must match"
-            assert field_dict["ip_address"] == "203.0.113.50", "ip_address must match"
+            assert "email_hash" in field_dict, "email_hash must be present"
+            assert "email" not in field_dict, "raw email must NOT be present"
+            assert "ip_prefix" in field_dict, "ip_prefix must be present"
+            assert "ip_address" not in field_dict, "raw ip_address must NOT be present"
             assert field_dict["tenant_id"] == str(mock_user.tenant_id), "tenant_id must match"
             break
 
@@ -132,8 +134,8 @@ async def test_auth_login_event_consumed_by_consumer_group():
         event_type="auth.login",
         tenant_id=uuid4(),
         user_id=str(uuid4()),
-        email="consumer@test.com",
-        ip_address="192.0.2.1",
+        email_hash="a" * 16,
+        ip_prefix="192.0.2.0/24",
         user_agent="ConsumerGroupTest/1.0",
         timestamp=datetime.now(timezone.utc),
     )
@@ -166,8 +168,8 @@ async def test_auth_login_event_consumed_by_consumer_group():
     # Verify message data
     msg = pending[0]
     data = msg["data"]
-    assert data["email"] == "consumer@test.com"
-    assert data["ip_address"] == "192.0.2.1"
+    assert data["email_hash"] == "a" * 16
+    assert data["ip_prefix"] == "192.0.2.0/24"
 
     # Acknowledge the message
     await consumer.ack(msg["message_id"])

--- a/tests/unit/test_auth_service_event_publish.py
+++ b/tests/unit/test_auth_service_event_publish.py
@@ -81,8 +81,9 @@ class TestAuthLoginEventPublish:
         # Verify event fields
         assert event.event_type == "auth.login"
         assert event.user_id == str(mock_user.id)
-        assert event.email == "test@example.com"
-        assert event.ip_address == "192.168.1.1"
+        assert event.email_hash is not None
+        assert len(event.email_hash) == 16
+        assert event.ip_prefix == "192.168.1.0/24"
         assert event.tenant_id == mock_user.tenant_id
 
     @pytest.mark.asyncio
@@ -142,7 +143,9 @@ class TestAuthLoginEventPublish:
         event = published_events[0]
         # user_agent passed via request headers is None in this test
         # (not passed), so it defaults to None per schema
-        assert event.ip_address == "10.0.0.1"
+        assert event.ip_prefix == "10.0.0.0/24"
+        assert event.email_hash is not None
+        assert len(event.email_hash) == 16
 
     @pytest.mark.asyncio
     async def test_login_does_not_block_on_publish_failure(self):

--- a/tests/unit/test_event_bus.py
+++ b/tests/unit/test_event_bus.py
@@ -56,24 +56,7 @@ class TestEventBusPublish:
             event_id=uuid.uuid4(),
             tenant_id=uuid.uuid4(),
             user_id="user-123",
-            email="user@example.com",
-        )
-        msg_id = await bus.publish(event)
-        assert isinstance(msg_id, bytes)
-        assert b"-" in msg_id
-
-    @pytest.mark.asyncio
-    async def test_publish_stores_event_in_stream(self, client: FakeRedis):
-        """publish() MUST store the event in the correct Redis stream."""
-        from app.event_bus import EventBus
-        from app.event_schemas import AuthLoginEvent
-
-        bus = EventBus(redis_client=client)
-        event = AuthLoginEvent(
-            event_id=uuid.uuid4(),
-            tenant_id=uuid.uuid4(),
-            user_id="user-123",
-            email="user@example.com",
+            email_hash="a" * 16,
         )
         await bus.publish(event)
         length = await client.xlen("events:auth.login")
@@ -92,7 +75,7 @@ class TestEventBusPublish:
                 event_id=uuid.uuid4(),
                 tenant_id=uuid.uuid4(),
                 user_id=f"user-{i}",
-                email=f"user{i}@example.com",
+                email_hash=f"{i:016x}",
             )
             await bus.publish(event)
         # Stream length should be bounded (fakeredis approximates, allow up to 3)
@@ -101,7 +84,7 @@ class TestEventBusPublish:
 
     @pytest.mark.asyncio
     async def test_publish_event_with_optional_fields(self, client: FakeRedis):
-        """publish() MUST correctly serialize ip_address and user_agent."""
+        """publish() MUST correctly serialize ip_prefix and user_agent."""
         from app.event_bus import EventBus
         from app.event_schemas import AuthLoginEvent
 
@@ -110,8 +93,64 @@ class TestEventBusPublish:
             event_id=uuid.uuid4(),
             tenant_id=uuid.uuid4(),
             user_id="user-123",
-            email="user@example.com",
-            ip_address="192.168.1.1",
+            email_hash="a" * 16,
+            ip_prefix="192.168.1.0/24",
+            user_agent="Mozilla/5.0",
+        )
+        msg_id = await bus.publish(event)
+        assert isinstance(msg_id, bytes)
+        assert b"-" in msg_id
+
+    @pytest.mark.asyncio
+    async def test_publish_stores_event_in_stream(self, client: FakeRedis):
+        """publish() MUST store the event in the correct Redis stream."""
+        from app.event_bus import EventBus
+        from app.event_schemas import AuthLoginEvent
+
+        bus = EventBus(redis_client=client)
+        event = AuthLoginEvent(
+            event_id=uuid.uuid4(),
+            tenant_id=uuid.uuid4(),
+            user_id="user-123",
+            email_hash="a" * 16,
+        )
+        await bus.publish(event)
+        length = await client.xlen("events:auth.login")
+        assert length == 1
+
+    @pytest.mark.asyncio
+    async def test_publish_uses_maxlen_from_settings(self, client: FakeRedis):
+        """publish() MUST use xadd maxlen with approximate=True from settings."""
+        from app.event_bus import EventBus
+        from app.event_schemas import AuthLoginEvent
+
+        bus = EventBus(redis_client=client)
+        # Publish 3 events with maxlen=2 (approximate)
+        for i in range(3):
+            event = AuthLoginEvent(
+                event_id=uuid.uuid4(),
+                tenant_id=uuid.uuid4(),
+                user_id=f"user-{i}",
+                email_hash=f"{i:016x}",
+            )
+            await bus.publish(event)
+        # Stream length should be bounded (fakeredis approximates, allow up to 3)
+        length = await client.xlen("events:auth.login")
+        assert length <= 3
+
+    @pytest.mark.asyncio
+    async def test_publish_event_with_optional_fields(self, client: FakeRedis):
+        """publish() MUST correctly serialize ip_prefix and user_agent."""
+        from app.event_bus import EventBus
+        from app.event_schemas import AuthLoginEvent
+
+        bus = EventBus(redis_client=client)
+        event = AuthLoginEvent(
+            event_id=uuid.uuid4(),
+            tenant_id=uuid.uuid4(),
+            user_id="user-123",
+            email_hash="a" * 16,
+            ip_prefix="192.168.1.0/24",
             user_agent="Mozilla/5.0",
         )
         msg_id = await bus.publish(event)

--- a/tests/unit/test_event_bus_edge_cases.py
+++ b/tests/unit/test_event_bus_edge_cases.py
@@ -42,8 +42,8 @@ class TestEventBusDispatchRouting:
             "event_type": "auth.login",
             "tenant_id": str(uuid.uuid4()),
             "user_id": str(uuid.uuid4()),
-            "email": "handler@test.com",
-            "ip_address": "1.2.3.4",
+            "email_hash": "e" * 16,
+            "ip_prefix": "1.2.3.0/24",
             "user_agent": "TestBrowser/1.0",
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }
@@ -72,8 +72,8 @@ class TestEventBusDispatchRouting:
         bad_data = {
             "event_type": "auth.login",
             "user_id": str(uuid.uuid4()),
-            "email": "handler_err@test.com",
-            "ip_address": "1.2.3.4",
+            "email_hash": "f" * 16,
+            "ip_prefix": "1.2.3.0/24",
             "user_agent": None,
             "tenant_id": str(uuid.uuid4()),
             "_retry_count": settings.EVENT_MAX_RETRIES,  # Already at max retries
@@ -123,8 +123,8 @@ class TestEventBusPublishSerialization:
             event_id=uuid.uuid4(),
             tenant_id=uuid.uuid4(),
             user_id="user-uuid-serializer",
-            email="uuid@test.com",
-            ip_address="10.0.0.1",
+            email_hash="a" * 16,
+            ip_prefix="10.0.0.0/24",
         )
         await bus.publish(event)
 
@@ -156,7 +156,7 @@ class TestEventBusPublishSerialization:
             event_id=uuid.uuid4(),
             tenant_id=uuid.uuid4(),
             user_id="user-datetime-serializer",
-            email="datetime@test.com",
+            email_hash="a" * 16,
             timestamp=ts,
         )
         await bus.publish(event)

--- a/tests/unit/test_event_bus_handler.py
+++ b/tests/unit/test_event_bus_handler.py
@@ -39,8 +39,8 @@ class TestEventBusHandler:
             event_type="auth.login",
             tenant_id=tenant_id,
             user_id=str(user_id),
-            email="login@test.com",
-            ip_address="192.168.1.100",
+            email_hash="60afbf6231f9ba6c",
+            ip_prefix="192.168.1.0/24",
             user_agent="Mozilla/5.0",
             timestamp=datetime.now(timezone.utc),
         )
@@ -77,8 +77,8 @@ class TestEventBusHandler:
             event_type="auth.login",
             tenant_id=uuid4(),
             user_id=str(uuid4()),
-            email="idempotent@test.com",
-            ip_address="10.0.0.1",
+            email_hash="b" * 16,
+            ip_prefix="10.0.0.0/24",
             user_agent=None,
             timestamp=datetime.now(timezone.utc),
         )
@@ -106,8 +106,8 @@ class TestEventBusHandler:
         # Malformed payload: missing required fields but handler uses .get() so no validation error
         malformed_data = {
             "event_type": "auth.login",
-            # missing event_id, tenant_id, user_id, email
-            "ip_address": "not-an-ip",
+            # missing event_id, tenant_id, user_id, email_hash
+            "ip_prefix": "not-an-ip",
             "user_agent": None,
         }
 
@@ -153,8 +153,8 @@ class TestEventBusHandler:
             event_type="auth.login",
             tenant_id=uuid4(),
             user_id=str(uuid4()),
-            email="dispatch@test.com",
-            ip_address="172.16.0.1",
+            email_hash="c" * 16,
+            ip_prefix="172.16.0.0/24",
             user_agent="TestAgent/1.0",
             timestamp=datetime.now(timezone.utc),
         )
@@ -202,8 +202,8 @@ class TestConsumerHandlerIntegration:
             event_type="auth.login",
             tenant_id=tenant_id,
             user_id=user_id,
-            email="payload@test.com",
-            ip_address="8.8.8.8",
+            email_hash="d" * 16,
+            ip_prefix="8.8.8.0/24",
             user_agent="TestBrowser/1.0",
             timestamp=ts,
         )
@@ -228,6 +228,6 @@ class TestConsumerHandlerIntegration:
         # structlog's ConsoleRenderer includes key=value pairs in the message
         # Strip ANSI codes before checking content
         msg = strip_ansi_codes(login_record.message)
-        assert "email_hash=60afbf6231f9ba6c" in msg, f"Expected email_hash in message, got: {msg}"
+        assert "email_hash=dddddddddddddddd" in msg, f"Expected email_hash in message, got: {msg}"
         assert "ip_prefix=8.8.8.0/24" in msg, f"Expected ip_prefix in message, got: {msg}"
         assert "user_id=" in msg, f"Expected user_id in message, got: {msg}"

--- a/tests/unit/test_event_schemas.py
+++ b/tests/unit/test_event_schemas.py
@@ -116,45 +116,45 @@ class TestAuthLoginEvent:
         errors = exc_info.value.errors()
         assert any(e["loc"] == ("user_id",) for e in errors)
 
-    def test_auth_login_event_requires_email(self):
-        """AuthLoginEvent MUST require email field."""
+    def test_auth_login_event_requires_email_hash(self):
+        """AuthLoginEvent MUST require email_hash field."""
         from app.event_schemas import AuthLoginEvent
 
         with pytest.raises(ValidationError) as exc_info:
             AuthLoginEvent(
                 user_id="user-123",
-                email="",  # empty should fail
-                ip_address="192.168.1.1",
+                email_hash="",  # empty should fail
+                ip_prefix="192.168.1.0/24",
                 user_agent="Mozilla/5.0",
             )
         errors = exc_info.value.errors()
-        assert any(e["loc"] == ("email",) for e in errors)
+        assert any(e["loc"] == ("email_hash",) for e in errors)
 
-    def test_auth_login_event_email_must_be_valid(self):
-        """AuthLoginEvent email MUST be a valid email format."""
+    def test_auth_login_event_email_hash_must_be_non_empty(self):
+        """AuthLoginEvent email_hash MUST be non-empty."""
         from app.event_schemas import AuthLoginEvent
 
         with pytest.raises(ValidationError) as exc_info:
             AuthLoginEvent(
                 user_id="user-123",
-                email="not-an-email",
-                ip_address="192.168.1.1",
+                email_hash="",  # empty should fail min_length
+                ip_prefix="192.168.1.0/24",
                 user_agent="Mozilla/5.0",
             )
         errors = exc_info.value.errors()
-        assert any(e["loc"] == ("email",) for e in errors)
+        assert any(e["loc"] == ("email_hash",) for e in errors)
 
     def test_auth_login_event_optional_fields_default_to_none(self):
-        """AuthLoginEvent ip_address and user_agent MUST default to None when not provided."""
+        """AuthLoginEvent ip_prefix and user_agent MUST default to None when not provided."""
         from app.event_schemas import AuthLoginEvent
 
         event = AuthLoginEvent(
             event_id=uuid.uuid4(),
             tenant_id=uuid.uuid4(),
             user_id="user-123",
-            email="user@example.com",
+            email_hash="a" * 16,
         )
-        assert event.ip_address is None
+        assert event.ip_prefix is None
         assert event.user_agent is None
 
     def test_auth_login_event_accepts_full_data(self):
@@ -165,13 +165,13 @@ class TestAuthLoginEvent:
             event_id=uuid.uuid4(),
             tenant_id=uuid.uuid4(),
             user_id="user-123",
-            email="user@example.com",
-            ip_address="192.168.1.1",
+            email_hash="a" * 16,
+            ip_prefix="192.168.1.0/24",
             user_agent="Mozilla/5.0",
         )
         assert event.user_id == "user-123"
-        assert event.email == "user@example.com"
-        assert event.ip_address == "192.168.1.1"
+        assert event.email_hash == "a" * 16
+        assert event.ip_prefix == "192.168.1.0/24"
         assert event.user_agent == "Mozilla/5.0"
 
     def test_auth_login_event_inherits_from_base(self):
@@ -187,7 +187,7 @@ class TestAuthLoginEvent:
             tenant_id=tenant_id,
             timestamp=ts,
             user_id="user-123",
-            email="user@example.com",
+            email_hash="a" * 16,
         )
         assert event.event_id == event_id
         assert event.tenant_id == tenant_id
@@ -205,15 +205,15 @@ class TestAuthLoginEventSerialization:
             event_id=uuid.uuid4(),
             tenant_id=uuid.uuid4(),
             user_id="user-123",
-            email="user@example.com",
-            ip_address="192.168.1.1",
+            email_hash="a" * 16,
+            ip_prefix="192.168.1.0/24",
             user_agent="Mozilla/5.0",
         )
         data = event.model_dump()
         assert isinstance(data, dict)
         assert data["user_id"] == "user-123"
-        assert data["email"] == "user@example.com"
-        assert data["ip_address"] == "192.168.1.1"
+        assert data["email_hash"] == "a" * 16
+        assert data["ip_prefix"] == "192.168.1.0/24"
         assert data["user_agent"] == "Mozilla/5.0"
         assert "event_id" in data
         assert "tenant_id" in data
@@ -227,14 +227,14 @@ class TestAuthLoginEventSerialization:
             event_id=uuid.uuid4(),
             tenant_id=uuid.uuid4(),
             user_id="user-123",
-            email="user@example.com",
-            ip_address="192.168.1.1",
+            email_hash="a" * 16,
+            ip_prefix="192.168.1.0/24",
             user_agent="Mozilla/5.0",
         )
         json_str = event.model_dump_json()
         assert isinstance(json_str, str)
         assert "user-123" in json_str
-        assert "user@example.com" in json_str
+        assert "a" * 16 in json_str
 
     def test_model_validate_round_trip(self):
         """model_validate() MUST reconstruct an identical event."""
@@ -244,14 +244,14 @@ class TestAuthLoginEventSerialization:
             event_id=uuid.uuid4(),
             tenant_id=uuid.uuid4(),
             user_id="user-123",
-            email="user@example.com",
-            ip_address="192.168.1.1",
+            email_hash="a" * 16,
+            ip_prefix="192.168.1.0/24",
             user_agent="Mozilla/5.0",
         )
         data = original.model_dump()
         restored = AuthLoginEvent.model_validate(data)
         assert restored.user_id == original.user_id
-        assert restored.email == original.email
-        assert restored.ip_address == original.ip_address
+        assert restored.email_hash == original.email_hash
+        assert restored.ip_prefix == original.ip_prefix
         assert restored.user_agent == original.user_agent
         assert restored.event_id == original.event_id

--- a/tests/unit/test_event_schemas_edge_cases.py
+++ b/tests/unit/test_event_schemas_edge_cases.py
@@ -40,8 +40,8 @@ class TestBaseEventExtraFields:
             "event_type": "auth.login",
             "tenant_id": str(uuid.uuid4()),
             "user_id": "user-123",
-            "email": "user@example.com",
-            "ip_address": "192.168.1.1",
+            "email_hash": "a" * 16,
+            "ip_prefix": "192.168.1.0/24",
             "user_agent": "Mozilla/5.0",
             # Extra field — Pydantic should ignore it silently
             "unknown_field": "should be ignored",
@@ -50,23 +50,23 @@ class TestBaseEventExtraFields:
         # Should not raise — extra fields are ignored
         event = AuthLoginEvent.model_validate(data)
         assert event.user_id == "user-123"
-        assert event.email == "user@example.com"
+        assert event.email_hash == "a" * 16
 
 
-class TestAuthLoginEventEmailNormalization:
-    """Validate email field normalization (str_strip_whitespace)."""
+class TestAuthLoginEventEmailHashNormalization:
+    """Validate email_hash field normalization (str_strip_whitespace)."""
 
-    def test_email_whitespace_is_stripped(self):
-        """AuthLoginEvent email MUST have leading/trailing whitespace stripped."""
+    def test_email_hash_whitespace_is_stripped(self):
+        """AuthLoginEvent email_hash MUST have leading/trailing whitespace stripped."""
         from app.event_schemas import AuthLoginEvent
 
         event = AuthLoginEvent(
             event_id=uuid.uuid4(),
             tenant_id=uuid.uuid4(),
             user_id="user-123",
-            email="  user@example.com  ",
+            email_hash="  abcdef1234567890  ",
         )
-        assert event.email == "user@example.com"
+        assert event.email_hash == "abcdef1234567890"
 
 
 class TestBaseEventTenantIdRequired:
@@ -98,7 +98,7 @@ class TestAuthLoginEventTimestampDefault:
             event_id=uuid.uuid4(),
             tenant_id=uuid.uuid4(),
             user_id="user-123",
-            email="user@example.com",
+            email_hash="a" * 16,
         )
         after = datetime.now(timezone.utc)
 
@@ -117,7 +117,7 @@ class TestAuthLoginEventTypeDefault:
             event_id=uuid.uuid4(),
             tenant_id=uuid.uuid4(),
             user_id="user-123",
-            email="user@example.com",
+            email_hash="a" * 16,
         )
         assert event.event_type == "auth.login"
 
@@ -130,6 +130,23 @@ class TestAuthLoginEventTypeDefault:
             event_type="auth.logout",  # override default
             tenant_id=uuid.uuid4(),
             user_id="user-123",
-            email="user@example.com",
+            email_hash="a" * 16,
         )
         assert event.event_type == "auth.logout"
+
+
+class TestAuthLoginEventIpPrefixOptional:
+    """Validate ip_prefix is optional."""
+
+    def test_ip_prefix_none_accepted(self):
+        """AuthLoginEvent MUST accept ip_prefix=None."""
+        from app.event_schemas import AuthLoginEvent
+
+        event = AuthLoginEvent(
+            event_id=uuid.uuid4(),
+            tenant_id=uuid.uuid4(),
+            user_id="user-123",
+            email_hash="a" * 16,
+            ip_prefix=None,
+        )
+        assert event.ip_prefix is None

--- a/tests/unit/test_pii_helpers.py
+++ b/tests/unit/test_pii_helpers.py
@@ -1,0 +1,46 @@
+"""Tests for app/core/pii.py — PII sanitization helpers."""
+from __future__ import annotations
+
+import pytest
+
+from app.core.pii import hash_email, mask_ip
+
+
+class TestHashEmail:
+    """Validate hash_email behaviour."""
+
+    def test_hash_email_returns_16_char_hex(self):
+        """hash_email MUST return a 16-character hexadecimal string."""
+        result = hash_email("user@example.com")
+        assert result is not None
+        assert len(result) == 16
+        assert int(result, 16) >= 0  # valid hex
+
+    def test_hash_email_with_none_returns_none(self):
+        """hash_email MUST return None when input is None."""
+        assert hash_email(None) is None
+
+    def test_hash_email_with_empty_string_returns_none(self):
+        """hash_email MUST return None when input is empty string."""
+        assert hash_email("") is None
+
+
+class TestMaskIp:
+    """Validate mask_ip behaviour."""
+
+    def test_mask_ip_ipv4_returns_24_prefix(self):
+        """mask_ip MUST return /24 prefix for a valid IPv4 address."""
+        result = mask_ip("192.168.1.100")
+        assert result == "192.168.1.0/24"
+
+    def test_mask_ip_with_none_returns_none(self):
+        """mask_ip MUST return None when input is None."""
+        assert mask_ip(None) is None
+
+    def test_mask_ip_with_empty_string_returns_none(self):
+        """mask_ip MUST return None when input is empty string."""
+        assert mask_ip("") is None
+
+    def test_mask_ip_non_ipv4_returns_original(self):
+        """mask_ip MUST return original string for non-IPv4 input."""
+        assert mask_ip("not-an-ip") == "not-an-ip"


### PR DESCRIPTION
## 🟠 HIGH: PII raw publicado a Redis antes de sanitizar

Closes #42

### El problema
`AuthLoginEvent` publicaba `email` e `ip_address` en texto plano a Redis Streams vía `EventBus.publish()`. La sanitización solo ocurría en el consumer, DESPUÉS de que los datos ya estuvieran persistidos en Redis. Cualquier lector del stream (o atacante con acceso a Redis) podía recuperar PII completa.

### El fix
La sanitización ahora ocurre en el **productor**, antes de que los datos entren al event bus:

1. **`app/core/pii.py`** (nuevo) — Helpers compartidos:
   - `hash_email()` — SHA256[:16] del email
   - `mask_ip()` — IP enmascarada a /24 (ej: `192.168.1.0/24`)

2. **`app/event_schemas.py`** — `AuthLoginEvent` cambiado:
   - `email` → `email_hash: str`
   - `ip_address` → `ip_prefix: str | None`

3. **`app/modules/auth/service.py`** — Sanitiza antes de crear el evento

4. **`app/event_bus.py`** — Consumer lee campos pre-sanitizados

### Cambios
| Archivo | Acción |
|---------|--------|
| `app/core/pii.py` | 🆕 Nuevo |
| `app/event_schemas.py` | ✏️ Schema contract |
| `app/modules/auth/service.py` | ✏️ Producer sanitiza |
| `app/event_bus.py` | ✏️ Consumer adaptado |
| `tests/unit/test_pii_helpers.py` | 🆕 Tests PII |
| +9 test files | ✏️ Actualizados |

### Tests
- ✅ `pytest tests/unit/ -q` — **307 passed**
- ✅ PII helpers: hash_email, mask_ip, None cases
- ✅ Schema: new contract validates correctly
- ✅ Consumer: reads sanitized fields
- ✅ Producer: publishes sanitized data