### PR TITLE
fix(security): deshabilitar openapi.json en produccion

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -73,6 +73,7 @@ def create_app() -> FastAPI:
         version=APP_VERSION,
         docs_url="/api/docs" if settings.ENVIRONMENT != "production" else None,
         redoc_url="/api/redoc" if settings.ENVIRONMENT != "production" else None,
+        openapi_url="/api/openapi.json" if settings.ENVIRONMENT != "production" else None,
         lifespan=lifespan,
     )
     

--- a/tests/unit/test_main_security_integration.py
+++ b/tests/unit/test_main_security_integration.py
@@ -27,3 +27,17 @@ class TestMainSecurityIntegration:
         monkeypatch.setattr(settings, "ENVIRONMENT", "production")
         app = create_app()
         assert app.redoc_url is None
+
+    def test_openapi_url_none_in_production(self, monkeypatch: pytest.MonkeyPatch):
+        """openapi_url MUST be None when ENVIRONMENT=production."""
+        monkeypatch.setattr(settings, "ENVIRONMENT", "production")
+        app = create_app()
+        assert app.openapi_url is None
+
+    def test_openapi_url_present_in_development(self, monkeypatch: pytest.MonkeyPatch):
+        """openapi_url MUST retain its configured value when ENVIRONMENT=development."""
+        monkeypatch.setattr(settings, "ENVIRONMENT", "development")
+        app = create_app()
+        assert app.openapi_url == "/api/openapi.json"
+
+


### PR DESCRIPTION
## 🟠 HIGH: openapi_url expuesto en producción

**Problema:** docs_url y redoc_url se deshabilitan en producción, pero openapi_url quedaba con el default /openapi.json, exponiendo el schema completo de la API.

**Fix:** openapi_url ahora también se setea a None en producción, consistente con docs_url y redoc_url.

**Tests:** 2 nuevos tests unitarios en TestMainSecurityIntegration.

Closes #46