### PR TITLE
fix(security): X-Forwarded-Proto spoofeable — validar contra trusted proxies

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -64,6 +64,9 @@ class Settings(BaseSettings):
     
     #CORS
     CORS_ORIGINS: list[str] = ["http://localhost:5173"]
+
+    #Proxy
+    TRUSTED_PROXIES: list[str] = []
     
     #Validators
     

--- a/app/core/middleware.py
+++ b/app/core/middleware.py
@@ -28,7 +28,10 @@ class HTTPSRedirectMiddleware(BaseHTTPMiddleware):
         if settings.ENVIRONMENT != "production":
             return await call_next(request)
 
-        proto = request.headers.get("x-forwarded-proto", request.url.scheme)
+        if settings.TRUSTED_PROXIES and request.client and request.client.host in settings.TRUSTED_PROXIES:
+            proto = request.headers.get("x-forwarded-proto", request.url.scheme)
+        else:
+            proto = request.url.scheme
         if proto == "http":
             https_url = str(request.url.replace(scheme="https"))
             return RedirectResponse(url=https_url, status_code=307)

--- a/tests/unit/test_https_redirect_middleware.py
+++ b/tests/unit/test_https_redirect_middleware.py
@@ -115,6 +115,7 @@ class TestHTTPSRedirectMiddleware:
     async def test_respects_x_forwarded_proto_https(self, middleware, monkeypatch: pytest.MonkeyPatch):
         """Requests with X-Forwarded-Proto: https MUST NOT be redirected."""
         monkeypatch.setattr(settings, "ENVIRONMENT", "production")
+        monkeypatch.setattr(settings, "TRUSTED_PROXIES", ["10.0.0.1"])
 
         calls = []
 
@@ -124,6 +125,7 @@ class TestHTTPSRedirectMiddleware:
         scope = {
             "type": "http",
             "scheme": "http",
+            "client": ["10.0.0.1", 54321],
             "method": "GET",
             "path": "/api/v1/users",
             "headers": [
@@ -137,3 +139,31 @@ class TestHTTPSRedirectMiddleware:
         start = calls[0]
         assert start["type"] == "http.response.start"
         assert start["status"] == 200
+
+    @pytest.mark.asyncio
+    async def test_rejects_x_forwarded_proto_from_untrusted_client(self, middleware, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(settings, "ENVIRONMENT", "production")
+        monkeypatch.setattr(settings, "TRUSTED_PROXIES", ["10.0.0.1"])
+
+        calls = []
+
+        async def _send(message):
+            calls.append(message)
+
+        scope = {
+            "type": "http",
+            "scheme": "http",
+            "client": ["192.168.1.99", 54321],
+            "method": "GET",
+            "path": "/api/v1/users",
+            "headers": [
+                [b"host", b"api.example.com"],
+                [b"x-forwarded-proto", b"https"],
+            ],
+        }
+
+        await middleware(scope, AsyncMock(), _send)
+
+        start = calls[0]
+        assert start["type"] == "http.response.start"
+        assert start["status"] == 307


### PR DESCRIPTION
## 🟠 HIGH: X-Forwarded-Proto spoofeable — HTTPS redirect bypasseable

**Problema:** HTTPSRedirectMiddleware confiaba en X-Forwarded-Proto sin validar su origen. Un atacante podía mandar el header falso y bypassear el redirect a HTTPS.

**Fix:** Se agregó TRUSTED_PROXIES en settings. Solo se confía en X-Forwarded-Proto si la IP del cliente está en la whitelist. Caso contrario, se usa request.url.scheme.

**Cambios:**
- app/core/config.py — + TRUSTED_PROXIES: list[str]
- app/core/middleware.py — validación de proxy confiable
- tests/unit/test_https_redirect_middleware.py — test actualizado + 1 nuevo

**Tests:** 5/5 pasando.

Closes #48