### PR TITLE
fix(auth): pasar User-Agent al login service y al evento

### DIFF
--- a/app/modules/auth/router.py
+++ b/app/modules/auth/router.py
@@ -47,10 +47,12 @@ async def login(
     redis: RedisDep,
 ) -> TokenResponse:
     try:
+        user_agent = request.headers.get("user-agent")
         token_response, refresh_token = await service.login(
             email=body.email,
             password=body.password,
             request_ip=request.client.host if request.client else None,
+            user_agent=user_agent,
             db=db,
             redis=redis,
         )

--- a/app/modules/auth/service.py
+++ b/app/modules/auth/service.py
@@ -233,6 +233,7 @@ async def login(
     redis: Redis,
     request_ip: str | None = None,
     request_headers: dict | None = None,
+    user_agent: str | None = None,
 ) -> tuple[TokenResponse, str]:
     """Autentica al usuario y delvuelve el access token + refresh token"""
     if not await check_redis_healthy(redis):
@@ -271,6 +272,7 @@ async def login(
             user_id=str(user.id),
             email_hash=hash_email(user.email),
             ip_prefix=mask_ip(request_ip),
+            user_agent=user_agent,
         ))
     except Exception:
         logger = __import__("app.core.logging", fromlist=["get_logger"]).get_logger(__name__)


### PR DESCRIPTION
Closes #43

## Summary
- Router extrae User-Agent de request.headers y lo pasa al service.login()
- Service.login() acepta user_agent como parametro y lo inyecta en AuthLoginEvent
- La sanitizacion de user_agent en event_bus.py ya no es codigo muerto

## Changes
| File | Change |
|------|--------|
| `app/modules/auth/router.py` | Extraer user-agent de headers y pasarlo al service |
| `app/modules/auth/service.py` | Aceptar user_agent y pasarlo al AuthLoginEvent |

## Test Plan
- [x] User-Agent ahora fluye: Request.headers → Router → Service → AuthLoginEvent → EventBus