### PR TITLE
fix(auth): usar settings.REFRESH_TOKEN_EXPIRE_DAYS en cookie max_age

### DIFF
--- a/app/modules/auth/router.py
+++ b/app/modules/auth/router.py
@@ -26,7 +26,7 @@ def _set_refresh_cookie(response: Response, token: str) -> None:
         httponly=True,
         secure=settings.ENVIRONMENT != "development",
         samesite="strict",
-        max_age=7 * 24 * 3600,
+        max_age=settings.REFRESH_TOKEN_EXPIRE_DAYS * 24 * 3600,
         path="/api/v1/auth",
     )
 


### PR DESCRIPTION
Closes #50\n\n## Summary\n- Reemplazar max_age hardcodeado (7*24*3600) por settings.REFRESH_TOKEN_EXPIRE_DAYS * 24 * 3600\n\n## Changes\n| File | Change |\n|------|--------|\n| `app/modules/auth/router.py` | max_age ahora usa settings |