### PR TITLE
fix(auth): usar except JWTError en lugar de except Exception en refresh

### DIFF
--- a/app/modules/auth/router.py
+++ b/app/modules/auth/router.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Cookie, HTTPException, Request, Response
+from jose import JWTError
 
 from app.core.config import settings
 from app.core.exceptions import AppError
@@ -82,7 +83,7 @@ async def refresh(
             token = auth_header[7:]
             payload = decode_access_token(token)
             old_jti = payload.get("jti")
-        except Exception:
+        except JWTError:
             pass  # token inválido o expirado — no importa, no podemos removerlo
 
     try:


### PR DESCRIPTION
Closes #59\n\n## Summary\n- `except Exception` cambia a `except JWTError` para evitar tragar errores inesperados\n- Se importa JWTError desde jose