### PR TITLE
fix(core): extender hash_email de 16 a 32 chars hex

### DIFF
--- a/app/core/pii.py
+++ b/app/core/pii.py
@@ -5,10 +5,10 @@ import ipaddress
 
 
 def hash_email(email: str | None) -> str | None:
-    """Return SHA-256 hash of email truncated to 16 hex characters, or None."""
+    """Return SHA-256 hash of email truncated to 32 hex characters, or None."""
     if not email:
         return None
-    return hashlib.sha256(email.encode()).hexdigest()[:16]
+    return hashlib.sha256(email.encode()).hexdigest()[:32]
 
 
 def mask_ip(ip_address: str | None) -> str | None:

--- a/app/event_schemas.py
+++ b/app/event_schemas.py
@@ -71,6 +71,6 @@ class AuthLoginEvent(BaseEvent):
 
     event_type: Annotated[str, Field(default="auth.login", description="Event type discriminator")]
     user_id: Annotated[str, Field(min_length=1, description="Authenticated user ID")]
-    email_hash: Annotated[str, Field(min_length=1, description="SHA256[:16] of user email")]
+    email_hash: Annotated[str, Field(min_length=1, description="SHA256[:32] of user email")]
     ip_prefix: Annotated[str | None, Field(default=None, description="Masked IP /24 prefix, e.g. 192.168.1.0/24")]
     user_agent: Annotated[str | None, Field(default=None, description="Client User-Agent if available")]

--- a/tests/integration/test_auth_login_event_flow.py
+++ b/tests/integration/test_auth_login_event_flow.py
@@ -134,7 +134,7 @@ async def test_auth_login_event_consumed_by_consumer_group():
         event_type="auth.login",
         tenant_id=uuid4(),
         user_id=str(uuid4()),
-        email_hash="a" * 16,
+        email_hash="a" * 32,
         ip_prefix="192.0.2.0/24",
         user_agent="ConsumerGroupTest/1.0",
         timestamp=datetime.now(timezone.utc),
@@ -168,7 +168,7 @@ async def test_auth_login_event_consumed_by_consumer_group():
     # Verify message data
     msg = pending[0]
     data = msg["data"]
-    assert data["email_hash"] == "a" * 16
+    assert data["email_hash"] == "a" * 32
     assert data["ip_prefix"] == "192.0.2.0/24"
 
     # Acknowledge the message

--- a/tests/unit/test_auth_service_event_publish.py
+++ b/tests/unit/test_auth_service_event_publish.py
@@ -82,7 +82,7 @@ class TestAuthLoginEventPublish:
         assert event.event_type == "auth.login"
         assert event.user_id == str(mock_user.id)
         assert event.email_hash is not None
-        assert len(event.email_hash) == 16
+        assert len(event.email_hash) == 32
         assert event.ip_prefix == "192.168.1.0/24"
         assert event.tenant_id == mock_user.tenant_id
 
@@ -145,7 +145,7 @@ class TestAuthLoginEventPublish:
         # (not passed), so it defaults to None per schema
         assert event.ip_prefix == "10.0.0.0/24"
         assert event.email_hash is not None
-        assert len(event.email_hash) == 16
+        assert len(event.email_hash) == 32
 
     @pytest.mark.asyncio
     async def test_login_does_not_block_on_publish_failure(self):

--- a/tests/unit/test_event_bus.py
+++ b/tests/unit/test_event_bus.py
@@ -56,7 +56,7 @@ class TestEventBusPublish:
             event_id=uuid.uuid4(),
             tenant_id=uuid.uuid4(),
             user_id="user-123",
-            email_hash="a" * 16,
+            email_hash="a" * 32,
         )
         await bus.publish(event)
         length = await client.xlen("events:auth.login")
@@ -75,7 +75,7 @@ class TestEventBusPublish:
                 event_id=uuid.uuid4(),
                 tenant_id=uuid.uuid4(),
                 user_id=f"user-{i}",
-                email_hash=f"{i:016x}",
+                email_hash=f"{i:032x}",
             )
             await bus.publish(event)
         # Stream length should be bounded (fakeredis approximates, allow up to 3)
@@ -93,7 +93,7 @@ class TestEventBusPublish:
             event_id=uuid.uuid4(),
             tenant_id=uuid.uuid4(),
             user_id="user-123",
-            email_hash="a" * 16,
+            email_hash="a" * 32,
             ip_prefix="192.168.1.0/24",
             user_agent="Mozilla/5.0",
         )
@@ -112,7 +112,7 @@ class TestEventBusPublish:
             event_id=uuid.uuid4(),
             tenant_id=uuid.uuid4(),
             user_id="user-123",
-            email_hash="a" * 16,
+            email_hash="a" * 32,
         )
         await bus.publish(event)
         length = await client.xlen("events:auth.login")
@@ -131,7 +131,7 @@ class TestEventBusPublish:
                 event_id=uuid.uuid4(),
                 tenant_id=uuid.uuid4(),
                 user_id=f"user-{i}",
-                email_hash=f"{i:016x}",
+                email_hash=f"{i:032x}",
             )
             await bus.publish(event)
         # Stream length should be bounded (fakeredis approximates, allow up to 3)
@@ -149,7 +149,7 @@ class TestEventBusPublish:
             event_id=uuid.uuid4(),
             tenant_id=uuid.uuid4(),
             user_id="user-123",
-            email_hash="a" * 16,
+            email_hash="a" * 32,
             ip_prefix="192.168.1.0/24",
             user_agent="Mozilla/5.0",
         )

--- a/tests/unit/test_event_bus_edge_cases.py
+++ b/tests/unit/test_event_bus_edge_cases.py
@@ -42,7 +42,7 @@ class TestEventBusDispatchRouting:
             "event_type": "auth.login",
             "tenant_id": str(uuid.uuid4()),
             "user_id": str(uuid.uuid4()),
-            "email_hash": "e" * 16,
+            "email_hash": "e" * 32,
             "ip_prefix": "1.2.3.0/24",
             "user_agent": "TestBrowser/1.0",
             "timestamp": datetime.now(timezone.utc).isoformat(),
@@ -72,7 +72,7 @@ class TestEventBusDispatchRouting:
         bad_data = {
             "event_type": "auth.login",
             "user_id": str(uuid.uuid4()),
-            "email_hash": "f" * 16,
+            "email_hash": "f" * 32,
             "ip_prefix": "1.2.3.0/24",
             "user_agent": None,
             "tenant_id": str(uuid.uuid4()),
@@ -123,7 +123,7 @@ class TestEventBusPublishSerialization:
             event_id=uuid.uuid4(),
             tenant_id=uuid.uuid4(),
             user_id="user-uuid-serializer",
-            email_hash="a" * 16,
+            email_hash="a" * 32,
             ip_prefix="10.0.0.0/24",
         )
         await bus.publish(event)
@@ -156,7 +156,7 @@ class TestEventBusPublishSerialization:
             event_id=uuid.uuid4(),
             tenant_id=uuid.uuid4(),
             user_id="user-datetime-serializer",
-            email_hash="a" * 16,
+            email_hash="a" * 32,
             timestamp=ts,
         )
         await bus.publish(event)

--- a/tests/unit/test_event_bus_handler.py
+++ b/tests/unit/test_event_bus_handler.py
@@ -39,7 +39,7 @@ class TestEventBusHandler:
             event_type="auth.login",
             tenant_id=tenant_id,
             user_id=str(user_id),
-            email_hash="60afbf6231f9ba6c",
+            email_hash="60afbf6231f9ba6c60afbf6231f9ba6c",
             ip_prefix="192.168.1.0/24",
             user_agent="Mozilla/5.0",
             timestamp=datetime.now(timezone.utc),
@@ -77,7 +77,7 @@ class TestEventBusHandler:
             event_type="auth.login",
             tenant_id=uuid4(),
             user_id=str(uuid4()),
-            email_hash="b" * 16,
+            email_hash="b" * 32,
             ip_prefix="10.0.0.0/24",
             user_agent=None,
             timestamp=datetime.now(timezone.utc),
@@ -153,7 +153,7 @@ class TestEventBusHandler:
             event_type="auth.login",
             tenant_id=uuid4(),
             user_id=str(uuid4()),
-            email_hash="c" * 16,
+            email_hash="c" * 32,
             ip_prefix="172.16.0.0/24",
             user_agent="TestAgent/1.0",
             timestamp=datetime.now(timezone.utc),
@@ -202,7 +202,7 @@ class TestConsumerHandlerIntegration:
             event_type="auth.login",
             tenant_id=tenant_id,
             user_id=user_id,
-            email_hash="d" * 16,
+            email_hash="d" * 32,
             ip_prefix="8.8.8.0/24",
             user_agent="TestBrowser/1.0",
             timestamp=ts,
@@ -228,6 +228,6 @@ class TestConsumerHandlerIntegration:
         # structlog's ConsoleRenderer includes key=value pairs in the message
         # Strip ANSI codes before checking content
         msg = strip_ansi_codes(login_record.message)
-        assert "email_hash=dddddddddddddddd" in msg, f"Expected email_hash in message, got: {msg}"
+        assert "email_hash=dddddddddddddddddddddddddddddddd" in msg, f"Expected email_hash in message, got: {msg}"
         assert "ip_prefix=8.8.8.0/24" in msg, f"Expected ip_prefix in message, got: {msg}"
         assert "user_id=" in msg, f"Expected user_id in message, got: {msg}"

--- a/tests/unit/test_event_schemas.py
+++ b/tests/unit/test_event_schemas.py
@@ -152,7 +152,7 @@ class TestAuthLoginEvent:
             event_id=uuid.uuid4(),
             tenant_id=uuid.uuid4(),
             user_id="user-123",
-            email_hash="a" * 16,
+            email_hash="a" * 32,
         )
         assert event.ip_prefix is None
         assert event.user_agent is None
@@ -165,12 +165,12 @@ class TestAuthLoginEvent:
             event_id=uuid.uuid4(),
             tenant_id=uuid.uuid4(),
             user_id="user-123",
-            email_hash="a" * 16,
+            email_hash="a" * 32,
             ip_prefix="192.168.1.0/24",
             user_agent="Mozilla/5.0",
         )
         assert event.user_id == "user-123"
-        assert event.email_hash == "a" * 16
+        assert event.email_hash == "a" * 32
         assert event.ip_prefix == "192.168.1.0/24"
         assert event.user_agent == "Mozilla/5.0"
 
@@ -187,7 +187,7 @@ class TestAuthLoginEvent:
             tenant_id=tenant_id,
             timestamp=ts,
             user_id="user-123",
-            email_hash="a" * 16,
+            email_hash="a" * 32,
         )
         assert event.event_id == event_id
         assert event.tenant_id == tenant_id
@@ -205,14 +205,14 @@ class TestAuthLoginEventSerialization:
             event_id=uuid.uuid4(),
             tenant_id=uuid.uuid4(),
             user_id="user-123",
-            email_hash="a" * 16,
+            email_hash="a" * 32,
             ip_prefix="192.168.1.0/24",
             user_agent="Mozilla/5.0",
         )
         data = event.model_dump()
         assert isinstance(data, dict)
         assert data["user_id"] == "user-123"
-        assert data["email_hash"] == "a" * 16
+        assert data["email_hash"] == "a" * 32
         assert data["ip_prefix"] == "192.168.1.0/24"
         assert data["user_agent"] == "Mozilla/5.0"
         assert "event_id" in data
@@ -227,14 +227,14 @@ class TestAuthLoginEventSerialization:
             event_id=uuid.uuid4(),
             tenant_id=uuid.uuid4(),
             user_id="user-123",
-            email_hash="a" * 16,
+            email_hash="a" * 32,
             ip_prefix="192.168.1.0/24",
             user_agent="Mozilla/5.0",
         )
         json_str = event.model_dump_json()
         assert isinstance(json_str, str)
         assert "user-123" in json_str
-        assert "a" * 16 in json_str
+        assert "a" * 32 in json_str
 
     def test_model_validate_round_trip(self):
         """model_validate() MUST reconstruct an identical event."""
@@ -244,7 +244,7 @@ class TestAuthLoginEventSerialization:
             event_id=uuid.uuid4(),
             tenant_id=uuid.uuid4(),
             user_id="user-123",
-            email_hash="a" * 16,
+            email_hash="a" * 32,
             ip_prefix="192.168.1.0/24",
             user_agent="Mozilla/5.0",
         )

--- a/tests/unit/test_event_schemas_edge_cases.py
+++ b/tests/unit/test_event_schemas_edge_cases.py
@@ -40,7 +40,7 @@ class TestBaseEventExtraFields:
             "event_type": "auth.login",
             "tenant_id": str(uuid.uuid4()),
             "user_id": "user-123",
-            "email_hash": "a" * 16,
+            "email_hash": "a" * 32,
             "ip_prefix": "192.168.1.0/24",
             "user_agent": "Mozilla/5.0",
             # Extra field — Pydantic should ignore it silently
@@ -50,7 +50,7 @@ class TestBaseEventExtraFields:
         # Should not raise — extra fields are ignored
         event = AuthLoginEvent.model_validate(data)
         assert event.user_id == "user-123"
-        assert event.email_hash == "a" * 16
+        assert event.email_hash == "a" * 32
 
 
 class TestAuthLoginEventEmailHashNormalization:
@@ -64,9 +64,9 @@ class TestAuthLoginEventEmailHashNormalization:
             event_id=uuid.uuid4(),
             tenant_id=uuid.uuid4(),
             user_id="user-123",
-            email_hash="  abcdef1234567890  ",
+            email_hash="  abcdef1234567890abcdef1234567890  ",
         )
-        assert event.email_hash == "abcdef1234567890"
+        assert event.email_hash == "abcdef1234567890abcdef1234567890"
 
 
 class TestBaseEventTenantIdRequired:
@@ -98,7 +98,7 @@ class TestAuthLoginEventTimestampDefault:
             event_id=uuid.uuid4(),
             tenant_id=uuid.uuid4(),
             user_id="user-123",
-            email_hash="a" * 16,
+            email_hash="a" * 32,
         )
         after = datetime.now(timezone.utc)
 
@@ -117,7 +117,7 @@ class TestAuthLoginEventTypeDefault:
             event_id=uuid.uuid4(),
             tenant_id=uuid.uuid4(),
             user_id="user-123",
-            email_hash="a" * 16,
+            email_hash="a" * 32,
         )
         assert event.event_type == "auth.login"
 
@@ -130,7 +130,7 @@ class TestAuthLoginEventTypeDefault:
             event_type="auth.logout",  # override default
             tenant_id=uuid.uuid4(),
             user_id="user-123",
-            email_hash="a" * 16,
+            email_hash="a" * 32,
         )
         assert event.event_type == "auth.logout"
 
@@ -146,7 +146,7 @@ class TestAuthLoginEventIpPrefixOptional:
             event_id=uuid.uuid4(),
             tenant_id=uuid.uuid4(),
             user_id="user-123",
-            email_hash="a" * 16,
+            email_hash="a" * 32,
             ip_prefix=None,
         )
         assert event.ip_prefix is None

--- a/tests/unit/test_pii_helpers.py
+++ b/tests/unit/test_pii_helpers.py
@@ -9,11 +9,11 @@ from app.core.pii import hash_email, mask_ip
 class TestHashEmail:
     """Validate hash_email behaviour."""
 
-    def test_hash_email_returns_16_char_hex(self):
-        """hash_email MUST return a 16-character hexadecimal string."""
+    def test_hash_email_returns_32_char_hex(self):
+        """hash_email MUST return a 32-character hexadecimal string."""
         result = hash_email("user@example.com")
         assert result is not None
-        assert len(result) == 16
+        assert len(result) == 32
         assert int(result, 16) >= 0  # valid hex
 
     def test_hash_email_with_none_returns_none(self):


### PR DESCRIPTION
Closes #49\n\n## Summary\n- hash_email() ahora trunca a 32 chars (128 bits) en vez de 16 (64 bits)\n- Reduce significativamente riesgo de colisiones\n- Todos los tests actualizados