### PR TITLE
fix(tenants): paralelizar revocacion de tokens Redis con asyncio.gather

### DIFF
--- a/app/modules/tenants/service.py
+++ b/app/modules/tenants/service.py
@@ -4,6 +4,7 @@ import re
 import uuid
 import unicodedata
 from typing import Any
+import asyncio
 
 from redis.asyncio import Redis
 from sqlalchemy import select, func, update
@@ -186,15 +187,17 @@ async def update_tenant(
         await _revoke_all_user_tokens_for_tenant(tenant_id, db)
 
         # Revocar todos los access tokens de los usuarios del tenant (Redis denylist)
-        user_ids = await db.scalars(
+        user_ids = (await db.scalars(
             select(User.id).where(User.tenant_id == tenant_id)
-        )
-        for uid in user_ids:
-            await revoke_all_user_access_tokens(
+        )).all()
+        await asyncio.gather(*[
+            revoke_all_user_access_tokens(
                 user_id=str(uid),
                 redis=redis,
                 ttl_seconds=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60,
             )
+            for uid in user_ids
+        ])
 
     await db.refresh(tenant)
     return tenant
@@ -224,15 +227,17 @@ async def deactivate_tenant(
     await _revoke_all_user_tokens_for_tenant(tenant_id, db)
 
     # Revocar todos los access tokens de los usuarios del tenant (Redis denylist)
-    user_ids = await db.scalars(
+    user_ids = (await db.scalars(
         select(User.id).where(User.tenant_id == tenant_id)
-    )
-    for uid in user_ids:
-        await revoke_all_user_access_tokens(
+    )).all()
+    await asyncio.gather(*[
+        revoke_all_user_access_tokens(
             user_id=str(uid),
             redis=redis,
             ttl_seconds=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60,
         )
+        for uid in user_ids
+    ])
 
     await db.flush()
     await db.refresh(tenant)


### PR DESCRIPTION
Closes #63\n\n## Summary\n- Cambiar loop serial N+1 a asyncio.gather paralelo\n- Aplica en update_tenant y deactivate_tenant\n- `.all()` materializa la query antes de gather