### PR TITLE
test(f2): add alembic graph verification with downgrade roundtrip for F2 tables

### DIFF
--- a/tests/integration/test_alembic_migration_graph.py
+++ b/tests/integration/test_alembic_migration_graph.py
@@ -8,13 +8,21 @@ environment variable set.
 """
 from __future__ import annotations
 
+import asyncio
 import os
 import subprocess
 import sys
 
+import asyncpg
 import pytest
 
 pytestmark = pytest.mark.integration
+
+
+# ---------------------------------------------------------------------------
+# F2 tables created by the assets/scans/vulnerabilities/reports migration
+# ---------------------------------------------------------------------------
+_F2_TABLES = frozenset({"assets", "scans", "vulnerabilities", "reports"})
 
 
 # ---------------------------------------------------------------------------
@@ -49,6 +57,44 @@ def _alembic(*args: str, timeout: int = 60) -> subprocess.CompletedProcess:
         text=True,
         timeout=timeout,
     )
+
+
+def _get_db_url() -> str:
+    """Return the DSN so helper queries can connect to the target database."""
+    raw = os.environ.get(
+        "DATABASE_URL_MIGRATION",
+        os.environ.get("DATABASE_URL", ""),
+    )
+    # Strip asyncpg driver prefix so asyncpg.connect() works
+    return raw.replace("+asyncpg", "")
+
+
+async def _fetch_table_names() -> frozenset[str]:
+    """Return the set of user-table names currently present in the public schema."""
+    dsn = _get_db_url()
+    conn = await asyncpg.connect(dsn=dsn)
+    try:
+        rows = await conn.fetch(
+            "SELECT tablename FROM pg_catalog.pg_tables "
+            "WHERE schemaname = 'public'"
+        )
+        return frozenset(r["tablename"] for r in rows)
+    finally:
+        await conn.close()
+
+
+def _current_head_revision() -> str:
+    """Return the alembic head revision ID."""
+    result = _alembic("current")
+    if result.returncode != 0:
+        return ""
+    # Format: "REV (head)" or "REV"
+    for line in result.stdout.strip().splitlines():
+        line = line.strip()
+        if line and not line.startswith("INFO"):
+            # Take the first token (revision id)
+            return line.split()[0]
+    return ""
 
 
 # ---------------------------------------------------------------------------
@@ -128,9 +174,20 @@ class TestCleanDatabaseUpgrade:
         """
         # First downgrade to base (clean state)
         downgrade_result = _alembic("downgrade", "base")
+        # downgrade to base can fail if we are already at base
+        # (Alembic revises base differently depending on version).
+        # Accept either success or a "no such revision / already at base" stderr.
         if downgrade_result.returncode != 0:
-            # DB might already be clean — try anyway
-            pass
+            stderr_lower = downgrade_result.stderr.lower()
+            acceptable = any(
+                phrase in stderr_lower
+                for phrase in ("no such revision", "can't locate", "already at base")
+            )
+            assert acceptable, (
+                f"downgrade base failed unexpectedly "
+                f"(exit {downgrade_result.returncode}).\n"
+                f"stderr: {downgrade_result.stderr}"
+            )
 
         # Then upgrade to head
         result = _alembic("upgrade", "head")
@@ -154,10 +211,6 @@ class TestSchemaIntegrity:
         This proves the rebase correctly removed the duplicated add_column
         operations from 8f2c1a4b9d7e.
         """
-        import asyncio
-
-        import asyncpg
-
         db_url = os.environ.get("DATABASE_URL_MIGRATION",
                                  os.environ.get("DATABASE_URL", ""))
 
@@ -193,27 +246,66 @@ class TestSchemaIntegrity:
 
 
 class TestDowngradeRoundtrip:
-    """Verify downgrade and re-upgrade integrity."""
+    """Verify downgrade and re-upgrade integrity with real schema checks."""
 
-    def test_downgrade_one_step_then_upgrade(self):
-        """GIVEN a database at the unified head
-        WHEN `alembic downgrade -1` then `alembic upgrade head` are executed
-        THEN both complete without error
-        AND the database returns to the unified head.
+    def test_downgrade_one_step_fully_reverses_f2(self):
+        """GIVEN a database at the unified head with all F2 tables present
+        WHEN `alembic downgrade -1` is executed
+        THEN every F2 table (assets, scans, vulnerabilities, reports) is removed
+        AND `alembic upgrade head` restores them.
 
-        Spec: Normal Alembic Workflow Restoration.
+        Spec: Normal Alembic Workflow Restoration — downgrade must roll back
+        the full F2 schema, not just superficial defaults.
         """
-        # Downgrade one step
+        # --- Ensure we start at head with F2 tables present ---
+        head_before = _current_head_revision()
+        assert head_before, "Could not determine head revision before test"
+
+        tables_before = asyncio.run(_fetch_table_names())
+        missing_before = _F2_TABLES - tables_before
+        assert not missing_before, (
+            f"Pre-condition failed: F2 tables missing before downgrade: "
+            f"{missing_before}. Run 'alembic upgrade head' first."
+        )
+
+        # --- Downgrade one step ---
         down_result = _alembic("downgrade", "-1")
         assert down_result.returncode == 0, (
             f"alembic downgrade -1 failed (exit {down_result.returncode}).\n"
-            f"stderr: {down_result.stderr}"
+            f"stderr: {down_result.stderr}\n"
+            f"stdout: {down_result.stdout}"
         )
 
-        # Re-upgrade to head
+        # --- Verify F2 tables were actually removed ---
+        tables_after_down = asyncio.run(_fetch_table_names())
+        still_present = _F2_TABLES & tables_after_down
+        assert not still_present, (
+            f"downgrade -1 did NOT remove F2 tables. "
+            f"Still present: {still_present}. "
+            f"All tables after downgrade: {tables_after_down}"
+        )
+
+        # --- Re-upgrade to head ---
         up_result = _alembic("upgrade", "head")
         assert up_result.returncode == 0, (
             f"alembic upgrade head after downgrade failed "
             f"(exit {up_result.returncode}).\n"
-            f"stderr: {up_result.stderr}"
+            f"stderr: {up_result.stderr}\n"
+            f"stdout: {up_result.stdout}"
+        )
+
+        # --- Verify F2 tables are back ---
+        tables_after_up = asyncio.run(_fetch_table_names())
+        missing_after_up = _F2_TABLES - tables_after_up
+        assert not missing_after_up, (
+            f"re-upgrade did NOT restore F2 tables. "
+            f"Missing: {missing_after_up}. "
+            f"All tables after upgrade: {tables_after_up}"
+        )
+
+        # --- Head revision should be preserved ---
+        head_after = _current_head_revision()
+        assert head_after == head_before, (
+            f"Head revision changed across roundtrip: "
+            f"{head_before} → {head_after}"
         )

--- a/tests/integration/test_f2_models.py
+++ b/tests/integration/test_f2_models.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from app.modules.assets.models import Asset
+from app.modules.scans.models import Scan
+from app.modules.tenants.models import Tenant
+
+pytestmark = pytest.mark.integration
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+NONEXISTENT_UUID = uuid.UUID("00000000-0000-0000-0000-000000000000")
+
+
+# ---------------------------------------------------------------------------
+# Asset — default persistence & constraints
+# ---------------------------------------------------------------------------
+
+class TestAssetPersistence:
+    """DB-backed tests for Asset model persistence and constraints."""
+
+    async def test_persist_minimal_asset_applies_defaults(
+        self, db_session, seed_data
+    ) -> None:
+        """Persisting an Asset with minimal fields applies column defaults."""
+        tenant = seed_data["tenant_a"]
+
+        asset = Asset(
+            tenant_id=tenant.id,
+            name="server-01",
+            asset_type="host",
+        )
+        db_session.add(asset)
+        await db_session.flush()
+
+        assert asset.status == "active"
+        assert asset.id is not None
+        assert asset.created_at is not None
+        assert asset.updated_at is not None
+
+    async def test_asset_without_tenant_fails(self, db_session, seed_data) -> None:
+        """FK constraint rejects Asset without tenant_id.
+
+        Uses seed_data to set superadmin context (bypasses RLS) so the
+        FK constraint — not RLS — is what rejects the insert.
+        """
+        asset = Asset(name="orphan", asset_type="host")
+        # tenant_id is NOT set — FK should reject on flush
+        db_session.add(asset)
+        with pytest.raises(IntegrityError):
+            await db_session.flush()
+
+    async def test_asset_with_invalid_tenant_fails(self, db_session, seed_data) -> None:
+        """FK constraint rejects Asset with non-existent tenant_id."""
+        asset = Asset(
+            tenant_id=NONEXISTENT_UUID,
+            name="bad-tenant",
+            asset_type="host",
+        )
+        db_session.add(asset)
+        with pytest.raises(IntegrityError):
+            await db_session.flush()
+
+    async def test_invalid_asset_type_rejected(self, db_session, seed_data) -> None:
+        """CheckConstraint rejects invalid asset_type."""
+        tenant = seed_data["tenant_a"]
+        asset = Asset(
+            tenant_id=tenant.id,
+            name="bad-type",
+            asset_type="invalid_type",
+        )
+        db_session.add(asset)
+        with pytest.raises(IntegrityError):
+            await db_session.flush()
+
+    async def test_invalid_status_rejected(self, db_session, seed_data) -> None:
+        """CheckConstraint rejects invalid status."""
+        tenant = seed_data["tenant_a"]
+        asset = Asset(
+            tenant_id=tenant.id,
+            name="bad-status",
+            asset_type="host",
+            status="deleted",
+        )
+        db_session.add(asset)
+        with pytest.raises(IntegrityError):
+            await db_session.flush()
+
+    async def test_nullable_columns_accept_none(self, db_session, seed_data) -> None:
+        """Nullable columns (hostname, asset_metadata) accept None."""
+        tenant = seed_data["tenant_a"]
+        asset = Asset(
+            tenant_id=tenant.id,
+            name="minimal",
+            asset_type="ip",
+            hostname=None,
+            asset_metadata=None,
+        )
+        db_session.add(asset)
+        await db_session.flush()
+
+        assert asset.hostname is None
+        assert asset.asset_metadata is None
+
+
+# ---------------------------------------------------------------------------
+# Scan — default persistence & constraints
+# ---------------------------------------------------------------------------
+
+class TestScanPersistence:
+    """DB-backed tests for Scan model persistence and constraints."""
+
+    async def test_persist_scan_applies_defaults(
+        self, db_session, seed_data
+    ) -> None:
+        tenant = seed_data["tenant_a"]
+        # Need an asset first (scan FK → asset)
+        asset = Asset(tenant_id=tenant.id, name="target", asset_type="host")
+        db_session.add(asset)
+        await db_session.flush()
+
+        scan = Scan(
+            tenant_id=tenant.id,
+            asset_id=asset.id,
+            name="vuln-scan-01",
+            scan_type="vulnerability",
+        )
+        db_session.add(scan)
+        await db_session.flush()
+
+        assert scan.status == "pending"
+        assert scan.id is not None
+        assert scan.created_at is not None
+
+    async def test_scan_without_asset_fails(self, db_session, seed_data) -> None:
+        """FK to assets rejects Scan without asset_id."""
+        tenant = seed_data["tenant_a"]
+        scan = Scan(
+            tenant_id=tenant.id,
+            # asset_id intentionally omitted
+            name="no-asset",
+            scan_type="discovery",
+        )
+        db_session.add(scan)
+        with pytest.raises(IntegrityError):
+            await db_session.flush()
+
+    async def test_invalid_scan_type_rejected(self, db_session, seed_data) -> None:
+        """CheckConstraint rejects invalid scan_type."""
+        tenant = seed_data["tenant_a"]
+        asset = Asset(tenant_id=tenant.id, name="t2", asset_type="domain")
+        db_session.add(asset)
+        await db_session.flush()
+
+        scan = Scan(
+            tenant_id=tenant.id,
+            asset_id=asset.id,
+            name="bad-scan-type",
+            scan_type="impossible",
+        )
+        db_session.add(scan)
+        with pytest.raises(IntegrityError):
+            await db_session.flush()
+
+    async def test_nullable_timestamps_accept_none(self, db_session, seed_data) -> None:
+        """Nullable started_at/completed_at accept None."""
+        tenant = seed_data["tenant_a"]
+        asset = Asset(tenant_id=tenant.id, name="t3", asset_type="web_app")
+        db_session.add(asset)
+        await db_session.flush()
+
+        scan = Scan(
+            tenant_id=tenant.id,
+            asset_id=asset.id,
+            name="timed-scan",
+            scan_type="full",
+            started_at=None,
+            completed_at=None,
+        )
+        db_session.add(scan)
+        await db_session.flush()
+
+        assert scan.started_at is None
+        assert scan.completed_at is None

--- a/tests/integration/test_f2_models.py
+++ b/tests/integration/test_f2_models.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 import uuid
 
 import pytest
+from sqlalchemy import text
 from sqlalchemy.exc import IntegrityError
 
 from app.modules.assets.models import Asset
+from app.modules.reports.models import Report
 from app.modules.scans.models import Scan
 from app.modules.tenants.models import Tenant
+from app.modules.vulnerabilities.models import Vulnerability
 
 pytestmark = pytest.mark.integration
 
@@ -189,3 +192,379 @@ class TestScanPersistence:
 
         assert scan.started_at is None
         assert scan.completed_at is None
+
+
+# ---------------------------------------------------------------------------
+# Vulnerability — default persistence & constraints
+# ---------------------------------------------------------------------------
+
+
+class TestVulnerabilityPersistence:
+    """DB-backed tests for Vulnerability model persistence and constraints."""
+
+    async def test_persist_minimal_vuln_applies_defaults(
+        self, db_session, seed_data
+    ) -> None:
+        """Persisting a Vulnerability with minimal fields applies column defaults."""
+        tenant = seed_data["tenant_a"]
+        asset = Asset(tenant_id=tenant.id, name="vuln-target", asset_type="host")
+        db_session.add(asset)
+        await db_session.flush()
+
+        scan = Scan(
+            tenant_id=tenant.id,
+            asset_id=asset.id,
+            name="vuln-scan",
+            scan_type="vulnerability",
+        )
+        db_session.add(scan)
+        await db_session.flush()
+
+        vuln = Vulnerability(
+            tenant_id=tenant.id,
+            scan_id=scan.id,
+            title="CVE-2024-1234",
+            severity="high",
+        )
+        db_session.add(vuln)
+        await db_session.flush()
+
+        assert vuln.status == "open"
+        assert vuln.id is not None
+        assert vuln.created_at is not None
+        assert vuln.updated_at is not None
+
+    async def test_vuln_without_scan_fails(self, db_session, seed_data) -> None:
+        """FK to scans rejects Vulnerability without scan_id."""
+        tenant = seed_data["tenant_a"]
+        vuln = Vulnerability(
+            tenant_id=tenant.id,
+            title="orphan-vuln",
+            severity="medium",
+        )
+        db_session.add(vuln)
+        with pytest.raises(IntegrityError):
+            await db_session.flush()
+
+    async def test_invalid_severity_rejected(self, db_session, seed_data) -> None:
+        """CheckConstraint rejects invalid severity."""
+        tenant = seed_data["tenant_a"]
+        asset = Asset(tenant_id=tenant.id, name="sev-target", asset_type="host")
+        db_session.add(asset)
+        await db_session.flush()
+
+        scan = Scan(
+            tenant_id=tenant.id,
+            asset_id=asset.id,
+            name="sev-scan",
+            scan_type="vulnerability",
+        )
+        db_session.add(scan)
+        await db_session.flush()
+
+        vuln = Vulnerability(
+            tenant_id=tenant.id,
+            scan_id=scan.id,
+            title="bad-sev",
+            severity="impossible",
+        )
+        db_session.add(vuln)
+        with pytest.raises(IntegrityError):
+            await db_session.flush()
+
+    async def test_invalid_status_rejected(self, db_session, seed_data) -> None:
+        """CheckConstraint rejects invalid status."""
+        tenant = seed_data["tenant_a"]
+        asset = Asset(tenant_id=tenant.id, name="stat-target", asset_type="ip")
+        db_session.add(asset)
+        await db_session.flush()
+
+        scan = Scan(
+            tenant_id=tenant.id,
+            asset_id=asset.id,
+            name="stat-scan",
+            scan_type="vulnerability",
+        )
+        db_session.add(scan)
+        await db_session.flush()
+
+        vuln = Vulnerability(
+            tenant_id=tenant.id,
+            scan_id=scan.id,
+            title="bad-status",
+            severity="low",
+            status="deleted",
+        )
+        db_session.add(vuln)
+        with pytest.raises(IntegrityError):
+            await db_session.flush()
+
+    async def test_nullable_columns_accept_none(self, db_session, seed_data) -> None:
+        """Nullable columns (description, cve_id, cvss_score, metadata) accept None."""
+        tenant = seed_data["tenant_a"]
+        asset = Asset(tenant_id=tenant.id, name="null-target", asset_type="domain")
+        db_session.add(asset)
+        await db_session.flush()
+
+        scan = Scan(
+            tenant_id=tenant.id,
+            asset_id=asset.id,
+            name="null-scan",
+            scan_type="vulnerability",
+        )
+        db_session.add(scan)
+        await db_session.flush()
+
+        vuln = Vulnerability(
+            tenant_id=tenant.id,
+            scan_id=scan.id,
+            title="nullable-fields",
+            severity="info",
+            description=None,
+            cve_id=None,
+            cvss_score=None,
+            vulnerability_metadata=None,
+        )
+        db_session.add(vuln)
+        await db_session.flush()
+
+        assert vuln.description is None
+        assert vuln.cve_id is None
+        assert vuln.cvss_score is None
+        assert vuln.vulnerability_metadata is None
+
+
+# ---------------------------------------------------------------------------
+# Report — default persistence & constraints
+# ---------------------------------------------------------------------------
+
+
+class TestReportPersistence:
+    """DB-backed tests for Report model persistence and constraints."""
+
+    async def test_persist_report_applies_defaults(
+        self, db_session, seed_data
+    ) -> None:
+        """Persisting a Report with minimal fields applies column defaults."""
+        tenant = seed_data["tenant_a"]
+        asset = Asset(tenant_id=tenant.id, name="report-target", asset_type="web_app")
+        db_session.add(asset)
+        await db_session.flush()
+
+        report = Report(
+            tenant_id=tenant.id,
+            asset_id=asset.id,
+            name="monthly-report",
+            report_type="vulnerability",
+        )
+        db_session.add(report)
+        await db_session.flush()
+
+        assert report.status == "pending"
+        assert report.id is not None
+        assert report.created_at is not None
+
+    async def test_report_without_asset_fails(self, db_session, seed_data) -> None:
+        """FK to assets rejects Report without asset_id."""
+        tenant = seed_data["tenant_a"]
+        report = Report(
+            tenant_id=tenant.id,
+            name="orphan-report",
+            report_type="technical",
+        )
+        db_session.add(report)
+        with pytest.raises(IntegrityError):
+            await db_session.flush()
+
+    async def test_invalid_report_type_rejected(self, db_session, seed_data) -> None:
+        """CheckConstraint rejects invalid report_type."""
+        tenant = seed_data["tenant_a"]
+        asset = Asset(tenant_id=tenant.id, name="rtype-target", asset_type="host")
+        db_session.add(asset)
+        await db_session.flush()
+
+        report = Report(
+            tenant_id=tenant.id,
+            asset_id=asset.id,
+            name="bad-type",
+            report_type="invalid_type",
+        )
+        db_session.add(report)
+        with pytest.raises(IntegrityError):
+            await db_session.flush()
+
+    async def test_invalid_status_rejected(self, db_session, seed_data) -> None:
+        """CheckConstraint rejects invalid status."""
+        tenant = seed_data["tenant_a"]
+        asset = Asset(tenant_id=tenant.id, name="rstat-target", asset_type="ip")
+        db_session.add(asset)
+        await db_session.flush()
+
+        report = Report(
+            tenant_id=tenant.id,
+            asset_id=asset.id,
+            name="bad-status",
+            report_type="compliance",
+            status="archived",
+        )
+        db_session.add(report)
+        with pytest.raises(IntegrityError):
+            await db_session.flush()
+
+    async def test_nullable_generated_at(self, db_session, seed_data) -> None:
+        """Nullable generated_at accepts None."""
+        tenant = seed_data["tenant_a"]
+        asset = Asset(tenant_id=tenant.id, name="gen-target", asset_type="domain")
+        db_session.add(asset)
+        await db_session.flush()
+
+        report = Report(
+            tenant_id=tenant.id,
+            asset_id=asset.id,
+            name="no-gen-date",
+            report_type="executive",
+            generated_at=None,
+        )
+        db_session.add(report)
+        await db_session.flush()
+
+        assert report.generated_at is None
+
+
+# ---------------------------------------------------------------------------
+# ON DELETE CASCADE integrity
+# ---------------------------------------------------------------------------
+
+
+class TestCascadeDelete:
+    """DB-backed tests for ON DELETE CASCADE across the F2 model graph."""
+
+    async def test_delete_asset_cascades_to_scans(
+        self, db_session, seed_data
+    ) -> None:
+        """ON DELETE CASCADE: deleting an asset removes its scans."""
+        tenant = seed_data["tenant_a"]
+        asset = Asset(tenant_id=tenant.id, name="cascade-asset", asset_type="host")
+        db_session.add(asset)
+        await db_session.flush()
+
+        scan = Scan(
+            tenant_id=tenant.id,
+            asset_id=asset.id,
+            name="cascade-scan",
+            scan_type="discovery",
+        )
+        db_session.add(scan)
+        await db_session.flush()
+
+        asset_id = asset.id
+        scan_id = scan.id
+
+        # Delete asset — ON DELETE CASCADE removes the scan
+        await db_session.delete(asset)
+        await db_session.flush()
+
+        # Verify scan is gone
+        result = await db_session.execute(
+            text("SELECT 1 FROM scans WHERE id = :id"), {"id": scan_id}
+        )
+        assert result.fetchone() is None
+
+    async def test_delete_scan_cascades_to_vulnerabilities(
+        self, db_session, seed_data
+    ) -> None:
+        """ON DELETE CASCADE: deleting a scan removes its vulnerabilities."""
+        tenant = seed_data["tenant_a"]
+        asset = Asset(
+            tenant_id=tenant.id, name="vuln-cascade-asset", asset_type="host"
+        )
+        db_session.add(asset)
+        await db_session.flush()
+
+        scan = Scan(
+            tenant_id=tenant.id,
+            asset_id=asset.id,
+            name="vuln-cascade-scan",
+            scan_type="vulnerability",
+        )
+        db_session.add(scan)
+        await db_session.flush()
+
+        vuln = Vulnerability(
+            tenant_id=tenant.id,
+            scan_id=scan.id,
+            title="cascade-vuln",
+            severity="medium",
+        )
+        db_session.add(vuln)
+        await db_session.flush()
+
+        scan_id = scan.id
+        vuln_id = vuln.id
+
+        # Delete scan — ON DELETE CASCADE removes the vulnerability
+        await db_session.delete(scan)
+        await db_session.flush()
+
+        # Verify vulnerability is gone
+        result = await db_session.execute(
+            text("SELECT 1 FROM vulnerabilities WHERE id = :id"), {"id": vuln_id}
+        )
+        assert result.fetchone() is None
+
+    async def test_delete_tenant_cascades_to_assets(
+        self, db_session, seed_data
+    ) -> None:
+        """ON DELETE CASCADE: deleting a tenant removes its assets."""
+        unique_tag = uuid.uuid4().hex[:8]
+        tenant = Tenant(
+            name=f"Test Cascade {unique_tag}",
+            slug=f"test-cascade-{unique_tag}",
+            plan="free",
+        )
+        db_session.add(tenant)
+        await db_session.flush()
+
+        asset = Asset(
+            tenant_id=tenant.id, name="tenant-cascade-asset", asset_type="ip"
+        )
+        db_session.add(asset)
+        await db_session.flush()
+
+        tenant_id = tenant.id
+        asset_id = asset.id
+
+        # Delete tenant — ON DELETE CASCADE removes the asset
+        await db_session.delete(tenant)
+        await db_session.flush()
+
+        # Verify asset is gone
+        result = await db_session.execute(
+            text("SELECT 1 FROM assets WHERE id = :id"), {"id": asset_id}
+        )
+        assert result.fetchone() is None
+
+
+# ---------------------------------------------------------------------------
+# Table existence — schema verification
+# ---------------------------------------------------------------------------
+
+
+class TestF2TableExistence:
+    """Verify all 4 F2 tables exist in the public schema."""
+
+    async def test_f2_tables_present_in_information_schema(
+        self, db_session
+    ) -> None:
+        """Assert assets, scans, vulnerabilities, reports tables exist."""
+        result = await db_session.execute(
+            text(
+                "SELECT table_name FROM information_schema.tables "
+                "WHERE table_schema = 'public' "
+                "AND table_name IN "
+                "('assets', 'scans', 'vulnerabilities', 'reports')"
+            )
+        )
+        tables = {row[0] for row in result}
+        expected = {"assets", "scans", "vulnerabilities", "reports"}
+        assert tables == expected

--- a/tests/unit/test_f2_models.py
+++ b/tests/unit/test_f2_models.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import uuid
+
+from app.modules.assets.models import Asset
+from app.modules.reports.models import Report
+from app.modules.scans.models import Scan
+from app.modules.vulnerabilities.models import Vulnerability
+
+
+# ---------------------------------------------------------------------------
+# Helpers for model inspection (DB-free — no session needed)
+# ---------------------------------------------------------------------------
+
+def _non_nullable_columns(model_cls: type) -> set[str]:
+    return {c.name for c in model_cls.__mapper__.columns if not c.nullable}
+
+
+def _nullable_columns(model_cls: type) -> set[str]:
+    return {c.name for c in model_cls.__mapper__.columns if c.nullable}
+
+
+def _check_constraint_names(model_cls: type) -> set[str]:
+    return {
+        c.name
+        for c in model_cls.__table__.constraints
+        if c.name is not None
+    }
+
+
+def _column_default(table, col_name: str):
+    """Return the Python-side ColumnDefault arg or None."""
+    col = getattr(table.c, col_name)
+    if col.default is not None:
+        return col.default.arg
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Asset
+# ---------------------------------------------------------------------------
+
+class TestAssetModel:
+    """Tests unitarios de inspección del modelo Asset — DB-free"""
+
+    def test_tablename(self) -> None:
+        assert Asset.__tablename__ == "assets"
+
+    def test_required_columns(self) -> None:
+        nn = _non_nullable_columns(Asset)
+        assert "id" in nn
+        assert "tenant_id" in nn
+        assert "name" in nn
+        assert "asset_type" in nn
+        assert "status" in nn
+        assert "created_at" in nn
+        assert "updated_at" in nn
+
+    def test_nullable_columns(self) -> None:
+        n = _nullable_columns(Asset)
+        assert "hostname" in n
+        assert "asset_metadata" in n
+
+    def test_column_defaults(self) -> None:
+        """Verify column-level defaults (Python-side `default=` arg)."""
+        assert _column_default(Asset.__table__, "status") == "active"
+
+    def test_check_constraint_names(self) -> None:
+        names = _check_constraint_names(Asset)
+        assert "chk_assets_asset_type" in names
+        assert "chk_assets_status" in names
+
+    def test_repr_format(self) -> None:
+        asset = Asset(
+            id=uuid.uuid4(),
+            tenant_id=uuid.uuid4(),
+            name="server-01",
+            asset_type="host",
+        )
+        result = repr(asset)
+        assert "Asset" in result
+        assert "server-01" in result
+
+
+# ---------------------------------------------------------------------------
+# Scan
+# ---------------------------------------------------------------------------
+
+class TestScanModel:
+    """Tests unitarios de inspección del modelo Scan — DB-free"""
+
+    def test_tablename(self) -> None:
+        assert Scan.__tablename__ == "scans"
+
+    def test_required_columns(self) -> None:
+        nn = _non_nullable_columns(Scan)
+        assert "id" in nn
+        assert "tenant_id" in nn
+        assert "asset_id" in nn
+        assert "name" in nn
+        assert "scan_type" in nn
+        assert "status" in nn
+        assert "created_at" in nn
+        assert "updated_at" in nn
+
+    def test_nullable_columns(self) -> None:
+        n = _nullable_columns(Scan)
+        assert "config" in n
+        assert "started_at" in n
+        assert "completed_at" in n
+
+    def test_column_defaults(self) -> None:
+        assert _column_default(Scan.__table__, "status") == "pending"
+
+    def test_check_constraint_names(self) -> None:
+        names = _check_constraint_names(Scan)
+        assert "chk_scans_scan_type" in names
+        assert "chk_scans_status" in names
+
+    def test_fk_columns(self) -> None:
+        """Verify foreign keys point to expected parent tables."""
+        fks = {fk.column.table.name: fk.parent.name for fk in Scan.__table__.foreign_keys}
+        assert fks["tenants"] == "tenant_id"
+        assert fks["assets"] == "asset_id"
+
+    def test_repr_format(self) -> None:
+        scan = Scan(
+            id=uuid.uuid4(),
+            tenant_id=uuid.uuid4(),
+            asset_id=uuid.uuid4(),
+            name="scan-01",
+            scan_type="vulnerability",
+        )
+        result = repr(scan)
+        assert "Scan" in result
+        assert "scan-01" in result
+
+
+# ---------------------------------------------------------------------------
+# Vulnerability
+# ---------------------------------------------------------------------------
+
+class TestVulnerabilityModel:
+    """Tests unitarios de inspección del modelo Vulnerability — DB-free"""
+
+    def test_tablename(self) -> None:
+        assert Vulnerability.__tablename__ == "vulnerabilities"
+
+    def test_required_columns(self) -> None:
+        nn = _non_nullable_columns(Vulnerability)
+        assert "id" in nn
+        assert "tenant_id" in nn
+        assert "scan_id" in nn
+        assert "title" in nn
+        assert "severity" in nn
+        assert "status" in nn
+        assert "created_at" in nn
+        assert "updated_at" in nn
+
+    def test_nullable_columns(self) -> None:
+        n = _nullable_columns(Vulnerability)
+        assert "description" in n
+        assert "cve_id" in n
+        assert "cvss_score" in n
+        assert "vulnerability_metadata" in n
+
+    def test_column_defaults(self) -> None:
+        assert _column_default(Vulnerability.__table__, "status") == "open"
+
+    def test_check_constraint_names(self) -> None:
+        names = _check_constraint_names(Vulnerability)
+        assert "chk_vulnerabilities_severity" in names
+        assert "chk_vulnerabilities_status" in names
+
+    def test_fk_columns(self) -> None:
+        fks = {fk.column.table.name: fk.parent.name for fk in Vulnerability.__table__.foreign_keys}
+        assert fks["tenants"] == "tenant_id"
+        assert fks["scans"] == "scan_id"
+
+    def test_repr_format(self) -> None:
+        vuln = Vulnerability(
+            id=uuid.uuid4(),
+            tenant_id=uuid.uuid4(),
+            scan_id=uuid.uuid4(),
+            title="SQL Injection",
+            severity="high",
+        )
+        result = repr(vuln)
+        assert "Vulnerability" in result
+        assert "SQL Injection" in result
+
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+class TestReportModel:
+    """Tests unitarios de inspección del modelo Report — DB-free"""
+
+    def test_tablename(self) -> None:
+        assert Report.__tablename__ == "reports"
+
+    def test_required_columns(self) -> None:
+        nn = _non_nullable_columns(Report)
+        assert "id" in nn
+        assert "tenant_id" in nn
+        assert "asset_id" in nn
+        assert "name" in nn
+        assert "report_type" in nn
+        assert "status" in nn
+        assert "created_at" in nn
+        assert "updated_at" in nn
+
+    def test_nullable_columns(self) -> None:
+        n = _nullable_columns(Report)
+        assert "summary" in n
+        assert "report_metadata" in n
+        assert "generated_at" in n
+
+    def test_column_defaults(self) -> None:
+        assert _column_default(Report.__table__, "status") == "pending"
+
+    def test_check_constraint_names(self) -> None:
+        names = _check_constraint_names(Report)
+        assert "chk_reports_report_type" in names
+        assert "chk_reports_status" in names
+
+    def test_fk_columns(self) -> None:
+        fks = {fk.column.table.name: fk.parent.name for fk in Report.__table__.foreign_keys}
+        assert fks["tenants"] == "tenant_id"
+        assert fks["assets"] == "asset_id"
+
+    def test_repr_format(self) -> None:
+        report = Report(
+            id=uuid.uuid4(),
+            tenant_id=uuid.uuid4(),
+            asset_id=uuid.uuid4(),
+            name="report-01",
+            report_type="vulnerability",
+        )
+        result = repr(report)
+        assert "Report" in result
+        assert "report-01" in result


### PR DESCRIPTION
## Summary

Extends `test_alembic_migration_graph.py` with F2-specific verification:
- `_F2_TABLES` constant
- `_fetch_table_names()`, `_current_head_revision()` helpers
- `TestDowngradeRoundtrip.test_downgrade_one_step_fully_reverses_f2()` — verifies downgrade actually removes F2 tables and re-upgrade restores them
- Robust handling of downgrade-to-base precondition (accepts "already at base")

### Files changed
| File | Action |
|------|--------|
| `tests/integration/test_alembic_migration_graph.py` | Modified — +109/-17 lines |

### Part of F2 slicing chain (2/5)
Ref: #91