### PR TITLE
test(f2): add DB-free unit tests for Asset, Scan, Vulnerability, Report models

### DIFF
--- a/tests/integration/test_f2_models.py
+++ b/tests/integration/test_f2_models.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from app.modules.assets.models import Asset
+from app.modules.scans.models import Scan
+from app.modules.tenants.models import Tenant
+
+pytestmark = pytest.mark.integration
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+NONEXISTENT_UUID = uuid.UUID("00000000-0000-0000-0000-000000000000")
+
+
+# ---------------------------------------------------------------------------
+# Asset — default persistence & constraints
+# ---------------------------------------------------------------------------
+
+class TestAssetPersistence:
+    """DB-backed tests for Asset model persistence and constraints."""
+
+    async def test_persist_minimal_asset_applies_defaults(
+        self, db_session, seed_data
+    ) -> None:
+        """Persisting an Asset with minimal fields applies column defaults."""
+        tenant = seed_data["tenant_a"]
+
+        asset = Asset(
+            tenant_id=tenant.id,
+            name="server-01",
+            asset_type="host",
+        )
+        db_session.add(asset)
+        await db_session.flush()
+
+        assert asset.status == "active"
+        assert asset.id is not None
+        assert asset.created_at is not None
+        assert asset.updated_at is not None
+
+    async def test_asset_without_tenant_fails(self, db_session, seed_data) -> None:
+        """FK constraint rejects Asset without tenant_id.
+
+        Uses seed_data to set superadmin context (bypasses RLS) so the
+        FK constraint — not RLS — is what rejects the insert.
+        """
+        asset = Asset(name="orphan", asset_type="host")
+        # tenant_id is NOT set — FK should reject on flush
+        db_session.add(asset)
+        with pytest.raises(IntegrityError):
+            await db_session.flush()
+
+    async def test_asset_with_invalid_tenant_fails(self, db_session, seed_data) -> None:
+        """FK constraint rejects Asset with non-existent tenant_id."""
+        asset = Asset(
+            tenant_id=NONEXISTENT_UUID,
+            name="bad-tenant",
+            asset_type="host",
+        )
+        db_session.add(asset)
+        with pytest.raises(IntegrityError):
+            await db_session.flush()
+
+    async def test_invalid_asset_type_rejected(self, db_session, seed_data) -> None:
+        """CheckConstraint rejects invalid asset_type."""
+        tenant = seed_data["tenant_a"]
+        asset = Asset(
+            tenant_id=tenant.id,
+            name="bad-type",
+            asset_type="invalid_type",
+        )
+        db_session.add(asset)
+        with pytest.raises(IntegrityError):
+            await db_session.flush()
+
+    async def test_invalid_status_rejected(self, db_session, seed_data) -> None:
+        """CheckConstraint rejects invalid status."""
+        tenant = seed_data["tenant_a"]
+        asset = Asset(
+            tenant_id=tenant.id,
+            name="bad-status",
+            asset_type="host",
+            status="deleted",
+        )
+        db_session.add(asset)
+        with pytest.raises(IntegrityError):
+            await db_session.flush()
+
+    async def test_nullable_columns_accept_none(self, db_session, seed_data) -> None:
+        """Nullable columns (hostname, asset_metadata) accept None."""
+        tenant = seed_data["tenant_a"]
+        asset = Asset(
+            tenant_id=tenant.id,
+            name="minimal",
+            asset_type="ip",
+            hostname=None,
+            asset_metadata=None,
+        )
+        db_session.add(asset)
+        await db_session.flush()
+
+        assert asset.hostname is None
+        assert asset.asset_metadata is None
+
+
+# ---------------------------------------------------------------------------
+# Scan — default persistence & constraints
+# ---------------------------------------------------------------------------
+
+class TestScanPersistence:
+    """DB-backed tests for Scan model persistence and constraints."""
+
+    async def test_persist_scan_applies_defaults(
+        self, db_session, seed_data
+    ) -> None:
+        tenant = seed_data["tenant_a"]
+        # Need an asset first (scan FK → asset)
+        asset = Asset(tenant_id=tenant.id, name="target", asset_type="host")
+        db_session.add(asset)
+        await db_session.flush()
+
+        scan = Scan(
+            tenant_id=tenant.id,
+            asset_id=asset.id,
+            name="vuln-scan-01",
+            scan_type="vulnerability",
+        )
+        db_session.add(scan)
+        await db_session.flush()
+
+        assert scan.status == "pending"
+        assert scan.id is not None
+        assert scan.created_at is not None
+
+    async def test_scan_without_asset_fails(self, db_session, seed_data) -> None:
+        """FK to assets rejects Scan without asset_id."""
+        tenant = seed_data["tenant_a"]
+        scan = Scan(
+            tenant_id=tenant.id,
+            # asset_id intentionally omitted
+            name="no-asset",
+            scan_type="discovery",
+        )
+        db_session.add(scan)
+        with pytest.raises(IntegrityError):
+            await db_session.flush()
+
+    async def test_invalid_scan_type_rejected(self, db_session, seed_data) -> None:
+        """CheckConstraint rejects invalid scan_type."""
+        tenant = seed_data["tenant_a"]
+        asset = Asset(tenant_id=tenant.id, name="t2", asset_type="domain")
+        db_session.add(asset)
+        await db_session.flush()
+
+        scan = Scan(
+            tenant_id=tenant.id,
+            asset_id=asset.id,
+            name="bad-scan-type",
+            scan_type="impossible",
+        )
+        db_session.add(scan)
+        with pytest.raises(IntegrityError):
+            await db_session.flush()
+
+    async def test_nullable_timestamps_accept_none(self, db_session, seed_data) -> None:
+        """Nullable started_at/completed_at accept None."""
+        tenant = seed_data["tenant_a"]
+        asset = Asset(tenant_id=tenant.id, name="t3", asset_type="web_app")
+        db_session.add(asset)
+        await db_session.flush()
+
+        scan = Scan(
+            tenant_id=tenant.id,
+            asset_id=asset.id,
+            name="timed-scan",
+            scan_type="full",
+            started_at=None,
+            completed_at=None,
+        )
+        db_session.add(scan)
+        await db_session.flush()
+
+        assert scan.started_at is None
+        assert scan.completed_at is None

--- a/tests/integration/test_f2_models.py
+++ b/tests/integration/test_f2_models.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 import uuid
 
 import pytest
+from sqlalchemy import text
 from sqlalchemy.exc import IntegrityError
 
 from app.modules.assets.models import Asset
+from app.modules.reports.models import Report
 from app.modules.scans.models import Scan
 from app.modules.tenants.models import Tenant
+from app.modules.vulnerabilities.models import Vulnerability
 
 pytestmark = pytest.mark.integration
 
@@ -189,3 +192,379 @@ class TestScanPersistence:
 
         assert scan.started_at is None
         assert scan.completed_at is None
+
+
+# ---------------------------------------------------------------------------
+# Vulnerability — default persistence & constraints
+# ---------------------------------------------------------------------------
+
+
+class TestVulnerabilityPersistence:
+    """DB-backed tests for Vulnerability model persistence and constraints."""
+
+    async def test_persist_minimal_vuln_applies_defaults(
+        self, db_session, seed_data
+    ) -> None:
+        """Persisting a Vulnerability with minimal fields applies column defaults."""
+        tenant = seed_data["tenant_a"]
+        asset = Asset(tenant_id=tenant.id, name="vuln-target", asset_type="host")
+        db_session.add(asset)
+        await db_session.flush()
+
+        scan = Scan(
+            tenant_id=tenant.id,
+            asset_id=asset.id,
+            name="vuln-scan",
+            scan_type="vulnerability",
+        )
+        db_session.add(scan)
+        await db_session.flush()
+
+        vuln = Vulnerability(
+            tenant_id=tenant.id,
+            scan_id=scan.id,
+            title="CVE-2024-1234",
+            severity="high",
+        )
+        db_session.add(vuln)
+        await db_session.flush()
+
+        assert vuln.status == "open"
+        assert vuln.id is not None
+        assert vuln.created_at is not None
+        assert vuln.updated_at is not None
+
+    async def test_vuln_without_scan_fails(self, db_session, seed_data) -> None:
+        """FK to scans rejects Vulnerability without scan_id."""
+        tenant = seed_data["tenant_a"]
+        vuln = Vulnerability(
+            tenant_id=tenant.id,
+            title="orphan-vuln",
+            severity="medium",
+        )
+        db_session.add(vuln)
+        with pytest.raises(IntegrityError):
+            await db_session.flush()
+
+    async def test_invalid_severity_rejected(self, db_session, seed_data) -> None:
+        """CheckConstraint rejects invalid severity."""
+        tenant = seed_data["tenant_a"]
+        asset = Asset(tenant_id=tenant.id, name="sev-target", asset_type="host")
+        db_session.add(asset)
+        await db_session.flush()
+
+        scan = Scan(
+            tenant_id=tenant.id,
+            asset_id=asset.id,
+            name="sev-scan",
+            scan_type="vulnerability",
+        )
+        db_session.add(scan)
+        await db_session.flush()
+
+        vuln = Vulnerability(
+            tenant_id=tenant.id,
+            scan_id=scan.id,
+            title="bad-sev",
+            severity="impossible",
+        )
+        db_session.add(vuln)
+        with pytest.raises(IntegrityError):
+            await db_session.flush()
+
+    async def test_invalid_status_rejected(self, db_session, seed_data) -> None:
+        """CheckConstraint rejects invalid status."""
+        tenant = seed_data["tenant_a"]
+        asset = Asset(tenant_id=tenant.id, name="stat-target", asset_type="ip")
+        db_session.add(asset)
+        await db_session.flush()
+
+        scan = Scan(
+            tenant_id=tenant.id,
+            asset_id=asset.id,
+            name="stat-scan",
+            scan_type="vulnerability",
+        )
+        db_session.add(scan)
+        await db_session.flush()
+
+        vuln = Vulnerability(
+            tenant_id=tenant.id,
+            scan_id=scan.id,
+            title="bad-status",
+            severity="low",
+            status="deleted",
+        )
+        db_session.add(vuln)
+        with pytest.raises(IntegrityError):
+            await db_session.flush()
+
+    async def test_nullable_columns_accept_none(self, db_session, seed_data) -> None:
+        """Nullable columns (description, cve_id, cvss_score, metadata) accept None."""
+        tenant = seed_data["tenant_a"]
+        asset = Asset(tenant_id=tenant.id, name="null-target", asset_type="domain")
+        db_session.add(asset)
+        await db_session.flush()
+
+        scan = Scan(
+            tenant_id=tenant.id,
+            asset_id=asset.id,
+            name="null-scan",
+            scan_type="vulnerability",
+        )
+        db_session.add(scan)
+        await db_session.flush()
+
+        vuln = Vulnerability(
+            tenant_id=tenant.id,
+            scan_id=scan.id,
+            title="nullable-fields",
+            severity="info",
+            description=None,
+            cve_id=None,
+            cvss_score=None,
+            vulnerability_metadata=None,
+        )
+        db_session.add(vuln)
+        await db_session.flush()
+
+        assert vuln.description is None
+        assert vuln.cve_id is None
+        assert vuln.cvss_score is None
+        assert vuln.vulnerability_metadata is None
+
+
+# ---------------------------------------------------------------------------
+# Report — default persistence & constraints
+# ---------------------------------------------------------------------------
+
+
+class TestReportPersistence:
+    """DB-backed tests for Report model persistence and constraints."""
+
+    async def test_persist_report_applies_defaults(
+        self, db_session, seed_data
+    ) -> None:
+        """Persisting a Report with minimal fields applies column defaults."""
+        tenant = seed_data["tenant_a"]
+        asset = Asset(tenant_id=tenant.id, name="report-target", asset_type="web_app")
+        db_session.add(asset)
+        await db_session.flush()
+
+        report = Report(
+            tenant_id=tenant.id,
+            asset_id=asset.id,
+            name="monthly-report",
+            report_type="vulnerability",
+        )
+        db_session.add(report)
+        await db_session.flush()
+
+        assert report.status == "pending"
+        assert report.id is not None
+        assert report.created_at is not None
+
+    async def test_report_without_asset_fails(self, db_session, seed_data) -> None:
+        """FK to assets rejects Report without asset_id."""
+        tenant = seed_data["tenant_a"]
+        report = Report(
+            tenant_id=tenant.id,
+            name="orphan-report",
+            report_type="technical",
+        )
+        db_session.add(report)
+        with pytest.raises(IntegrityError):
+            await db_session.flush()
+
+    async def test_invalid_report_type_rejected(self, db_session, seed_data) -> None:
+        """CheckConstraint rejects invalid report_type."""
+        tenant = seed_data["tenant_a"]
+        asset = Asset(tenant_id=tenant.id, name="rtype-target", asset_type="host")
+        db_session.add(asset)
+        await db_session.flush()
+
+        report = Report(
+            tenant_id=tenant.id,
+            asset_id=asset.id,
+            name="bad-type",
+            report_type="invalid_type",
+        )
+        db_session.add(report)
+        with pytest.raises(IntegrityError):
+            await db_session.flush()
+
+    async def test_invalid_status_rejected(self, db_session, seed_data) -> None:
+        """CheckConstraint rejects invalid status."""
+        tenant = seed_data["tenant_a"]
+        asset = Asset(tenant_id=tenant.id, name="rstat-target", asset_type="ip")
+        db_session.add(asset)
+        await db_session.flush()
+
+        report = Report(
+            tenant_id=tenant.id,
+            asset_id=asset.id,
+            name="bad-status",
+            report_type="compliance",
+            status="archived",
+        )
+        db_session.add(report)
+        with pytest.raises(IntegrityError):
+            await db_session.flush()
+
+    async def test_nullable_generated_at(self, db_session, seed_data) -> None:
+        """Nullable generated_at accepts None."""
+        tenant = seed_data["tenant_a"]
+        asset = Asset(tenant_id=tenant.id, name="gen-target", asset_type="domain")
+        db_session.add(asset)
+        await db_session.flush()
+
+        report = Report(
+            tenant_id=tenant.id,
+            asset_id=asset.id,
+            name="no-gen-date",
+            report_type="executive",
+            generated_at=None,
+        )
+        db_session.add(report)
+        await db_session.flush()
+
+        assert report.generated_at is None
+
+
+# ---------------------------------------------------------------------------
+# ON DELETE CASCADE integrity
+# ---------------------------------------------------------------------------
+
+
+class TestCascadeDelete:
+    """DB-backed tests for ON DELETE CASCADE across the F2 model graph."""
+
+    async def test_delete_asset_cascades_to_scans(
+        self, db_session, seed_data
+    ) -> None:
+        """ON DELETE CASCADE: deleting an asset removes its scans."""
+        tenant = seed_data["tenant_a"]
+        asset = Asset(tenant_id=tenant.id, name="cascade-asset", asset_type="host")
+        db_session.add(asset)
+        await db_session.flush()
+
+        scan = Scan(
+            tenant_id=tenant.id,
+            asset_id=asset.id,
+            name="cascade-scan",
+            scan_type="discovery",
+        )
+        db_session.add(scan)
+        await db_session.flush()
+
+        asset_id = asset.id
+        scan_id = scan.id
+
+        # Delete asset — ON DELETE CASCADE removes the scan
+        await db_session.delete(asset)
+        await db_session.flush()
+
+        # Verify scan is gone
+        result = await db_session.execute(
+            text("SELECT 1 FROM scans WHERE id = :id"), {"id": scan_id}
+        )
+        assert result.fetchone() is None
+
+    async def test_delete_scan_cascades_to_vulnerabilities(
+        self, db_session, seed_data
+    ) -> None:
+        """ON DELETE CASCADE: deleting a scan removes its vulnerabilities."""
+        tenant = seed_data["tenant_a"]
+        asset = Asset(
+            tenant_id=tenant.id, name="vuln-cascade-asset", asset_type="host"
+        )
+        db_session.add(asset)
+        await db_session.flush()
+
+        scan = Scan(
+            tenant_id=tenant.id,
+            asset_id=asset.id,
+            name="vuln-cascade-scan",
+            scan_type="vulnerability",
+        )
+        db_session.add(scan)
+        await db_session.flush()
+
+        vuln = Vulnerability(
+            tenant_id=tenant.id,
+            scan_id=scan.id,
+            title="cascade-vuln",
+            severity="medium",
+        )
+        db_session.add(vuln)
+        await db_session.flush()
+
+        scan_id = scan.id
+        vuln_id = vuln.id
+
+        # Delete scan — ON DELETE CASCADE removes the vulnerability
+        await db_session.delete(scan)
+        await db_session.flush()
+
+        # Verify vulnerability is gone
+        result = await db_session.execute(
+            text("SELECT 1 FROM vulnerabilities WHERE id = :id"), {"id": vuln_id}
+        )
+        assert result.fetchone() is None
+
+    async def test_delete_tenant_cascades_to_assets(
+        self, db_session, seed_data
+    ) -> None:
+        """ON DELETE CASCADE: deleting a tenant removes its assets."""
+        unique_tag = uuid.uuid4().hex[:8]
+        tenant = Tenant(
+            name=f"Test Cascade {unique_tag}",
+            slug=f"test-cascade-{unique_tag}",
+            plan="free",
+        )
+        db_session.add(tenant)
+        await db_session.flush()
+
+        asset = Asset(
+            tenant_id=tenant.id, name="tenant-cascade-asset", asset_type="ip"
+        )
+        db_session.add(asset)
+        await db_session.flush()
+
+        tenant_id = tenant.id
+        asset_id = asset.id
+
+        # Delete tenant — ON DELETE CASCADE removes the asset
+        await db_session.delete(tenant)
+        await db_session.flush()
+
+        # Verify asset is gone
+        result = await db_session.execute(
+            text("SELECT 1 FROM assets WHERE id = :id"), {"id": asset_id}
+        )
+        assert result.fetchone() is None
+
+
+# ---------------------------------------------------------------------------
+# Table existence — schema verification
+# ---------------------------------------------------------------------------
+
+
+class TestF2TableExistence:
+    """Verify all 4 F2 tables exist in the public schema."""
+
+    async def test_f2_tables_present_in_information_schema(
+        self, db_session
+    ) -> None:
+        """Assert assets, scans, vulnerabilities, reports tables exist."""
+        result = await db_session.execute(
+            text(
+                "SELECT table_name FROM information_schema.tables "
+                "WHERE table_schema = 'public' "
+                "AND table_name IN "
+                "('assets', 'scans', 'vulnerabilities', 'reports')"
+            )
+        )
+        tables = {row[0] for row in result}
+        expected = {"assets", "scans", "vulnerabilities", "reports"}
+        assert tables == expected

--- a/tests/unit/test_f2_models.py
+++ b/tests/unit/test_f2_models.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import uuid
+
+from app.modules.assets.models import Asset
+from app.modules.reports.models import Report
+from app.modules.scans.models import Scan
+from app.modules.vulnerabilities.models import Vulnerability
+
+
+# ---------------------------------------------------------------------------
+# Helpers for model inspection (DB-free — no session needed)
+# ---------------------------------------------------------------------------
+
+def _non_nullable_columns(model_cls: type) -> set[str]:
+    return {c.name for c in model_cls.__mapper__.columns if not c.nullable}
+
+
+def _nullable_columns(model_cls: type) -> set[str]:
+    return {c.name for c in model_cls.__mapper__.columns if c.nullable}
+
+
+def _check_constraint_names(model_cls: type) -> set[str]:
+    return {
+        c.name
+        for c in model_cls.__table__.constraints
+        if c.name is not None
+    }
+
+
+def _column_default(table, col_name: str):
+    """Return the Python-side ColumnDefault arg or None."""
+    col = getattr(table.c, col_name)
+    if col.default is not None:
+        return col.default.arg
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Asset
+# ---------------------------------------------------------------------------
+
+class TestAssetModel:
+    """Tests unitarios de inspección del modelo Asset — DB-free"""
+
+    def test_tablename(self) -> None:
+        assert Asset.__tablename__ == "assets"
+
+    def test_required_columns(self) -> None:
+        nn = _non_nullable_columns(Asset)
+        assert "id" in nn
+        assert "tenant_id" in nn
+        assert "name" in nn
+        assert "asset_type" in nn
+        assert "status" in nn
+        assert "created_at" in nn
+        assert "updated_at" in nn
+
+    def test_nullable_columns(self) -> None:
+        n = _nullable_columns(Asset)
+        assert "hostname" in n
+        assert "asset_metadata" in n
+
+    def test_column_defaults(self) -> None:
+        """Verify column-level defaults (Python-side `default=` arg)."""
+        assert _column_default(Asset.__table__, "status") == "active"
+
+    def test_check_constraint_names(self) -> None:
+        names = _check_constraint_names(Asset)
+        assert "chk_assets_asset_type" in names
+        assert "chk_assets_status" in names
+
+    def test_repr_format(self) -> None:
+        asset = Asset(
+            id=uuid.uuid4(),
+            tenant_id=uuid.uuid4(),
+            name="server-01",
+            asset_type="host",
+        )
+        result = repr(asset)
+        assert "Asset" in result
+        assert "server-01" in result
+
+
+# ---------------------------------------------------------------------------
+# Scan
+# ---------------------------------------------------------------------------
+
+class TestScanModel:
+    """Tests unitarios de inspección del modelo Scan — DB-free"""
+
+    def test_tablename(self) -> None:
+        assert Scan.__tablename__ == "scans"
+
+    def test_required_columns(self) -> None:
+        nn = _non_nullable_columns(Scan)
+        assert "id" in nn
+        assert "tenant_id" in nn
+        assert "asset_id" in nn
+        assert "name" in nn
+        assert "scan_type" in nn
+        assert "status" in nn
+        assert "created_at" in nn
+        assert "updated_at" in nn
+
+    def test_nullable_columns(self) -> None:
+        n = _nullable_columns(Scan)
+        assert "config" in n
+        assert "started_at" in n
+        assert "completed_at" in n
+
+    def test_column_defaults(self) -> None:
+        assert _column_default(Scan.__table__, "status") == "pending"
+
+    def test_check_constraint_names(self) -> None:
+        names = _check_constraint_names(Scan)
+        assert "chk_scans_scan_type" in names
+        assert "chk_scans_status" in names
+
+    def test_fk_columns(self) -> None:
+        """Verify foreign keys point to expected parent tables."""
+        fks = {fk.column.table.name: fk.parent.name for fk in Scan.__table__.foreign_keys}
+        assert fks["tenants"] == "tenant_id"
+        assert fks["assets"] == "asset_id"
+
+    def test_repr_format(self) -> None:
+        scan = Scan(
+            id=uuid.uuid4(),
+            tenant_id=uuid.uuid4(),
+            asset_id=uuid.uuid4(),
+            name="scan-01",
+            scan_type="vulnerability",
+        )
+        result = repr(scan)
+        assert "Scan" in result
+        assert "scan-01" in result
+
+
+# ---------------------------------------------------------------------------
+# Vulnerability
+# ---------------------------------------------------------------------------
+
+class TestVulnerabilityModel:
+    """Tests unitarios de inspección del modelo Vulnerability — DB-free"""
+
+    def test_tablename(self) -> None:
+        assert Vulnerability.__tablename__ == "vulnerabilities"
+
+    def test_required_columns(self) -> None:
+        nn = _non_nullable_columns(Vulnerability)
+        assert "id" in nn
+        assert "tenant_id" in nn
+        assert "scan_id" in nn
+        assert "title" in nn
+        assert "severity" in nn
+        assert "status" in nn
+        assert "created_at" in nn
+        assert "updated_at" in nn
+
+    def test_nullable_columns(self) -> None:
+        n = _nullable_columns(Vulnerability)
+        assert "description" in n
+        assert "cve_id" in n
+        assert "cvss_score" in n
+        assert "vulnerability_metadata" in n
+
+    def test_column_defaults(self) -> None:
+        assert _column_default(Vulnerability.__table__, "status") == "open"
+
+    def test_check_constraint_names(self) -> None:
+        names = _check_constraint_names(Vulnerability)
+        assert "chk_vulnerabilities_severity" in names
+        assert "chk_vulnerabilities_status" in names
+
+    def test_fk_columns(self) -> None:
+        fks = {fk.column.table.name: fk.parent.name for fk in Vulnerability.__table__.foreign_keys}
+        assert fks["tenants"] == "tenant_id"
+        assert fks["scans"] == "scan_id"
+
+    def test_repr_format(self) -> None:
+        vuln = Vulnerability(
+            id=uuid.uuid4(),
+            tenant_id=uuid.uuid4(),
+            scan_id=uuid.uuid4(),
+            title="SQL Injection",
+            severity="high",
+        )
+        result = repr(vuln)
+        assert "Vulnerability" in result
+        assert "SQL Injection" in result
+
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+class TestReportModel:
+    """Tests unitarios de inspección del modelo Report — DB-free"""
+
+    def test_tablename(self) -> None:
+        assert Report.__tablename__ == "reports"
+
+    def test_required_columns(self) -> None:
+        nn = _non_nullable_columns(Report)
+        assert "id" in nn
+        assert "tenant_id" in nn
+        assert "asset_id" in nn
+        assert "name" in nn
+        assert "report_type" in nn
+        assert "status" in nn
+        assert "created_at" in nn
+        assert "updated_at" in nn
+
+    def test_nullable_columns(self) -> None:
+        n = _nullable_columns(Report)
+        assert "summary" in n
+        assert "report_metadata" in n
+        assert "generated_at" in n
+
+    def test_column_defaults(self) -> None:
+        assert _column_default(Report.__table__, "status") == "pending"
+
+    def test_check_constraint_names(self) -> None:
+        names = _check_constraint_names(Report)
+        assert "chk_reports_report_type" in names
+        assert "chk_reports_status" in names
+
+    def test_fk_columns(self) -> None:
+        fks = {fk.column.table.name: fk.parent.name for fk in Report.__table__.foreign_keys}
+        assert fks["tenants"] == "tenant_id"
+        assert fks["assets"] == "asset_id"
+
+    def test_repr_format(self) -> None:
+        report = Report(
+            id=uuid.uuid4(),
+            tenant_id=uuid.uuid4(),
+            asset_id=uuid.uuid4(),
+            name="report-01",
+            report_type="vulnerability",
+        )
+        result = repr(report)
+        assert "Report" in result
+        assert "report-01" in result


### PR DESCRIPTION
## Summary

Adds `tests/unit/test_f2_models.py` — DB-free mapper inspection tests covering:
- `__tablename__` verification for all 4 models
- Non-nullable and nullable column sets
- Python-side `ColumnDefault` args
- CHECK constraint names
- FK column → parent table mappings
- `__repr__` format validation

Runs without PostgreSQL — pure SQLAlchemy mapper inspection.

### Files changed
| File | Action |
|------|--------|
| `tests/unit/test_f2_models.py` | Created — 243 lines |

### Part of F2 slicing chain (3/5)
Ref: #91