### PR TITLE
feat(demo): add isolated vulnerable target container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
 services:
-  
   postgres:
     image: postgres:16-alpine
     container_name: soc360_postgres
@@ -21,7 +20,7 @@ services:
       timeout: 6s
       retries: 5
     restart: unless-stopped
-  
+
   redis:
     image: redis:7-alpine
     container_name: soc360_redis
@@ -41,3 +40,31 @@ services:
       timeout: 6s
       retries: 5
     restart: unless-stopped
+
+  # ---------------------------------------------------------------------------
+  # Demo-only simulated vulnerable target for Nmap scan walkthroughs
+  # ---------------------------------------------------------------------------
+  # SAFETY: This is a STATIC, FAKE, SIMULATED target. It serves predictable
+  # fake banners on ports 22/80/21/3306 for demo scans. No real vulnerabilities.
+  #
+  # Enabled only with: docker compose --profile demo up
+  # Isolated to the internal demo_network — NO host ports exposed by default.
+  # ---------------------------------------------------------------------------
+  vulnerable-target:
+    build:
+      context: ./docker/vulnerable-target
+      dockerfile: Dockerfile
+    container_name: soc360_demo_vulnerable_target
+    profiles: [demo]
+    # No 'ports:' section → NOT exposed to host (internal Docker network only)
+    networks:
+      - demo_network
+    restart: unless-stopped
+
+networks:
+  demo_network:
+    driver: bridge
+    internal: true
+    # Internal Docker network — not reachable from host unless explicitly
+    # connected. The scanner workload attaches to this same network.
+

--- a/docker/vulnerable-target/Dockerfile
+++ b/docker/vulnerable-target/Dockerfile
@@ -1,0 +1,34 @@
+# =============================================================================
+# Demo Vulnerable Target for SOC360 Pymes
+# =============================================================================
+# SAFETY: This image serves STATIC, FAKE, CLEARLY-LABELED service banners.
+# It does NOT contain any real vulnerable software, exploitable services, or
+# production workloads. It is gated behind the 'demo' Docker Compose profile
+# and attaches only to an internal demo network.
+# =============================================================================
+
+FROM alpine:3.20
+
+LABEL org.soc360.demo="true" \
+      org.soc360.component="vulnerable-target" \
+      org.soc360.simulated="true" \
+      description="Demo-only simulated vulnerable target for Nmap scan walkthroughs"
+
+# netcat-openbsd: used by entrypoint.sh to bind ports and serve banner files
+RUN apk add --no-cache netcat-openbsd
+
+# Banner files — static, fake service responses returned to connecting scanners
+COPY banners/ /banners/
+
+# Entrypoint script — binds ports and manages banner listeners
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+# Demo ports: 22 (SSH), 80 (HTTP), 21 (FTP), 3306(MySQL)
+EXPOSE 22 80 21 3306
+
+# Non-root for safety (even though there's nothing exploitable here)
+RUN addgroup -S demo && adduser -S demo -G demo
+USER demo
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/vulnerable-target/banners/ftp.banner
+++ b/docker/vulnerable-target/banners/ftp.banner
@@ -1,0 +1,7 @@
+220 (vsFTPd 3.0.5) [DEMO-SIMULATED]
+331 Please specify the password.
+230 Login successful. [SIMULATED]
+227 Entering Passive Mode (127,0,0,1,19,137).
+150 Here comes the directory listing. [SIMULATED]
+226 Directory send OK. [SIMULATED]
+221 Goodbye. [DEMO-TARGET-SOC360]

--- a/docker/vulnerable-target/banners/http.banner
+++ b/docker/vulnerable-target/banners/http.banner
@@ -1,0 +1,16 @@
+HTTP/1.1 200 OK
+Server: Apache/2.4.62 (Unix) [DEMO-SIMULATED]
+Content-Type: text/html; charset=UTF-8
+X-Powered-By: PHP/8.2.27 [DEMO]
+X-Demo-Company: LeadFlow
+X-Demo-Platform: PrestaShop-like [SIMULATED]
+
+<!DOCTYPE html>
+<html>
+<head><title>LeadFlow Backoffice</title></head>
+<body>
+<h1>LeadFlow Admin Portal [SIMULATED]</h1>
+<p>PrestaShop-like backoffice demo for SOC360 scan demonstrations.</p>
+<p>No real login, customer data, orders, or vulnerabilities are present.</p>
+</body>
+</html>

--- a/docker/vulnerable-target/banners/mysql.banner
+++ b/docker/vulnerable-target/banners/mysql.banner
@@ -1,0 +1,5 @@
+5.7.44-log MySQL Community Server [DEMO-SIMULATED]
+X-Demo-Company: LeadFlow
+X-Demo-Service: MySQL-like database banner [SIMULATED]
+No real database engine, credentials, customer data, or queries are available.
+

--- a/docker/vulnerable-target/banners/ssh.banner
+++ b/docker/vulnerable-target/banners/ssh.banner
@@ -1,0 +1,7 @@
+SSH-2.0-OpenSSH_9.6p1 Ubuntu-3ubuntu13.5 [DEMO-SIMULATED]
+
+===========================================
+  SOC360 Pymes — Demo Vulnerable Target
+  THIS IS A SIMULATED SSH SERVICE
+  No real authentication or shell access
+===========================================

--- a/docker/vulnerable-target/entrypoint.sh
+++ b/docker/vulnerable-target/entrypoint.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+# =============================================================================
+# entrypoint.sh — Demo Vulnerable Target for SOC360 Pymes
+# Binds ports 22 (SSH), 80 (HTTP), 21 (FTP), 3306(MySQL) and serves static fake banners.
+#
+# SAFETY: This is a SIMULATED target. No real services. No real vulnerabilities.
+# =============================================================================
+set -e
+
+echo "================================================"
+echo "  SOC360 Pymes — Demo Vulnerable Target"
+echo "  [SIMULATED — for walkthroughs and demos only]"
+echo "================================================"
+echo ""
+echo "Exposing demo ports: 22 (SSH), 80 (HTTP), 21 (FTP), 3306(MySQL)"
+echo "Banners are static, fake, and clearly labeled."
+echo ""
+
+# Start banner listeners in background.
+# Each listener loops: accepts one connection, sends the banner, then restarts.
+#
+# netcat-openbsd behavior:
+#   nc -l -p PORT < /banners/FILE.banner
+#   → listens on PORT, sends file content to the first connecting client, exits.
+#   The while loop restarts the listener immediately after the connection ends.
+
+while true; do
+  nc -l -p 22 </banners/ssh.banner 2>/dev/null || true
+done &
+
+while true; do
+  nc -l -p 80 </banners/http.banner 2>/dev/null || true
+done &
+
+while true; do
+  nc -l -p 21 </banners/ftp.banner 2>/dev/null || true
+done &
+
+while true; do
+  nc -l -p 3306 </banners/mysql.banner 2>/dev/null || true
+done &
+
+echo "[vulnerable-target] All listeners started on ports 22, 80, 21, 3306."
+echo "[vulnerable-target] Container ready for demo scans."
+
+# Keep the container alive — wait for any child process to exit
+wait

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -1,0 +1,119 @@
+# Demo Vulnerable Target — Operator Guide
+
+> **⚠️ IMPORTANTE**: Este es un target **SIMULADO**. No contiene software vulnerable real, exploits, ni servicios productivos. Sus banners y respuestas son completamente falsos y predecibles. Está diseñado exclusivamente para demos, walkthroughs y presentaciones a clientes.
+
+## ¿Qué es?
+
+Un contenedor Docker aislado que expone puertos 22 (SSH), 80 (HTTP), 21 (FTP) y 3306 (MySQL) con banners falsos y predecibles, para que los escaneos Nmap de F2 produzcan resultados consistentes durante demostraciones.
+
+## Cómo habilitarlo
+
+El target está **apagado por defecto** y solo se activa con el perfil `demo`:
+
+```bash
+# Arrancar el target (Compose también levanta servicios sin perfil, como Redis)
+docker compose --profile demo up -d
+
+# Arrancar con todos los servicios (dev + demo)
+docker compose --profile dev --profile demo up -d
+```
+
+## Verificar que funciona
+
+El script de verificación automatizada comprueba que todo está correcto:
+
+```bash
+bash tests/verify_demo_target.sh
+```
+
+Este script valida:
+1. Que el target **NO** arranca sin `--profile demo`
+2. Que el target **SÍ** arranca con `--profile demo`
+3. Que los puertos 22, 80, 21, 3306 responden con los banners esperados
+4. Que **NO** hay puertos expuestos al host
+5. Que el contenedor tiene etiquetas de seguridad (`demo=true`, `simulated=true`)
+
+## Salida esperada de un escaneo Nmap
+
+Cuando se ejecuta Nmap desde F2 (conectado a `soc360-pymes_demo_network`), el resultado será similar a:
+
+```
+PORT    STATE SERVICE VERSION
+21/tcp  open  ftp     vsFTPd 3.0.5 [DEMO-SIMULATED]
+22/tcp  open  ssh     OpenSSH 9.6p1 (Ubuntu) [DEMO-SIMULATED]
+80/tcp  open  http    Apache httpd 2.4.62 (Unix) [DEMO-SIMULATED]
+3306/tcp open mysql   MySQL 5.7.44-log Community Server [DEMO-SIMULATED]
+```
+
+> Los banners siempre incluyen el sufijo `[DEMO-SIMULATED]` para que no haya confusión con servicios reales.
+
+## Cómo apagarlo
+
+```bash
+# Apagar solo el perfil demo
+docker compose --profile demo down
+
+# Apagar todo
+docker compose down
+```
+
+## Validación de seguridad (pre-presentación)
+
+Antes de una presentación o walkthrough con un cliente, verificá:
+
+| Check | Comando | Resultado esperado |
+|-------|---------|-------------------|
+| Solo arranca con perfil | `docker compose up -d` → `docker compose ps` | `vulnerable-target` NO aparece |
+| Sin puertos host | `docker compose port vulnerable-target 22` | `:0` (expuesto pero no publicado) |
+| Banners correctos | `bash tests/verify_demo_target.sh` | 11/11 PASSED |
+| Etiquetas de seguridad | `docker inspect soc360_demo_vulnerable_target \| grep -i demo` | `demo=true`, `simulated=true` |
+
+## Arquitectura
+
+```
+┌─────────────────────────────────────────────┐
+│  Host                                       │
+│  ┌───────────────────────────────────────┐  │
+│  │  soc360-pymes_demo_network (bridge)   │  │
+│  │                                       │  │
+│  │  ┌──────────────────────────┐           │  │
+│  │  │ vulnerable-target         │           │  │
+│  │  │ ports: 22, 80, 21, 3306   │           │  │
+│  │  │ (internal only)           │           │  │
+│  │  └──────────────────────────┘           │  │
+│  │                                       │  │
+│  │  ┌─────────────────────┐              │  │
+│  │  │ F2 scanner          │              │  │
+│  │  │ (same network)      │              │  │
+│  │  └─────────────────────┘              │  │
+│  └───────────────────────────────────────┘  │
+│                                             │
+│  ❌ No host port mapping                    │
+│  ❌ No external access                      │
+└─────────────────────────────────────────────┘
+```
+
+## Preguntas frecuentes
+
+**¿Puedo exponer el target al host para debuggear?**
+Sí, pero no por defecto. Si necesitás acceso desde el host para debug, agregá temporalmente un `ports:` mapping en `docker-compose.yml` y **acordate de quitarlo antes de hacer commit**. El perfil `demo` está diseñado para ser seguro out-of-the-box.
+
+**¿Los banners son reales?**
+No. Son archivos de texto estáticos (`docker/vulnerable-target/banners/*.banner`) que se sirven vía netcat. No hay Apache, OpenSSH, ni vsFTPd reales ejecutándose.
+
+**¿Puedo usar esto en producción?**
+**NO.** Este target es exclusivamente para demostraciones. No representa un entorno real y no debe usarse para pruebas de seguridad reales. Si llegara a aparecer en un entorno productivo, el guard rail de perfil (`profiles: [demo]`) impide que arranque accidentalmente.
+
+**¿Qué pasa si alguien hace un escaneo agresivo?**
+Como los servicios son emulados (netcat sirviendo archivos de texto), no hay riesgo de derribar servicios reales ni de explotar vulnerabilidades. En el peor caso, netcat se reinicia automáticamente (está en un loop `while true`).
+
+## Archivos relevantes
+
+| Archivo | Propósito |
+|---------|-----------|
+| `docker/vulnerable-target/Dockerfile` | Imagen Alpine con netcat-openbsd |
+| `docker/vulnerable-target/entrypoint.sh` | Script que levanta los listeners |
+| `docker/vulnerable-target/banners/*.banner` | Banners falsos servidos por netcat |
+| `docker-compose.yml` (servicio `vulnerable-target`) | Definición del servicio + perfil `demo` |
+| `tests/verify_demo_target.sh` | Suite de verificación automatizada |
+| `docs/demo.md` | Este documento |

--- a/tests/verify_demo_target.sh
+++ b/tests/verify_demo_target.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# =============================================================================
+# verify_demo_target.sh
+# Acceptance test suite for the demo-vulnerable-target Docker service.
+#
+# Spec reference: sdd/vulnerable-target-container/spec
+# Requirements:
+#   - Demo profile-gated availability (starts only with --profile demo)
+#   - Internal-only network isolation (no host ports by default)
+#   - Predictable emulated scan surface (ports 22/80/21/3306 + fake banners)
+#   - Safety and non-production guarantee
+#
+# Strict TDD: this script was written BEFORE the Docker infrastructure exists.
+# It will FAIL (RED) until Phase 2 implementation is complete.
+# =============================================================================
+set -euo pipefail
+
+# --- Colors ---
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+# --- Counters ---
+PASS=0
+FAIL=0
+
+log_pass() {
+  echo -e "  ${GREEN}[PASS]${NC} $1"
+  PASS=$((PASS + 1))
+}
+log_fail() {
+  echo -e "  ${RED}[FAIL]${NC} $1"
+  FAIL=$((FAIL + 1))
+}
+log_info() { echo -e "  ${YELLOW}[INFO]${NC} $1"; }
+
+# Derived from the directory name — compose auto-detects this
+PROJECT_NAME="soc360-pymes"
+COMPOSE_FILE="docker-compose.yml"
+PROFILE="demo"
+SERVICE="vulnerable-target"
+NETWORK="${PROJECT_NAME}_demo_network"
+
+# ---------------------------------------------------------------------------
+# Cleanup: ensure demo stack is fully torn down after test run
+# ---------------------------------------------------------------------------
+cleanup() {
+  echo ""
+  log_info "Tearing down demo stack..."
+  docker compose --profile "$PROFILE" down -v --remove-orphans 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Pre-flight: ensure we are in the project root (where docker-compose.yml lives)
+# ---------------------------------------------------------------------------
+if [[ ! -f "$COMPOSE_FILE" ]]; then
+  echo -e "${RED}[ABORT]${NC} $COMPOSE_FILE not found. Run this script from the project root."
+  exit 1
+fi
+
+echo ""
+echo -e "${BOLD}=== verify_demo_target.sh ===${NC}"
+echo -e "${BOLD}Spec: sdd/vulnerable-target-container/spec${NC}"
+echo ""
+
+# ===========================================================================
+# TEST 1 — Container is absent WITHOUT the demo profile
+# Requirement: Demo profile-gated availability
+# Scenario:   Demo target stays absent by default
+# ===========================================================================
+echo -e "${BOLD}--- Test 1: Profile-gated absence (no --profile demo) ---${NC}"
+
+# Start the platform WITHOUT the demo profile (default services only)
+docker compose up -d 2>/dev/null || true
+sleep 2
+
+# Verify the vulnerable-target container does NOT exist
+if docker compose ps --format 'table {{.Name}}' 2>/dev/null | grep -q "${SERVICE}"; then
+  log_fail "vulnerable-target container found when it should NOT be running (demo profile NOT enabled)"
+else
+  log_pass "vulnerable-target is NOT running without --profile demo"
+fi
+
+# Tear down default services
+docker compose down 2>/dev/null || true
+
+# ===========================================================================
+# TEST 2 — Container starts WITH the demo profile
+# Requirement: Demo profile-gated availability
+# Scenario:   Demo target starts when explicitly requested
+# ===========================================================================
+echo ""
+echo -e "${BOLD}--- Test 2: Profile-gated availability (--profile demo) ---${NC}"
+
+# Start WITH the demo profile
+docker compose --profile "$PROFILE" up -d 2>/dev/null
+# Give the container a moment to initialize
+sleep 3
+
+# Verify the container exists and is running
+CONTAINER_ID=$(docker compose ps -q "$SERVICE" 2>/dev/null || echo "")
+if [[ -z "$CONTAINER_ID" ]]; then
+  log_fail "vulnerable-target container did NOT start with --profile demo"
+else
+  STATUS=$(docker inspect -f '{{.State.Status}}' "$CONTAINER_ID" 2>/dev/null || echo "unknown")
+  if [[ "$STATUS" == "running" ]]; then
+    log_pass "vulnerable-target container is running with --profile demo (status: $STATUS)"
+  else
+    log_fail "vulnerable-target container exists but status is '$STATUS' (expected 'running')"
+  fi
+fi
+
+# ===========================================================================
+# TEST 3 — Expected ports respond within the demo network
+# Requirement: Predictable emulated scan surface
+# Scenario:   Scanner sees expected ports and banners
+# ===========================================================================
+echo ""
+echo -e "${BOLD}--- Test 3: Emulated ports respond on demo network ---${NC}"
+
+EXPECTED_PORTS=(22 80 21 3306)
+PORT_NAMES=("SSH (22)" "HTTP (80)" "FTP (21)" "MySQL (3306)")
+
+# Use a temporary busybox container attached to the demo network to probe each port
+for i in "${!EXPECTED_PORTS[@]}"; do
+  PORT="${EXPECTED_PORTS[$i]}"
+  NAME="${PORT_NAMES[$i]}"
+
+  # Use nc (netcat) from a temporary container on the same network
+  RESULT=$(docker run --rm --network "$NETWORK" alpine:3.20 \
+    sh -c "apk add --quiet netcat-openbsd 2>/dev/null; echo 'QUIT' | timeout 5 nc -w 3 ${SERVICE} ${PORT} 2>&1" || echo "TIMEOUT_OR_ERROR")
+
+  if echo "$RESULT" | grep -q "TIMEOUT_OR_ERROR"; then
+    log_fail "$NAME port did NOT respond within timeout"
+  elif [[ -z "$(echo "$RESULT" | tr -d '[:space:]')" ]]; then
+    log_fail "$NAME port connected but returned EMPTY response (expected banner text)"
+  else
+    BANNER_PREVIEW=$(echo "$RESULT" | head -1 | cut -c1-60)
+    log_pass "$NAME responded: '${BANNER_PREVIEW}...'"
+  fi
+done
+
+# ===========================================================================
+# TEST 4 — No host ports exposed by default
+# Requirement: Internal-only network isolation
+# Scenario:   Host cannot reach the target by default
+# ===========================================================================
+echo ""
+echo -e "${BOLD}--- Test 4: No host port exposure ---${NC}"
+
+for PORT in 22 80 21 3306; do
+  HOST_MAPPING=$(docker compose port "$SERVICE" "$PORT" 2>&1 || true)
+  # Strip compose warning lines (e.g., missing env var warnings)
+  CLEAN_MAPPING=$(echo "$HOST_MAPPING" | grep -v "level=warning" | grep -v "^$" | tail -1)
+
+  if [[ -z "$CLEAN_MAPPING" ]]; then
+    log_pass "Port $PORT has NO host mapping"
+  elif [[ "$CLEAN_MAPPING" == ":0" ]]; then
+    # Port is EXPOSEd in Dockerfile but NOT published to host.
+    # This is the expected demo posture — internal network only.
+    log_pass "Port $PORT is EXPOSEd but NOT published to host (internal network only)"
+  elif echo "$CLEAN_MAPPING" | grep -qi "error\|no port\|not published\|no container"; then
+    log_pass "Port $PORT is NOT published to host"
+  else
+    # A real host mapping was returned (e.g., "0.0.0.0:8080") — unwelcome
+    log_fail "Port $PORT IS published to host: $CLEAN_MAPPING"
+  fi
+done
+
+# ===========================================================================
+# TEST 5 — Container is labeled as demo/simulated (safety check)
+# Requirement: Safety and non-production guarantee
+# Scenario:   Demo target is identified as simulated
+# ===========================================================================
+echo ""
+echo -e "${BOLD}--- Test 5: Demo/simulation labeling ---${NC}"
+
+if [[ -n "$CONTAINER_ID" ]]; then
+  LABELS=$(docker inspect -f '{{range $k,$v := .Config.Labels}}{{$k}}={{$v}} {{end}}' "$CONTAINER_ID" 2>/dev/null || echo "")
+  if echo "$LABELS" | grep -qi "demo\|simulated"; then
+    log_pass "Container has demo/simulated label: $(echo "$LABELS" | grep -oi 'demo[^ ]*\|simulated[^ ]*')"
+  else
+    log_fail "Container lacks demo/simulated label — safety labeling missing"
+  fi
+else
+  log_fail "Cannot verify labels — container not running"
+fi
+
+# ===========================================================================
+# SUMMARY
+# ===========================================================================
+echo ""
+echo -e "${BOLD}========================================${NC}"
+echo -e "${BOLD}  RESULTS${NC}"
+echo -e "${BOLD}========================================${NC}"
+echo -e "  ${GREEN}Passed:${NC} $PASS"
+echo -e "  ${RED}Failed:${NC} $FAIL"
+echo ""
+
+if [[ "$FAIL" -gt 0 ]]; then
+  echo -e "${RED}[VERDICT] Some tests FAILED.${NC}"
+  exit 1
+else
+  echo -e "${GREEN}[VERDICT] All tests PASSED.${NC}"
+  exit 0
+fi


### PR DESCRIPTION
Closes #98

## PR Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Adds a demo-only vulnerable target container for SOC360 F2 walkthroughs.
- Simulates LeadFlow services on 22/80/21/3306 with static banners and no real exploitable services.
- Documents safe usage and adds a verification script that validates profile gating, internal reachability, no host ports, and demo labels.

## Changes
| File | Change |
|------|--------|
| `docker-compose.yml` | Adds `vulnerable-target` service behind `demo` profile on internal `demo_network` with no host ports. |
| `docker/vulnerable-target/*` | Adds Dockerfile, entrypoint, and static simulated banners. |
| `tests/verify_demo_target.sh` | Adds acceptance verification for 11 checks across profile gating, ports, host exposure, and labels. |
| `docs/demo.md` | Adds operator guide, expected scan output, and safety notes. |

## Test Plan
- [x] `bash tests/verify_demo_target.sh` → 11/11 PASSED
- [x] `docker compose --profile demo config` → valid, `demo_network.internal: true`, no host `ports:` for `vulnerable-target`
- [x] Docs updated for behavior change

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran relevant verification for modified script
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers