### PR TITLE
test(tenants): align scalars mock with SQLAlchemy result

### DIFF
--- a/tests/unit/test_tenants.py
+++ b/tests/unit/test_tenants.py
@@ -436,7 +436,9 @@ class TestUpdateTenantTokenRevocation:
         mock_db.flush = AsyncMock()
         mock_db.refresh = AsyncMock()
         mock_db.execute = AsyncMock()
-        mock_db.scalars = AsyncMock(return_value=[user1, user2])
+        mock_scalar_result = MagicMock()
+        mock_scalar_result.all.return_value = [user1, user2]
+        mock_db.scalars = AsyncMock(return_value=mock_scalar_result)
 
         mock_redis = AsyncMock()
 


### PR DESCRIPTION
Closes #107

## Type
- [x] Maintenance/tooling (`type:chore`)

## Summary
- Aligns the tenant deactivation token revocation unit test mock with SQLAlchemy scalar result behavior.
- Keeps the branch scoped to the approved tenant test-only fix.

## Changes
| File | Change |
|------|--------|
| `tests/unit/test_tenants.py` | Wraps the mocked scalars result with an object exposing `.all()` instead of returning a raw list. |

## Test Plan
- [ ] Not run by executor; PR creation task only.

## Checklist
- [x] Linked approved issue with `Closes #107`
- [x] Added exactly one `type:*` label: `type:chore`
- [x] Conventional commit format
- [x] No source files modified during PR creation
- [x] No untracked files staged or committed