### PR TITLE
feat(f2): add base domain exceptions

### DIFF
--- a/app/core/exceptions.py
+++ b/app/core/exceptions.py
@@ -61,3 +61,21 @@ class LLMResponseError(LLMError):
 
     def __init__(self, detail: Any = None) -> None:
         super().__init__(detail, status_code=502)
+
+
+# ── F2 Domain Exceptions ───────────────────────────────────────────────
+
+class AssetError(AppError):
+    """Errores del modulo assets (F2)."""
+
+
+class ScanError(AppError):
+    """Errores del modulo scans (F2)."""
+
+
+class VulnerabilityError(AppError):
+    """Errores del modulo vulnerabilities (F2)."""
+
+
+class ReportError(AppError):
+    """Errores del modulo reports (F2)."""

--- a/openspec/changes/rescue-f2-domain-exceptions/apply-progress.md
+++ b/openspec/changes/rescue-f2-domain-exceptions/apply-progress.md
@@ -1,0 +1,83 @@
+# Apply Progress: Rescue F2 Domain Exceptions
+
+**Change**: rescue-f2-domain-exceptions
+**Mode**: Strict TDD (strict_tdd: true, pytest available)
+**Branch**: feat/f2-domain-exceptions
+**Source**: Manual extraction only from `origin/feat/f2-foundation-alignment` commit `99692c4`.
+
+## Completed Tasks
+
+### Phase 1: Guardrails / Extraction Prep
+- [x] 1.1 Verified only `app/core/exceptions.py` and `tests/unit/test_f2_exceptions.py` are sourced from `99692c4`; manual path extraction used.
+- [x] 1.2 No forbidden areas touched (CI, lifespan, tenant, docker/demo, migrations, routers/services, cherry-pick/merge).
+- [x] 1.3 Preserved existing exception style: appended after `LLMResponseError`, Spanish docstrings, `# ── F2 Domain Exceptions ──` separator.
+
+### Phase 2: RED — Test Rescue
+- [x] 2.1 Created `tests/unit/test_f2_exceptions.py` from source branch; renamed `test_asserterror_*` → `test_asseterror_*` and `test_scannerror_*` → `test_scanerror_*` only.
+- [x] 2.2 Test bodies unchanged (hierarchy, default/custom status, `str()`, no module-state leak).
+
+### Phase 3: GREEN — Code Rescue
+- [x] 3.1 Added `AssetError`, `ScanError`, `VulnerabilityError`, `ReportError` as bare `AppError` subclasses with no custom `__init__`.
+- [x] 3.2 Targeted tests pass; broader DB-backed tests blocked by missing local PostgreSQL service (port 5433), not by code changes.
+- [x] 3.3 No behavior drift, no new runtime imports, no module-state leak.
+
+### Phase 4: Review / PR Prep / Rollback
+- [x] 4.1 `git diff --stat` confirms only `app/core/exceptions.py` is modified among tracked files; `tests/unit/test_f2_exceptions.py` is new.
+- [x] 4.2 Reviewed edge cases: all four classes inherit `AppError.__init__` defaults (`status_code=400`), custom detail/status flows preserved, `str()` includes detail.
+- [x] 4.3 PR notes captured below; rollback is a single revert.
+
+## TDD Cycle Evidence
+
+| Task | Test File | Layer | Safety Net | RED | GREEN | TRIANGULATE | REFACTOR |
+|------|-----------|-------|------------|-----|-------|-------------|----------|
+| 2.1–3.1 | `tests/unit/test_f2_exceptions.py` | Unit | N/A (new file) | ✅ Written (ImportError before impl) | ✅ 25/25 passed | ✅ Parametrized + custom detail/status cases | ✅ Cleaned odd test names only |
+
+### Test Summary
+- **Total tests written/rescued**: 25 (11 methods via parametrize + individual cases)
+- **Total tests passing**: 25 (targeted F2 file)
+- **Layers used**: Unit
+- **Approval tests**: None — no refactoring of existing code
+- **Pure functions created**: N/A (exception classes)
+
+## Files Changed
+
+| File | Action | What Was Done |
+|------|--------|---------------|
+| `app/core/exceptions.py` | Modified | Appended 4 F2 domain exception classes (`AssetError`, `ScanError`, `VulnerabilityError`, `ReportError`) as bare `AppError` subclasses. |
+| `tests/unit/test_f2_exceptions.py` | Created | Rescued DB-free unit tests from source branch; cleaned odd test names (`asserterror`/`scannerror`) without changing assertions. |
+| `openspec/changes/rescue-f2-domain-exceptions/tasks.md` | Modified | Marked all tasks `[x]`. |
+| `openspec/changes/rescue-f2-domain-exceptions/apply-progress.md` | Created | This apply-progress artifact. |
+| `tests/unit/test_f2_exceptions.py` | Modified | Added missing `test_vulnerabilityerror_custom_status_code` case (post-apply review). |
+| `openspec/changes/rescue-f2-domain-exceptions/apply-progress.md` | Modified | Removed trailing whitespace; updated test counts and `--confcutdir` evidence (post-apply review). |
+
+## Post-Apply Review Fixes
+
+1. **Trailing whitespace**: Removed trailing spaces in the front-matter of `apply-progress.md` (lines 3–5). `git diff --check main...HEAD` now reports no whitespace errors.
+2. **Coverage gap**: Added `test_vulnerabilityerror_custom_status_code` so every F2 domain exception has an explicit custom-status-code test. Total targeted tests increased from 24 to 25; all pass.
+3. **DB fixture isolation**: Confirmed the targeted test command must use `--confcutdir=tests/unit` to bypass the session-scoped `prepare_database` fixture in the root `tests/conftest.py`. Without it, every test errors while connecting to PostgreSQL on `localhost:5433`. No `conftest.py` changes were made.
+
+## Deviations from Design
+
+None — implementation matches design.
+
+## Issues / Environment Blockers
+
+- `pytest tests/unit/test_tenants.py` and full `pytest tests/unit/` cannot run locally because the session-scoped `prepare_database` fixture requires a PostgreSQL instance on `localhost:5433`, and the Docker daemon is not available in this environment. The failures are connection errors (`OSError: [Errno 111] Connect call failed`), not code regressions.
+- The F2 exception tests are DB-free and pass with the isolated command `PYTHONPATH=. pytest --confcutdir=tests/unit tests/unit/test_f2_exceptions.py -v` (25 passed). Running the same file without `--confcutdir=tests/unit` errors during `prepare_database` setup because the root `tests/conftest.py` is loaded.
+
+## Workload / PR Boundary
+
+- **Mode**: single PR
+- **Current work unit**: Unit 1 — manual extract of the two allowed files
+- **Boundary**: Adds F2 exception classes + unit tests only; no runtime call-site changes
+- **Estimated review budget impact**: ~150 changed lines (well under 400-line budget)
+
+## PR Notes
+
+- Manual extraction only; do **not** cherry-pick `feat/f2-foundation-alignment`.
+- No forbidden-area files touched.
+- Rollback: revert the single commit on `feat/f2-domain-exceptions`.
+
+## Status
+
+11/11 tasks complete. Ready for verify (noting local DB service is unavailable for full unit-suite execution).

--- a/openspec/changes/rescue-f2-domain-exceptions/tasks.md
+++ b/openspec/changes/rescue-f2-domain-exceptions/tasks.md
@@ -1,0 +1,46 @@
+# Tasks: Rescue F2 Domain Exceptions
+
+## Review Workload Forecast
+
+| Field | Value |
+|-------|-------|
+| Estimated changed lines | ~150 (+ tasks artifact) |
+| 400-line budget risk | Low |
+| Chained PRs recommended | No |
+| Suggested split | Single PR |
+| Delivery strategy | ask-on-risk |
+| Chain strategy | N/A |
+
+Decision needed before apply: No
+Chained PRs recommended: No
+Chain strategy: N/A
+400-line budget risk: Low
+
+### Suggested Work Units
+
+| Unit | Goal | Likely PR | Notes |
+|------|------|-----------|-------|
+| 1 | Manual extract only the two allowed files from `origin/feat/f2-foundation-alignment` (`99692c4`) | PR 1 | No cherry-pick, no forbidden paths, no runtime call-site changes |
+
+## Phase 1: Guardrails / Extraction Prep
+
+- [x] 1.1 Verify only `app/core/exceptions.py` and `tests/unit/test_f2_exceptions.py` are sourced from `origin/feat/f2-foundation-alignment` commit `99692c4`; use manual path extraction only.
+- [x] 1.2 Keep forbidden areas untouched: `.github/workflows/ci.yml`, `tests/unit/test_main_lifespan.py`, `tests/unit/test_tenants.py`, `docker/**`, `docker-compose.yml`, `docs/demo.md`, `tests/verify_demo_target.sh`, migrations, routers/services/runtime call sites; no broad branch merge or broad cherry-pick.
+- [x] 1.3 Preserve existing exception style in `app/core/exceptions.py`: append after `LLMResponseError` with `# ── F2 Domain Exceptions ──` and Spanish docstrings.
+
+## Phase 2: RED — Test Rescue
+
+- [x] 2.1 Create `tests/unit/test_f2_exceptions.py` from the source branch and rename `test_asserterror_*`/`test_scannerror_*` to readable names only.
+- [x] 2.2 Keep the test body unchanged: hierarchy, default/custom status code, `str()`, and no module-state leak.
+
+## Phase 3: GREEN — Code Rescue
+
+- [x] 3.1 Add `AssetError`, `ScanError`, `VulnerabilityError`, and `ReportError` to `app/core/exceptions.py` as bare `AppError` subclasses with no custom `__init__`.
+- [x] 3.2 Re-run `pytest tests/unit/test_f2_exceptions.py -v` and then `pytest tests/unit/ -v`; fix only rescue-related issues if they appear.
+- [x] 3.3 Confirm no behavior drift, no new imports in runtime call sites, and no hidden state changes in the exception module.
+
+## Phase 4: Review / PR Prep / Rollback
+
+- [x] 4.1 Audit `git diff --stat` and `git diff` to ensure only the two allowed files changed.
+- [x] 4.2 Review edge cases and adjacent exception files; if any failure mode is unclear, stop and ask rather than shallow-pass.
+- [x] 4.3 Prepare PR notes with manual extraction only, explicit no-cherry-pick warning, and rollback via a single revert.

--- a/openspec/changes/rescue-f2-domain-exceptions/verify-report.md
+++ b/openspec/changes/rescue-f2-domain-exceptions/verify-report.md
@@ -1,0 +1,120 @@
+## Verification Report
+
+**Change**: rescue-f2-domain-exceptions
+**Version**: N/A — no F2 OpenSpec capability delta exists
+**Mode**: Strict TDD verify, HYBRID persistence
+**Branch / commit**: `feat/f2-domain-exceptions` / final amended HEAD
+
+### Completeness
+
+| Metric | Value |
+|--------|-------|
+| Required artifacts read | proposal, design, tasks, apply-progress |
+| Tasks total | 11 |
+| Tasks complete | 11 |
+| Tasks incomplete | 0 |
+| Changed files in `main...feat/f2-domain-exceptions` | 5 tracked files, 404 insertions |
+| Forbidden-path diff | None |
+
+### Build & Tests Execution
+
+**Targeted tests**: ✅ Passed
+```text
+PYTHONPATH=. .venv/bin/pytest --confcutdir=tests/unit tests/unit/test_f2_exceptions.py -q
+25 passed in 0.02s
+```
+
+**Broader unit suite**: ⚠️ Environment-blocked locally
+```text
+PYTHONPATH=. .venv/bin/pytest tests/unit -q
+243 setup errors in 56.95s while tests/conftest.py::prepare_database connects to localhost:5433.
+Representative error: OSError: Multiple exceptions: [Errno 111] Connect call failed ('::1', 5433), ('127.0.0.1', 5433)
+```
+Assessment: this is a local PostgreSQL service blocker, not an F2 exception regression. CI defines PostgreSQL/Redis services and database env vars, so CI is expected to run the broader suite.
+
+**Quality checks**: ✅ Passed
+```text
+.venv/bin/ruff check app/core/exceptions.py tests/unit/test_f2_exceptions.py
+All checks passed!
+
+.venv/bin/mypy app/core/exceptions.py tests/unit/test_f2_exceptions.py
+Success: no issues found in 2 source files
+```
+
+**Coverage**: ➖ Skipped — `openspec/config.yaml` marks coverage unavailable.
+
+### Proposal / Requirement Compliance Matrix
+
+| Requirement / Success Criterion | Evidence | Result |
+|---------------------------------|----------|--------|
+| Add `AssetError`, `ScanError`, `VulnerabilityError`, `ReportError` as `AppError` subclasses | `app/core/exceptions.py:66-81`; targeted inheritance tests passed | ✅ COMPLIANT |
+| Preserve inherited `status_code=400`, custom status, detail, and `str()` behavior | 25 targeted tests cover defaults, custom detail/status, and string detail | ✅ COMPLIANT |
+| No module-state leak | `test_f2_exceptions_do_not_leak_module_state` passed | ✅ COMPLIANT |
+| No runtime call-site changes | grep found class names only in `app/core/exceptions.py` and `tests/unit/test_f2_exceptions.py` | ✅ COMPLIANT |
+| No forbidden files touched | `git diff --name-status main...feat/f2-domain-exceptions -- <forbidden paths>` returned no files | ✅ COMPLIANT |
+| No cherry-pick / merge | `main..feat/f2-domain-exceptions` has one non-merge commit with one parent; no cherry-pick metadata | ✅ COMPLIANT |
+| Full unit suite green | Attempted, blocked by missing local PostgreSQL on `localhost:5433` | ⚠️ ENV-BLOCKED |
+
+### Correctness (Static Evidence)
+
+| Area | Status | Notes |
+|------|--------|-------|
+| Inheritance | ✅ Implemented | All four classes are bare `AppError` subclasses with no custom `__init__`. |
+| Class placement/style | ✅ Implemented | Appended after `LLMResponseError` with the F2 separator and Spanish docstrings. |
+| Source extraction | ✅ Implemented | `app/core/exceptions.py` matches `origin/feat/f2-foundation-alignment`; test file differs only by intended renames plus one extra coverage test. |
+| Diff boundary | ✅ Implemented | Tracked diff contains only `app/core/exceptions.py`, `tests/unit/test_f2_exceptions.py`, `tasks.md`, and `apply-progress.md`. |
+
+### Coherence (Design)
+
+| Decision | Followed? | Notes |
+|----------|-----------|-------|
+| Manual path extraction, no cherry-pick | ✅ Yes | History and diff show no merge/cherry-pick contamination. |
+| Bare subclasses, inherited interface | ✅ Yes | Constructor behavior remains inherited from `AppError`. |
+| DB-free targeted unit tests | ✅ Yes | Passes only when isolated from root DB fixture via `--confcutdir=tests/unit`. |
+| Keep forbidden areas untouched | ✅ Yes | CI, lifespan/tenant tests, docker/demo, migrations, routers/services were not changed. |
+
+### TDD Compliance
+
+| Check | Result | Details |
+|-------|--------|---------|
+| TDD Evidence reported | ✅ | `apply-progress.md` includes a TDD Cycle Evidence table. |
+| RED confirmed | ✅ | Test file exists and is new in `main...HEAD`. Historical RED cannot be re-run from current tree. |
+| GREEN confirmed | ✅ | Targeted file passes now: 25/25. |
+| Triangulation adequate | ✅ | Parametrized four-class coverage plus per-class custom detail/status cases. |
+| Safety net | ✅ | New behavior covered by new DB-free unit file. |
+
+### Test Layer Distribution
+
+| Layer | Tests | Files | Tools |
+|-------|-------|-------|-------|
+| Unit | 25 | 1 | pytest |
+| Integration | 0 | 0 | pytest + PostgreSQL available in CI, not local |
+| E2E | 0 | 0 | not available |
+| **Total** | **25** | **1** | |
+
+### Assertion Quality
+
+**Assertion quality**: ✅ All assertions call production exception classes and verify inheritance, instance type, detail, status code, string output, or state invariance. No tautologies, ghost loops, or type-only assertions used alone were found.
+
+### Issues Found
+
+**CRITICAL**: None.
+
+**WARNING**:
+- Full unit-suite execution is locally blocked by missing PostgreSQL on `localhost:5433`; CI should verify it with configured services.
+- `tasks.md` contains 11 checked tasks; `apply-progress.md` task count was corrected from `10/10` to `11/11` during final review.
+- The rescued test file is not strictly “assertions unchanged”: it intentionally adds `test_vulnerabilityerror_custom_status_code`. This is test-only and improves edge coverage, but it deviates from the proposal/task wording.
+- Workspace has unrelated untracked SDD/project artifacts outside this branch diff. They are not forbidden-path edits, but PR prep must stage only intended files.
+
+**SUGGESTION**:
+- In a future cleanup, isolate DB-free unit tests from the root autouse DB fixture so `tests/unit` does not require `--confcutdir` for pure unit files.
+
+### PR Readiness
+
+Implementation is PR-ready from a code-scope perspective: no CRITICAL findings, targeted tests and quality checks pass, forbidden files are untouched, and no merge/cherry-pick contamination was found. Before opening/merging, run CI or a local PostgreSQL-backed full suite and keep PR staging disciplined around the untracked OpenSpec/project artifacts.
+
+### Verdict
+
+PASS WITH WARNINGS
+
+The implementation matches the intended F2 exception rescue and passes the direct behavioral safety net; remaining warnings are environment/artifact-hygiene issues rather than implementation failures.

--- a/tests/unit/test_f2_exceptions.py
+++ b/tests/unit/test_f2_exceptions.py
@@ -1,0 +1,137 @@
+"""Unit tests for F2 domain exceptions — DB-free.
+
+These tests verify that the four F2 domain exception classes
+(AssetError, ScanError, VulnerabilityError, ReportError) exist,
+subclass AppError correctly, and carry appropriate status codes.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.core.exceptions import (
+    AppError,
+    AssetError,
+    ReportError,
+    ScanError,
+    VulnerabilityError,
+)
+
+
+class TestF2DomainExceptions:
+    """Verify F2 domain exception hierarchy and behavior."""
+
+    # ── existence and inheritance ──────────────────────────────────────
+
+    @pytest.mark.parametrize(
+        "exc_class",
+        [AssetError, ScanError, VulnerabilityError, ReportError],
+    )
+    def test_f2_exception_subclasses_app_error(self, exc_class: type) -> None:
+        """Each F2 domain exception MUST subclass AppError."""
+        assert issubclass(exc_class, AppError), (
+            f"{exc_class.__name__} does not subclass AppError"
+        )
+
+    @pytest.mark.parametrize(
+        "exc_class",
+        [AssetError, ScanError, VulnerabilityError, ReportError],
+    )
+    def test_f2_exception_is_instantiable(self, exc_class: type) -> None:
+        """Each F2 domain exception MUST be instantiable without arguments."""
+        instance = exc_class()
+        assert isinstance(instance, exc_class)
+        assert isinstance(instance, AppError)
+        assert isinstance(instance, Exception)
+
+    # ── default status code ────────────────────────────────────────────
+
+    @pytest.mark.parametrize(
+        "exc_class",
+        [AssetError, ScanError, VulnerabilityError, ReportError],
+    )
+    def test_f2_exception_default_status_code_is_400(self, exc_class: type) -> None:
+        """F2 domain exceptions inherit AppError's default status_code=400."""
+        instance = exc_class()
+        assert instance.status_code == 400, (
+            f"{exc_class.__name__}.status_code expected 400, got {instance.status_code}"
+        )
+
+    # ── custom detail ──────────────────────────────────────────────────
+
+    def test_asseterror_with_custom_detail(self) -> None:
+        """AssetError MUST accept and store custom detail."""
+        exc = AssetError("Asset not found")
+        assert exc.detail == "Asset not found"
+        assert exc.status_code == 400
+
+    def test_scanerror_with_custom_detail(self) -> None:
+        """ScanError MUST accept and store custom detail."""
+        exc = ScanError("Scan timed out")
+        assert exc.detail == "Scan timed out"
+        assert exc.status_code == 400
+
+    def test_vulnerabilityerror_with_custom_detail(self) -> None:
+        """VulnerabilityError MUST accept and store custom detail."""
+        exc = VulnerabilityError("Duplicate fingerprint")
+        assert exc.detail == "Duplicate fingerprint"
+
+    def test_reporterror_with_custom_detail(self) -> None:
+        """ReportError MUST accept and store custom detail."""
+        exc = ReportError("PDF generation failed")
+        assert exc.detail == "PDF generation failed"
+
+    # ── custom status code ─────────────────────────────────────────────
+
+    def test_asseterror_custom_status_code(self) -> None:
+        """AssetError MUST support custom status_code via kwargs."""
+        exc = AssetError("Limit exceeded", status_code=422)
+        assert exc.status_code == 422
+        assert exc.detail == "Limit exceeded"
+
+    def test_scanerror_custom_status_code(self) -> None:
+        """ScanError MUST support custom status_code."""
+        exc = ScanError("Quota exhausted", status_code=429)
+        assert exc.status_code == 429
+
+    def test_vulnerabilityerror_custom_status_code(self) -> None:
+        """VulnerabilityError MUST support custom status_code."""
+        exc = VulnerabilityError("Duplicate fingerprint", status_code=409)
+        assert exc.status_code == 409
+
+    def test_reporterror_custom_status_code(self) -> None:
+        """ReportError MUST support custom status_code."""
+        exc = ReportError("Report expired", status_code=410)
+        assert exc.status_code == 410
+
+    # ── string representation ──────────────────────────────────────────
+
+    @pytest.mark.parametrize(
+        "exc_class,detail",
+        [
+            (AssetError, "bad asset"),
+            (ScanError, "scan failure"),
+            (VulnerabilityError, "vuln conflict"),
+            (ReportError, "report missing"),
+        ],
+    )
+    def test_f2_exception_str_contains_detail(
+        self, exc_class: type, detail: str
+    ) -> None:
+        """Exception string representation MUST include the detail message."""
+        exc = exc_class(detail)
+        assert detail in str(exc)
+
+    # ── no accidental side effects ─────────────────────────────────────
+
+    def test_f2_exceptions_do_not_leak_module_state(self) -> None:
+        """Instantiating F2 exceptions MUST NOT modify global state."""
+        # Pre-condition: known classes
+        before = {AssetError, ScanError, VulnerabilityError, ReportError}
+        # Instantiate all
+        AssetError()
+        ScanError()
+        VulnerabilityError()
+        ReportError()
+        after = {AssetError, ScanError, VulnerabilityError, ReportError}
+        assert before == after


### PR DESCRIPTION
### Summary
Rescues the foundational F2 domain exception types (`AssetError`, `ScanError`, `VulnerabilityError`, `ReportError`) into `main` as the first incremental slice of the main-based F2 rescue chain. Manual extraction only; no cherry-pick, no forbidden-area changes.

Closes #91

### Changes

| File | Change |
|---|---|
| `app/core/exceptions.py` | Append four bare `AppError` subclasses with Spanish docstrings and F2 separator |
| `tests/unit/test_f2_exceptions.py` | Add DB-free unit tests covering inheritance, default/custom status codes, detail, `str()`, and module-state invariance |
| `openspec/changes/rescue-f2-domain-exceptions/tasks.md` | Mark all 11 tasks complete |
| `openspec/changes/rescue-f2-domain-exceptions/apply-progress.md` | Apply progress artifact (11/11 tasks complete) |
| `openspec/changes/rescue-f2-domain-exceptions/verify-report.md` | Verification report |

### Test Plan
- Targeted: `PYTHONPATH=. .venv/bin/pytest --confcutdir=tests/unit tests/unit/test_f2_exceptions.py -q` → **25 passed**.
- Quality: `ruff check app/core/exceptions.py tests/unit/test_f2_exceptions.py` → all passed; `mypy app/core/exceptions.py tests/unit/test_f2_exceptions.py` → no issues.
- Full local unit suite (`pytest tests/unit`) is blocked by missing PostgreSQL on `localhost:5433`; CI provides the required DB services and should run the broader suite.

### Contributor Checklist
- [x] I have read the contribution guidelines.
- [x] The change is scoped to the allowed files only.
- [x] No forbidden-area files (CI, lifespan, tenant, docker/demo, migrations, routers/services) were touched.
- [x] Targeted tests and quality checks pass.
- [ ] Full local unit suite verified (environment-blocked; pending CI).

### Warnings
- This branch is part of a delicate structural rescue phase. Do **not** broad cherry-pick `feat/f2-foundation-alignment`; changes were manually extracted.
- The rescued test file intentionally renames `test_asserterror_*`/`test_scannerror_*` to readable names and adds `test_vulnerabilityerror_custom_status_code` for extra coverage; assertions are otherwise unchanged.
