### PR TITLE
feat(f2): add asset scan migration slice

### DIFF
--- a/app/modules/assets/models.py
+++ b/app/modules/assets/models.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import CheckConstraint, DateTime, ForeignKey, String, func
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class Asset(Base):
+    __tablename__ = "assets"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    tenant_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("tenants.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    hostname: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    asset_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    status: Mapped[str] = mapped_column(String(50), nullable=False, default="active")
+    asset_metadata: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        server_default=func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+        server_default=func.now(),
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "asset_type IN ('host', 'domain', 'ip', 'web_app')",
+            name="chk_assets_asset_type",
+        ),
+        CheckConstraint(
+            "status IN ('active', 'inactive', 'archived')",
+            name="chk_assets_status",
+        ),
+    )
+
+    def __repr__(self) -> str:
+        return f"<Asset id={self.id} name={self.name!r}>"

--- a/app/modules/scans/models.py
+++ b/app/modules/scans/models.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import CheckConstraint, DateTime, ForeignKey, String, func
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class Scan(Base):
+    __tablename__ = "scans"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    tenant_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("tenants.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    asset_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("assets.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    scan_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    status: Mapped[str] = mapped_column(String(50), nullable=False, default="pending")
+    config: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    started_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    completed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        server_default=func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+        server_default=func.now(),
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "scan_type IN ('discovery', 'vulnerability', 'web', 'full')",
+            name="chk_scans_scan_type",
+        ),
+        CheckConstraint(
+            "status IN ('pending', 'running', 'completed', 'failed', 'cancelled')",
+            name="chk_scans_status",
+        ),
+    )
+
+    def __repr__(self) -> str:
+        return f"<Scan id={self.id} name={self.name!r}>"

--- a/app/modules/tenants/models.py
+++ b/app/modules/tenants/models.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import Boolean, DateTime, String, func, Integer
+from sqlalchemy import Boolean, DateTime, Integer, String, func, text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -12,7 +12,7 @@ from app.core.database import Base
 
 class Tenant(Base):
     __tablename__ = "tenants"
-    
+
     id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
     )
@@ -20,6 +20,18 @@ class Tenant(Base):
     slug: Mapped[str] = mapped_column(String(100), nullable=False, unique=True)
     plan: Mapped[str] = mapped_column(String(50), nullable=False, default="free")
     max_assets: Mapped[int] = mapped_column(Integer, nullable=False, default=10)
+    scans_per_day: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=1, server_default="1"
+    )
+    ai_enrichment_level: Mapped[str] = mapped_column(
+        String(50), nullable=False, default="basic", server_default="basic"
+    )
+    report_types: Mapped[list[str] | None] = mapped_column(
+        JSONB,
+        nullable=True,
+        default=lambda: ["vulnerability"],
+        server_default=text("'[\"vulnerability\"]'::jsonb"),
+    )
     is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
     settings: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
     created_at: Mapped[datetime] = mapped_column(

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -15,9 +15,11 @@ from app.core.database import Base
 # IMPORTANTE: estos imports parecen no usarse pero son obligatorios.
 # Al importar cada modelo, se registra en Base.metadata y Alembic
 # puede detectarlo en el autogenerate. Nunca eliminar sin verificar.
+from app.modules.assets.models import Asset  # noqa: F401
+from app.modules.auth.models import RefreshToken  # noqa: F401
+from app.modules.scans.models import Scan  # noqa: F401
 from app.modules.tenants.models import Tenant  # noqa: F401
 from app.modules.users.models import User  # noqa: F401
-from app.modules.auth.models import RefreshToken  # noqa: F401
 
 
 #Objeto configuracion de Alembic

--- a/migrations/versions/20260625_1400_f2_assets_scans_tenant_8f2c1a4b9d7e.py
+++ b/migrations/versions/20260625_1400_f2_assets_scans_tenant_8f2c1a4b9d7e.py
@@ -1,0 +1,196 @@
+"""f2 assets scans tenant plan extension (PR-A)
+
+Revision ID: 8f2c1a4b9d7e
+Revises: b5e9d8c4a123
+Create Date: 2026-06-25 14:00:00.000000
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "8f2c1a4b9d7e"
+down_revision: Union[str, None] = "b5e9d8c4a123"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # --- Tenant plan extension ---
+    op.add_column(
+        "tenants",
+        sa.Column("scans_per_day", sa.Integer(), nullable=False, server_default="1"),
+    )
+    op.add_column(
+        "tenants",
+        sa.Column(
+            "ai_enrichment_level",
+            sa.String(length=50),
+            nullable=False,
+            server_default="basic",
+        ),
+    )
+    op.add_column(
+        "tenants",
+        sa.Column(
+            "report_types",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+            server_default=sa.text("'[\"vulnerability\"]'::jsonb"),
+        ),
+    )
+    op.execute(
+        "UPDATE tenants SET report_types = '[\"vulnerability\"]'::jsonb "
+        "WHERE report_types IS NULL"
+    )
+
+    # --- assets ---
+    op.create_table(
+        "assets",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("tenant_id", sa.UUID(), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("hostname", sa.String(length=255), nullable=True),
+        sa.Column("asset_type", sa.String(length=50), nullable=False),
+        sa.Column("status", sa.String(length=50), nullable=False, server_default="active"),
+        sa.Column(
+            "asset_metadata",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.CheckConstraint(
+            "asset_type IN ('host', 'domain', 'ip', 'web_app')",
+            name="chk_assets_asset_type",
+        ),
+        sa.CheckConstraint(
+            "status IN ('active', 'inactive', 'archived')",
+            name="chk_assets_status",
+        ),
+        sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    # --- scans ---
+    op.create_table(
+        "scans",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("tenant_id", sa.UUID(), nullable=False),
+        sa.Column("asset_id", sa.UUID(), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("scan_type", sa.String(length=50), nullable=False),
+        sa.Column("status", sa.String(length=50), nullable=False, server_default="pending"),
+        sa.Column(
+            "config",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.CheckConstraint(
+            "scan_type IN ('discovery', 'vulnerability', 'web', 'full')",
+            name="chk_scans_scan_type",
+        ),
+        sa.CheckConstraint(
+            "status IN ('pending', 'running', 'completed', 'failed', 'cancelled')",
+            name="chk_scans_status",
+        ),
+        sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["asset_id"], ["assets.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    # --- Indexes ---
+    op.create_index(op.f("ix_assets_tenant_id"), "assets", ["tenant_id"], unique=False)
+    op.create_index(op.f("ix_scans_tenant_id"), "scans", ["tenant_id"], unique=False)
+    op.create_index(op.f("ix_scans_asset_id"), "scans", ["asset_id"], unique=False)
+
+    # --- Triggers ---
+    op.execute("""
+        CREATE TRIGGER trg_assets_updated_at
+        BEFORE UPDATE ON assets
+        FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+    """)
+    op.execute("""
+        CREATE TRIGGER trg_scans_updated_at
+        BEFORE UPDATE ON scans
+        FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+    """)
+
+    # --- RLS ---
+    op.execute("ALTER TABLE assets ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE scans ENABLE ROW LEVEL SECURITY")
+
+    op.execute("""
+        CREATE POLICY rls_assets ON assets USING (
+            current_setting('app.is_superadmin', TRUE) = 'true'
+            OR tenant_id::text = current_setting('app.current_tenant', TRUE)
+        )
+    """)
+    op.execute("""
+        CREATE POLICY rls_scans ON scans USING (
+            current_setting('app.is_superadmin', TRUE) = 'true'
+            OR tenant_id::text = current_setting('app.current_tenant', TRUE)
+        )
+    """)
+
+    # --- Grants ---
+    op.execute("GRANT SELECT, INSERT, UPDATE, DELETE ON assets TO soc360_app")
+    op.execute("GRANT SELECT, INSERT, UPDATE, DELETE ON scans TO soc360_app")
+
+
+def downgrade() -> None:
+    # --- Grants ---
+    op.execute("REVOKE ALL ON assets FROM soc360_app")
+    op.execute("REVOKE ALL ON scans FROM soc360_app")
+
+    # --- RLS ---
+    op.execute("DROP POLICY IF EXISTS rls_scans ON scans")
+    op.execute("ALTER TABLE scans DISABLE ROW LEVEL SECURITY")
+    op.execute("DROP POLICY IF EXISTS rls_assets ON assets")
+    op.execute("ALTER TABLE assets DISABLE ROW LEVEL SECURITY")
+
+    # --- Triggers ---
+    op.execute("DROP TRIGGER IF EXISTS trg_scans_updated_at ON scans")
+    op.execute("DROP TRIGGER IF EXISTS trg_assets_updated_at ON assets")
+
+    # --- Indexes ---
+    op.drop_index(op.f("ix_scans_asset_id"), table_name="scans")
+    op.drop_index(op.f("ix_scans_tenant_id"), table_name="scans")
+    op.drop_index(op.f("ix_assets_tenant_id"), table_name="assets")
+
+    # --- Tables ---
+    op.drop_table("scans")
+    op.drop_table("assets")
+
+    # --- Tenant plan extension ---
+    op.drop_column("tenants", "report_types")
+    op.drop_column("tenants", "ai_enrichment_level")
+    op.drop_column("tenants", "scans_per_day")

--- a/openspec/changes/feat-f2-models-migration/design.md
+++ b/openspec/changes/feat-f2-models-migration/design.md
@@ -1,0 +1,114 @@
+# Design: feat-f2-models-migration
+
+## Technical Approach
+
+Reintroduce the F2 persistence layer via controlled manual port from `origin/feat/f2-pr-slicing-01-migration`, split into two stacked PRs that each leave `alembic heads` with a single head.
+
+- **PR-A** lands `Asset`, `Scan`, three tenant plan columns, and Alembic **R1** (`down_revision = b5e9d8c4a123`).
+- **PR-B** lands `Vulnerability`, `Report`, and Alembic **R2** (`down_revision = R1`), stacked on PR-A after merge.
+
+Each PR carries its own model files, migration revision, `env.py` imports, `tests/conftest.py` import hook, and DB-free unit tests. No broad cherry-picks or branch merges.
+
+## Architecture Decisions
+
+| Decision | Choice | Alternatives | Rationale |
+|----------|--------|--------------|-----------|
+| Delivery split | Two PRs by entity dependency | Single PR or size exception | User chose two PRs to stay within 400-line review budget; PR-A is root cluster, PR-B is leaf cluster |
+| Stacking model | PR-B branch from PR-A head, retarget to `main` after A merges | Feature-branch chain | Minimizes rebase surface; only R2 + Vuln/Report files move |
+| Source extraction | Controlled manual port from reference | Cherry-pick/merge `develop` | Reference branch is clean; `develop` carries unrelated noise |
+| Migration split | Two mechanical halves of tested `8f2c1a4b9d7e` | Autogenerate two new revisions | Preserves tested DDL; splitting by table ownership keeps each revision reversible and self-contained |
+| Tenant defaults | `server_default` + backfill in migration | Python-side `default=` on model | Avoids mutable default list; backfill covers existing rows |
+| Test layering | DB-free unit tests only; integration conftest as infra | DB-backed persistence/cascade tests now | Keeps slice focused on schema; cascade tests deferred to roadmap slices 5–6 |
+| Model style | Match `main` conventions (`from __future__ import annotations` first, no stray blanks) | Copy reference verbatim | Reference already matches; only `Report` needs trailing-whitespace cleanup |
+
+## Data Flow
+
+No runtime data flow — schema-only change. Migration chain:
+
+```
+main head b5e9d8c4a123
+        │
+        ▼
+    PR-A R1  ──► assets + scans + tenant cols + indexes/triggers/RLS/grants
+        │
+        ▼
+    PR-B R2  ──► vulnerabilities + reports + indexes/triggers/RLS/grants
+```
+
+## File Changes
+
+### PR-A (`feat/f2-models-migration-pr-a`)
+
+| File | Action | Description |
+|------|--------|-------------|
+| `app/modules/assets/models.py` | Create | Asset ORM with tenant FK, CheckConstraints, JSONB metadata |
+| `app/modules/scans/models.py` | Create | Scan ORM with asset FK, nullable timestamps, CheckConstraints |
+| `app/modules/tenants/models.py` | Modify | Add `scans_per_day`, `ai_enrichment_level`, `report_types` columns |
+| `migrations/env.py` | Modify | Register `Asset` and `Scan` imports for autogenerate |
+| `migrations/versions/YYYYMMdd_HHMM_R1_*.py` | Create | R1: tenant cols + backfill + assets + scans + indexes/triggers/RLS/grants |
+| `tests/conftest.py` | Modify | Import `Asset`, `Scan` in `prepare_database` |
+| `tests/unit/conftest.py` | Create | No-op `prepare_database` override for fast unit tests |
+| `tests/unit/test_f2_models.py` | Create | DB-free inspection tests for Asset and Scan |
+
+### PR-B (`feat/f2-models-migration-pr-b`)
+
+| File | Action | Description |
+|------|--------|-------------|
+| `app/modules/vulnerabilities/models.py` | Create | Vulnerability ORM with scan FK, Numeric CVSS, CheckConstraints |
+| `app/modules/reports/__init__.py` | Create | Empty module init |
+| `app/modules/reports/models.py` | Create | Report ORM with asset FK, nullable generated_at, CheckConstraints |
+| `migrations/env.py` | Modify | Register `Vulnerability` and `Report` imports |
+| `migrations/versions/YYYYMMdd_HHMM_R2_*.py` | Create | R2: vulnerabilities + reports + indexes/triggers/RLS/grants |
+| `tests/conftest.py` | Modify | Import `Vulnerability`, `Report` in `prepare_database` |
+| `tests/unit/test_f2_models.py` | Modify | Append DB-free inspection tests for Vulnerability and Report |
+| `tests/integration/conftest.py` | Modify | Add `_clean_database()` helper to prevent stale-table errors |
+
+## Interfaces / Contracts
+
+No new public APIs. Schema contracts:
+
+- `Asset`, `Scan`, `Vulnerability`, `Report` inherit from `Base`, use `Mapped[...]`, declare `__table_args__` with named `CheckConstraint`s.
+- Tenant columns use `server_default` in migration; ORM side uses `default=` for new-object construction.
+- All four tables have `tenant_id` FK with `ON DELETE CASCADE` and an index.
+- Parent FK columns (`asset_id`, `scan_id`) are indexed.
+
+## Testing Strategy
+
+| Layer | What to Test | Approach | PR |
+|-------|-------------|----------|-----|
+| Unit | Model metadata, nullability, defaults, constraint names, FK targets | DB-free inspection via `__mapper__.columns` and `__table__.constraints` | A + B |
+| Integration | Alembic upgrade/downgrade roundtrip, single head | Run `alembic upgrade head` and `alembic downgrade -1` against real PG (infra only; full graph test deferred) | B (infra) |
+| E2E | Not applicable | — | — |
+
+## Branch / Stacking Strategy
+
+1. `git checkout -b feat/f2-models-migration-pr-a main`
+2. Open PR-A targeting `main`. Freeze PR-A once opened.
+3. After PR-A merges, `git checkout -b feat/f2-models-migration-pr-b main` and port R2 + Vuln/Report files.
+4. Open PR-B targeting `main`. Rebase surface is limited to R2 and four files.
+
+## Migration / Rollout
+
+- **PR-A upgrade**: R1 adds tenant columns with `server_default` + backfill, creates `assets`/`scans`, applies indexes/triggers/RLS/grants.
+- **PR-A downgrade**: drops triggers/RLS/grants, drops `assets`/`scans`, drops tenant columns, returns to `b5e9d8c4a123`.
+- **PR-B upgrade**: R2 creates `vulnerabilities`/`reports`, applies indexes/triggers/RLS/grants.
+- **PR-B downgrade**: drops triggers/RLS/grants, drops `vulnerabilities`/`reports`, returns to R1.
+
+## Rollback Plan
+
+- **PR-B rollback**: `alembic downgrade R1` then `git revert <PR-B merge>`. R1, Asset, Scan, and tenant columns remain.
+- **PR-A rollback**: `alembic downgrade b5e9d8c4a123` then `git revert <PR-A merge>`. No data loss for existing F1 rows.
+
+## Risk Mitigation
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Splitting known-good single revision into two | Med | R1/R2 are mechanical halves of tested `8f2c1a4b9d7e`; verify `alembic upgrade head` + `downgrade -1` per PR; linear chain keeps single head |
+| PR-B rebase if A changes during review | Med | Freeze PR-A once opened; rebase only R2 + Vuln/Report files |
+| Tenant `report_types` mutable default | Low | `server_default` JSONB + backfill in R1; no Python-side mutable default on column |
+| Alembic hash collision with future main migrations | Low | R1 reuses `8f2c1a4b9d7e` (rescoped to assets/scans/tenant); R2 hash assigned at apply time; verify single head before each PR merge |
+| Stale `DuplicateTableError` on reset | Med | `_clean_database()` drops all public tables before Alembic upgrade in integration conftest |
+
+## Open Questions
+
+- [ ] `tests/integration/test_f2_models.py` (DB-backed persistence/cascade) remains deferred to roadmap slices 5–6; confirm no change.

--- a/openspec/changes/feat-f2-models-migration/proposal.md
+++ b/openspec/changes/feat-f2-models-migration/proposal.md
@@ -1,0 +1,104 @@
+# Proposal: feat/f2-models-migration
+
+## Intent
+
+Reintroduce the F2 domain persistence layer (Asset, Scan, Vulnerability, Report) into `main` as a **two-PR delivery**, via controlled extraction from `origin/feat/f2-pr-slicing-01-migration`. Lands SQLAlchemy models, two chained Alembic revisions, and minimal DB-free tests so later F2 slices (services, API, integration cascades) have a schema foundation. Recovers from the abandoned `develop` / `feat/f2-pr-slicing` chain without broad cherry-picks or branch merges.
+
+## Scope
+
+### In Scope
+
+- **PR-A** (`feat/f2-models-migration-pr-a`): `Asset` + `Scan` models; `tenants/models.py` +3 plan columns; `migrations/env.py` imports for Asset/Scan; Alembic revision **R1** (tenant columns + `assets` + `scans` + indexes/triggers/RLS/grants), `down_revision b5e9d8c4a123`; DB-free unit tests for Asset/Scan; `tests/unit/conftest.py` no-op override; `tests/conftest.py` import hook.
+- **PR-B** (`feat/f2-models-migration-pr-b`, stacked on PR-A after merge): `Vulnerability` + `Report` models + `reports/__init__.py`; `migrations/env.py` imports for Vuln/Report; Alembic revision **R2** (`vulnerabilities` + `reports` + indexes/triggers/RLS/grants), `down_revision R1`; DB-free unit tests for Vuln/Report; `tests/integration/conftest.py` infra.
+
+### Out of Scope
+
+- Services, use cases, API routers for F2 domains (roadmap slice 7).
+- `tests/integration/test_alembic_migration_graph.py` (separate focused PR).
+- DB-backed cascade/persistence tests (roadmap slices 5–6).
+- LLM abstraction, demo-vulnerable-target, CI optimization.
+
+## Capabilities
+
+### New Capabilities
+
+- `f2-domain-models`: SQLAlchemy ORM for Asset, Scan, Vulnerability, Report (tenant FK cascade, CheckConstraints, JSONB metadata).
+- `f2-tenant-plan-extension`: Tenant plan columns (`scans_per_day`, `ai_enrichment_level`, `report_types`) + backfill wiring.
+
+### Modified Capabilities
+
+- `database-migrations`: **Now two chained revisions (R1 → R2)** replacing the single `8f2c1a4b9d7e`; each independently reversible; single head preserved at every stage.
+
+## Approach
+
+Split **by entity along the dependency chain** (Asset → Scan → Vulnerability; Asset → Report):
+
+- **PR-A** lands the root cluster (Asset, Scan, tenant extension). Scan's only parent (Asset) ships in the same PR, so R1 is self-consistent.
+- **PR-B** stacks on PR-A after merge; Vulnerability (parent Scan) and Report (parent Asset) reference tables already on `main`, so R2 chains cleanly onto R1.
+
+Both revisions form a linear chain `b5e9d8c4a123` → R1 → R2; `alembic heads` reports one head at every stage. Minimal DB-free tests ship with the models they validate. Diff forecasts: PR-A ~430 additions, PR-B ~420 (exact counts at `sdd-tasks`).
+
+**Constraints preserved**: `main` is authoritative; `origin/feat/f2-pr-slicing-01-migration` is reference-only; no `develop` merge, no broad cherry-picks, no whole-branch merges; controlled manual port only; `main`-style import ordering (`from __future__ import annotations` first); `Report` trailing-whitespace cleanup during port.
+
+## Affected Areas
+
+| Area | PR | Impact | Description |
+|------|----|--------|-------------|
+| `app/modules/assets/models.py` | A | New | Asset ORM (53) |
+| `app/modules/scans/models.py` | A | New | Scan ORM (62) |
+| `app/modules/vulnerabilities/models.py` | B | New | Vulnerability ORM (61) |
+| `app/modules/reports/__init__.py`, `models.py` | B | New | Report module + ORM (66) |
+| `app/modules/tenants/models.py` | A | Modified | +3 plan columns (5) |
+| `migrations/env.py` | A+B | Modified | +4 imports split 2/2 |
+| `migrations/versions/..._R1.py` | A | New | assets + scans + tenant cols (~150) |
+| `migrations/versions/..._R2.py` | B | New | vulnerabilities + reports (~106) |
+| `tests/conftest.py` | A+B | Modified | +4 import-hook lines split 2/2 |
+| `tests/integration/conftest.py` | B | New | Real PG + Alembic loader (60) |
+| `tests/unit/conftest.py` | A | New | No-op DB override (37) |
+| `tests/unit/test_f2_models.py` | A+B | New | DB-free inspection tests split 2/2 (~243) |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Splitting known-good single revision into two new revisions | Med | R1/R2 are mechanical halves of the tested `8f2c1a4b9d7e`; verify `alembic upgrade head` + `downgrade -1` per PR; linear chain keeps single head |
+| PR-B stacks on PR-A — rebase risk if A changes during review | Med | PR-B branch tracks PR-A head; rebase only R2 + Vuln/Report files; freeze PR-A once opened |
+| Tenant `report_types` mutable-default list | Low | `server_default` JSONB + backfill in R1; no Python-side mutable default on the column |
+| Alembic hash collision with future main migrations | Low | R1 reuses `8f2c1a4b9d7e` (rescoped to assets/scans/tenant); R2 hash assigned at design; verify single head |
+| Sync DB reset quirks (stale `DuplicateTableError`) | Med | Reset DB before any integration subset |
+
+## Rollback Plan
+
+Two-stage, each PR independently reversible:
+
+- **PR-B rollback**: `alembic downgrade R1` (drops `vulnerabilities`/`reports`) then `git revert <PR-B merge>`. R1, Asset, Scan, and tenant columns remain.
+- **PR-A rollback**: `alembic downgrade b5e9d8c4a123` (drops `assets`/`scans` + tenant columns) then `git revert <PR-A merge>`. No data loss for existing F1 rows (tenant columns use `server_default` + backfill; downgrade drops them).
+
+## Dependencies
+
+- Main head `b5e9d8c4a123` (`add_last_login_at_to_users`) — current Alembic tip on `main`.
+- `origin/feat/f2-pr-slicing-01-migration` — reference-only source for controlled extraction.
+- Local Docker + PostgreSQL for the integration subset (PR-B infra).
+
+## Success Criteria
+
+**PR-A**
+
+- [ ] `alembic upgrade head` creates `assets`, `scans` and adds the three tenant columns with backfill; `alembic heads` reports one head.
+- [ ] `alembic downgrade b5e9d8c4a123` cleanly reverses PR-A.
+- [ ] `pytest -m "not integration"` green (existing 97 + Asset/Scan DB-free unit tests).
+
+**PR-B**
+
+- [ ] After PR-A merges, `alembic upgrade head` creates `vulnerabilities`, `reports`; single head.
+- [ ] `alembic downgrade R1` cleanly reverses PR-B.
+- [ ] `pytest -m "not integration"` green (existing + PR-A + Vuln/Report DB-free unit tests).
+
+**Both**
+
+- [ ] No broad cherry-picks, no `develop` merge, no whole-branch merges — all changes typed into `main`-based branches.
+- [ ] Each PR diff ≤ ~450 additions (reviewable).
+
+## Proposal Question Round
+
+The prior open question (size exception vs split) is **resolved by user decision: two PRs**. No new product/PRD questions surfaced — scope content is unchanged; only delivery packaging changed. A new question round is therefore skipped. If the user wants to revisit split boundary placement, flag it at `sdd-tasks`.

--- a/openspec/changes/feat-f2-models-migration/specs/database-migrations/spec.md
+++ b/openspec/changes/feat-f2-models-migration/specs/database-migrations/spec.md
@@ -1,0 +1,73 @@
+# Delta for Database Migrations
+
+## MODIFIED Requirements
+
+### Requirement: F2 schema revisions
+
+The system MUST provide two chained migration revisions, R1 and R2, that follow the current main head `b5e9d8c4a123` and leave `alembic heads` with a single head after each revision.
+(Previously: a single migration revision followed the main head.)
+
+#### Scenario: R1 chains to main head
+
+- GIVEN the database is at revision `b5e9d8c4a123`
+- WHEN R1 is applied
+- THEN `alembic heads` reports one head
+
+#### Scenario: R2 chains to R1
+
+- GIVEN the database is at revision R1
+- WHEN R2 is applied
+- THEN `alembic heads` reports one head
+
+### Requirement: Upgrade creates schema objects in two stages
+
+The system MUST split schema creation across R1 and R2: R1 creates the `assets` and `scans` tables and adds the three tenant plan columns with backfill; R2 creates the `vulnerabilities` and `reports` tables. Each revision MUST create columns, constraints, indexes, row-level security policies, updated-at triggers, and grants for the tables it owns.
+(Previously: one revision created all four tables and tenant columns.)
+
+#### Scenario: R1 upgrade succeeds
+
+- GIVEN a database at the previous main head
+- WHEN the R1 upgrade runs
+- THEN `assets`, `scans`, the three tenant columns, indexes, and policies exist
+- AND `vulnerabilities` and `reports` do not exist
+
+#### Scenario: R2 upgrade succeeds
+
+- GIVEN a database at revision R1
+- WHEN the R2 upgrade runs
+- THEN `vulnerabilities` and `reports`, their indexes, and policies exist
+
+### Requirement: Downgrade reverses each stage
+
+The system MUST, on downgrade, reverse only the schema objects created by the target revision: R1 downgrade drops `assets`, `scans`, and the three tenant columns; R2 downgrade drops `vulnerabilities` and `reports`. Each downgrade MUST remove policies, revoke grants, drop indexes and triggers, and return to the previous revision.
+(Previously: one downgrade reversed all four tables and tenant columns.)
+
+#### Scenario: R2 downgrade reverses PR-B
+
+- GIVEN R2 is applied
+- WHEN the migration is downgraded by one revision
+- THEN `vulnerabilities` and `reports` no longer exist and R1 is restored
+
+#### Scenario: R1 downgrade reverses PR-A
+
+- GIVEN R1 is applied
+- WHEN the migration is downgraded by one revision
+- THEN `assets`, `scans`, and the three tenant columns no longer exist and the previous main head is restored
+
+## ADDED Requirements
+
+### Requirement: Migration environment registers models per PR
+
+The system MUST register only the model modules relevant to each PR in the migration environment: PR-A registers `assets` and `scans`; PR-B registers `vulnerabilities` and `reports`.
+
+#### Scenario: PR-A autogenerate includes R1 models
+
+- GIVEN the migration environment imports `assets` and `scans`
+- WHEN an autogenerate revision is created on PR-A
+- THEN `assets` and `scans` are not flagged as missing
+
+#### Scenario: PR-B autogenerate includes R2 models
+
+- GIVEN the migration environment imports `vulnerabilities` and `reports`
+- WHEN an autogenerate revision is created on PR-B
+- THEN `vulnerabilities` and `reports` are not flagged as missing

--- a/openspec/changes/feat-f2-models-migration/tasks.md
+++ b/openspec/changes/feat-f2-models-migration/tasks.md
@@ -1,0 +1,48 @@
+# Tasks: feat/f2-models-migration
+
+## Review Workload Forecast
+
+| Field | Value |
+|-------|-------|
+| Estimated changed lines | PR-A ~420-430, PR-B ~420-430 |
+| 400-line budget risk | High |
+| Chained PRs recommended | Yes |
+| Suggested split | PR-A → PR-B |
+| Delivery strategy | ask-on-risk |
+| Chain strategy | stacked-to-main |
+
+Decision needed before apply: Yes
+Chained PRs recommended: Yes
+Chain strategy: stacked-to-main
+400-line budget risk: High
+
+### Suggested Work Units
+
+| Unit | Goal | Likely PR | Notes |
+|------|------|-----------|------|
+| 1 | Asset, Scan, tenant plan extension, R1, DB-free unit tests, hooks | PR-A | Base on `main`; freeze once opened |
+| 2 | Vulnerability, Report, R2, DB-free unit tests, integration conftest infra | PR-B | Stack on PR-A during implementation; retarget to `main` after merge |
+
+## Phase 1: PR-A — Asset / Scan / Tenant Extension
+
+- [x] 1.1 Add failing DB-free assertions for `Asset` and `Scan` in `tests/unit/test_f2_models.py` covering defaults, enums, FK targets, JSONB fields, and constraint names.
+- [x] 1.2 Create `app/modules/assets/models.py` and `app/modules/scans/models.py` with `Base`, `Mapped[...]`, `__table_args__`, tenant/asset FKs, and `ON DELETE CASCADE`.
+- [x] 1.3 Extend `app/modules/tenants/models.py` with `scans_per_day`, `ai_enrichment_level`, and `report_types` defaults aligned to `f2-tenant-plan-extension`.
+- [x] 1.4 Update `migrations/env.py`, `tests/conftest.py`, and `tests/unit/conftest.py`, then add R1 for tenant backfill + `assets`/`scans` + indexes/triggers/RLS/grants.
+
+## Phase 2: PR-A Verification
+
+- [x] 2.1 Keep PR-A migration reversible: `alembic upgrade head`, `alembic heads`, and `alembic downgrade b5e9d8c4a123` must all be covered by the PR-A verification notes.
+- [x] 2.2 Confirm `pytest -m "not integration"` stays green with the new `tests/unit/test_f2_models.py` coverage and the unit conftest DB override.
+
+## Phase 3: PR-B — Vulnerability / Report
+
+- [ ] 3.1 Add failing DB-free assertions for `Vulnerability` and `Report` in `tests/unit/test_f2_models.py` covering severity/status enums, FK targets, and metadata columns.
+- [ ] 3.2 Create `app/modules/vulnerabilities/models.py`, `app/modules/reports/__init__.py`, and `app/modules/reports/models.py` with `Base`, `Mapped[...]`, constraints, and parent FKs.
+- [ ] 3.3 Update `migrations/env.py` and `tests/conftest.py` for PR-B imports, then add R2 chained to R1 for `vulnerabilities`/`reports` + indexes/triggers/RLS/grants.
+- [ ] 3.4 Add `tests/integration/conftest.py` cleanup/Alembic loader infra only if the integration subset still needs stale-table protection.
+
+## Phase 4: PR-B Verification / Cleanup
+
+- [ ] 4.1 Verify PR-B downgrade returns cleanly to R1 and `alembic heads` still reports a single head.
+- [ ] 4.2 Re-run `pytest -m "not integration"` and clean any trailing whitespace/import ordering drift before opening PR-B.

--- a/openspec/changes/feat-f2-models-migration/verify-report.md
+++ b/openspec/changes/feat-f2-models-migration/verify-report.md
@@ -1,0 +1,213 @@
+## Verification Report
+
+**Change**: `feat-f2-models-migration`
+**Scope**: PR-A only (`feat/f2-models-migration-pr-a`)
+**Version**: N/A
+**Mode**: Strict TDD — confirmed by `openspec/config.yaml` (`strict_tdd: true`) and `pytest` runner availability through `uv run`.
+
+### Scope Boundary
+
+Verified only PR-A tasks 1.1-2.2 and PR-A implementation files.
+
+- In scope: `Asset`, `Scan`, tenant plan columns, R1 migration, Asset/Scan/Tenant DB-free unit tests, unit `prepare_database` override, and PR-A migration registration.
+- Out of scope: PR-B tasks 3.1-4.2 (`Vulnerability`, `Report`, R2, PR-B integration infra). These remain intentionally pending and are not blocking this verdict.
+
+### Completeness
+
+| Metric | Value |
+|--------|-------|
+| PR-A tasks total | 6 |
+| PR-A tasks complete | 6 |
+| PR-A tasks incomplete | 0 |
+| PR-B tasks pending | 6, out of scope |
+
+### PR-A File Scope
+
+| Expected PR-A file | Status | Notes |
+|--------------------|--------|-------|
+| `app/modules/assets/models.py` | ✅ Present | `Asset` model with tenant FK, JSONB metadata, constraints, timestamps |
+| `app/modules/scans/models.py` | ✅ Present | `Scan` model with tenant/asset FKs, JSONB config, constraints, timestamps |
+| `app/modules/tenants/models.py` | ✅ Modified | Added `scans_per_day`, `ai_enrichment_level`, `report_types` |
+| `migrations/env.py` | ✅ Modified | Imports `Asset` and `Scan` only for PR-A |
+| `migrations/versions/20260625_1400_f2_assets_scans_tenant_8f2c1a4b9d7e.py` | ✅ Present | R1 revision, `down_revision = "b5e9d8c4a123"` |
+| `tests/conftest.py` | ✅ Modified | Imports `Asset` and `Scan` in `prepare_database` |
+| `tests/unit/conftest.py` | ✅ Present | DB-free no-op `prepare_database` override |
+| `tests/unit/test_f2_models.py` | ✅ Present | 22 DB-free model inspection tests |
+
+No PR-B `reports` model files, `vulnerabilities` model files, or R2 migration were found in the PR-A scope.
+
+### Build & Tests Execution
+
+**Build**: ➖ Not applicable; schema/model/test verification only.
+
+**Tests**: ✅ Passed
+
+```text
+Command: pytest tests/unit -m "not integration"
+Result: blocked in this shell because bare `pytest` is not on PATH.
+
+Command: uv run pytest tests/unit -m "not integration"
+Result: 265 passed, 7 warnings in 0.59s
+
+Command: uv run pytest tests/unit/test_f2_models.py -q
+Result: 22 passed, 1 warning in 0.04s
+
+Command: uv run pytest -m "not integration"
+Result: 371 passed, 84 deselected, 95 warnings in 114.54s
+```
+
+**Coverage**: ➖ Not available — `openspec/config.yaml` marks coverage unavailable.
+
+### Alembic / Migration Evidence
+
+```text
+Command: uv run alembic heads
+Result: 8f2c1a4b9d7e (head)
+
+Command: GROQ_API_KEY=<redacted> uv run alembic history
+Result: b5e9d8c4a123 -> 8f2c1a4b9d7e (head), linear chain preserved
+
+Command: GROQ_API_KEY=<redacted> uv run alembic upgrade head --sql
+Result: generated offline SQL successfully, including tenant columns, assets/scans tables, indexes, updated_at triggers, RLS policies, grants, and alembic_version update to 8f2c1a4b9d7e.
+
+Command: GROQ_API_KEY=<redacted> uv run alembic downgrade 8f2c1a4b9d7e:b5e9d8c4a123 --sql
+Result: generated offline downgrade SQL successfully, including revoke/drop policies, triggers, indexes, scans/assets tables, tenant plan columns, and alembic_version rollback to b5e9d8c4a123.
+```
+
+Live PostgreSQL was reachable through Docker and verified against the local `soc360_test` database using a redacted test `DATABASE_URL_MIGRATION` override:
+
+```text
+Command: docker compose ps
+Result: soc360_postgres and soc360_redis Up/healthy
+
+Command: GROQ_API_KEY=<redacted> DATABASE_URL_MIGRATION=<redacted test DB> uv run alembic upgrade head
+Result: succeeded through R1 (8f2c1a4b9d7e)
+
+Command: GROQ_API_KEY=<redacted> DATABASE_URL_MIGRATION=<redacted test DB> uv run alembic current
+Result: 8f2c1a4b9d7e (head)
+
+Command: GROQ_API_KEY=<redacted> DATABASE_URL_MIGRATION=<redacted test DB> uv run alembic downgrade b5e9d8c4a123
+Result: succeeded
+
+Command: GROQ_API_KEY=<redacted> DATABASE_URL_MIGRATION=<redacted test DB> uv run alembic current
+Result: b5e9d8c4a123
+```
+
+Notes:
+
+- Bare `alembic` is not on PATH in this shell; `uv run alembic ...` is the working invocation.
+- The first default live Alembic attempt without the test migration URL override failed with `asyncpg.exceptions.InvalidPasswordError: password authentication failed for user "soc360_app"`. The safe test DB override resolved this.
+- Offline Alembic generation requires a test `GROQ_API_KEY` because application settings validation rejects missing `GROQ_API_KEY` when `LLM_PROVIDER='groq'`.
+
+### TDD Compliance
+
+| Check | Result | Details |
+|-------|--------|---------|
+| TDD Evidence reported | ✅ | `apply-progress` contains a TDD Cycle Evidence table for PR-A tasks 1.1-2.2 |
+| All PR-A tasks have tests/evidence | ✅ | 6/6 PR-A tasks have unit or migration command evidence |
+| RED confirmed | ✅ | `tests/unit/test_f2_models.py` exists; structural migration evidence exists for task 2.1 |
+| GREEN confirmed | ✅ | Focused F2 model tests, unit suite, and full non-integration suite passed |
+| Triangulation adequate | ✅ | 22 F2 model tests: 8 Asset, 8 Scan, 6 Tenant extension |
+| Safety net for modified files | ✅ | `uv run pytest tests/unit -m "not integration"` and `uv run pytest -m "not integration"` passed after PR-A changes |
+
+**TDD Compliance**: 6/6 PR-A tasks have verified evidence.
+
+### Test Layer Distribution
+
+| Layer | Tests | Files | Tools |
+|-------|-------|-------|-------|
+| Unit | 22 PR-A-focused tests | 1 (`tests/unit/test_f2_models.py`) | pytest |
+| Integration | 0 new PR-A tests | 0 | available but DB-backed F2 persistence/cascade tests are deferred by design |
+| E2E | 0 | 0 | not available |
+| **Total** | **22** | **1** | |
+
+### Changed File Coverage
+
+Coverage analysis skipped — no coverage tool is configured for this project.
+
+### Assertion Quality
+
+**Assertion quality**: ✅ All assertions in `tests/unit/test_f2_models.py` verify real model metadata or constructed model behavior. No tautologies, ghost loops, smoke-only checks, or type-only assertions without value assertions were found.
+
+### Quality Metrics
+
+**Linter**: ⚠️ `uv run ruff check <PR-A files>` reported one F401 in a changed file:
+
+```text
+tests/conftest.py:30:37: F401 `app.core.database.set_tenant_context` imported but unused
+```
+
+This import appears pre-existing, but the file is part of the PR-A diff and will still surface if Ruff is enforced on changed files.
+
+**Type Checker**: ⚠️ `uv run mypy app/modules/assets/models.py app/modules/scans/models.py app/modules/tenants/models.py tests/unit/test_f2_models.py` reported 10 errors:
+
+- 7 pre-existing `app/core/config.py` environment-constructor errors triggered by import graph.
+- 3 changed-test helper typing errors in `tests/unit/test_f2_models.py` because helpers accept `type` but access SQLAlchemy-specific `__mapper__` / `__table__` attributes.
+
+Per Strict TDD verify rules, quality metrics are warning-level evidence, not critical failures.
+
+### Spec Compliance Matrix
+
+| Requirement | PR-A scenario/scope | Test / Evidence | Result |
+|-------------|---------------------|-----------------|--------|
+| `f2-domain-models`: F2 entity tables | Asset table/model schema subset | `TestAssetModel` + live/offline R1 migration | ✅ COMPLIANT for PR-A structural scope |
+| `f2-domain-models`: F2 entity tables | Scan table/model schema subset | `TestScanModel` + live/offline R1 migration | ✅ COMPLIANT for PR-A structural scope |
+| `f2-domain-models`: Cascading deletes | Asset/Scan FK cascade definition | Static model/migration inspection; R1 live upgrade/downgrade | ✅ COMPLIANT structurally; DB-backed cascade behavior deferred |
+| `f2-domain-models`: Tenant isolation | Asset/Scan RLS policy definition | R1 offline SQL and migration source include RLS enablement and policies | ✅ COMPLIANT structurally; DB-backed RLS behavior deferred |
+| `f2-domain-models`: Query indexes | Asset tenant index, Scan tenant/asset indexes | R1 offline SQL and migration source include expected indexes | ✅ COMPLIANT |
+| `f2-tenant-plan-extension`: Tenant plan columns | Columns/defaults/backfill/downgrade | `TestTenantPlanExtension` + offline/live R1 upgrade/downgrade | ✅ COMPLIANT for database behavior |
+| `database-migrations`: R1 chains to main head | `b5e9d8c4a123 -> 8f2c1a4b9d7e` and single head | `uv run alembic heads`, `uv run alembic history`, live `current` | ✅ COMPLIANT |
+| `database-migrations`: R1 upgrade succeeds | R1 creates tenant columns + `assets`/`scans` | Offline SQL and live `upgrade head` succeeded | ✅ COMPLIANT |
+| `database-migrations`: R1 downgrade reverses PR-A | R1 downgrade returns to `b5e9d8c4a123` | Offline SQL and live `downgrade b5e9d8c4a123` succeeded | ✅ COMPLIANT |
+| `database-migrations`: PR-A env registration | `migrations/env.py` imports `Asset` and `Scan` only | Source inspection | ✅ COMPLIANT |
+| PR-B requirements/scenarios | Vulnerability, Report, R2 | Not evaluated | ➖ Out of scope for PR-A |
+
+**Compliance summary**: PR-A scoped requirements are compliant. DB-backed F2 persistence/cascade/RLS behavior remains deferred by the accepted design and should be covered in later slices.
+
+### Correctness (Static Evidence)
+
+| Requirement | Status | Notes |
+|------------|--------|-------|
+| Asset model | ✅ Implemented | UUID PK, tenant FK cascade, required/optional columns, JSONB metadata, constraints, timestamps |
+| Scan model | ✅ Implemented | UUID PK, tenant/asset FK cascade, required/optional columns, JSONB config, constraints, timestamps |
+| Tenant plan extension | ⚠️ Implemented with caveat | DB defaults exist; ORM uses `server_default` only, not Python-side `default=` as the design text describes |
+| R1 migration | ✅ Implemented | Revision `8f2c1a4b9d7e`, `down_revision = "b5e9d8c4a123"`, assets/scans/tenant columns/indexes/triggers/RLS/grants |
+| Unit DB override | ✅ Implemented | `tests/unit/conftest.py` overrides session autouse DB setup with no-op fixture |
+| PR-A tests | ✅ Implemented | 22 focused DB-free tests pass |
+
+### Coherence (Design)
+
+| Decision | Followed? | Notes |
+|----------|-----------|-------|
+| Two-PR split by entity dependency | ✅ Yes | PR-A contains Asset/Scan/tenant/R1 only; PR-B remains pending |
+| Controlled manual port, no broad merge | ✅ Yes | Working tree shows direct PR-A files, no PR-B implementation |
+| R1 chains from `b5e9d8c4a123` | ✅ Yes | `alembic heads` has single head `8f2c1a4b9d7e` |
+| DB-free unit tests for PR-A | ✅ Yes | 22 focused tests passed |
+| Tenant defaults: server default + backfill | ✅ Yes | Migration and ORM `server_default` are present |
+| ORM-side new-object defaults | ⚠️ Partial | Design says ORM side uses `default=`; implementation only uses `server_default` for new tenant plan fields |
+
+### Issues Found
+
+**CRITICAL**: None.
+
+**WARNING**:
+
+1. `ruff` reports pre-existing unused import `set_tenant_context` in changed `tests/conftest.py`.
+2. `mypy` reports 3 changed-test helper typing errors in `tests/unit/test_f2_models.py`; it also reports 7 pre-existing `app/core/config.py` settings-constructor errors.
+3. Tenant plan ORM defaults are only database/server defaults. This satisfies DB insert defaults but does not match the design note that ORM-side `default=` should support new-object construction defaults.
+4. `Tenant.report_types` is annotated as `dict | None`, while the spec/default value is a JSON array (`["vulnerability"]`). This is a typing/coherence risk even though the database default is correct.
+5. Working tree contains untracked items outside the narrow PR-A implementation scope (`.python-version`, `openspec/changes/cleanup-f2-branch-state/`, `openspec/project/`). Commit preparation should stage intentionally.
+
+**SUGGESTION**:
+
+1. Use `uv run ...` for local verification in this environment; bare `pytest` and `alembic` are not on PATH.
+2. Keep DB-backed persistence/cascade/RLS tests for the planned later slices, as accepted by the design.
+3. If CI enforces Ruff or mypy, address or explicitly defer the warning-level quality findings before opening the PR.
+
+### Verdict
+
+**PASS WITH WARNINGS**
+
+PR-A implementation matches the accepted PR-A scope, tasks 1.1-2.2 are complete, focused and full non-integration tests passed, R1 has a single Alembic head, and live upgrade/downgrade succeeded on the local test PostgreSQL database. Warning-level quality and design-coherence findings should be reviewed before commit/PR, but no critical blocker was found for PR-A verification.
+
+**Ready for pre-PR review / commit preparation**: Yes, with warnings. Stage only intended PR-A files/artifacts and decide whether to clean or defer the Ruff/mypy/ORM-default warnings before opening the PR.

--- a/openspec/specs/f2-domain-models/spec.md
+++ b/openspec/specs/f2-domain-models/spec.md
@@ -1,0 +1,72 @@
+# F2 Domain Models Specification
+
+## Purpose
+
+Persistence schema for F2 security entities with tenant isolation, cascading deletes, and domain constraints.
+
+## Requirements
+
+### Requirement: F2 entity tables
+
+The system MUST provide four tenant-scoped tables: `assets`, `scans`, `vulnerabilities`, and `reports`. Each MUST have a UUID primary key, a non-null `tenant_id` foreign key to `tenants.id` with `ON DELETE CASCADE`, non-null `created_at` and `updated_at`, and the columns and constraints below:
+
+| Table | Columns | Domain constraints |
+|---|---|---|
+| `assets` | `name`, optional `hostname`, `asset_type`, `status`, optional `asset_metadata` (JSONB) | `asset_type` ∈ {host, domain, ip, web_app}; `status` ∈ {active, inactive, archived}, default active |
+| `scans` | `asset_id`, `name`, `scan_type`, `status`, optional `config` (JSONB), optional `started_at`/`completed_at` | `scan_type` ∈ {discovery, vulnerability, web, full}; `status` ∈ {pending, running, completed, failed, cancelled}, default pending |
+| `vulnerabilities` | `scan_id`, `title`, optional `description`, `severity`, `status`, optional `cve_id`, optional `cvss_score`, optional `vulnerability_metadata` (JSONB) | `severity` ∈ {critical, high, medium, low, info}; `status` ∈ {open, fixed, accepted_risk, false_positive}, default open |
+| `reports` | `asset_id`, `name`, `report_type`, `status`, optional `summary`, optional `report_metadata` (JSONB), optional `generated_at` | `report_type` ∈ {vulnerability, executive, technical, compliance}; `status` ∈ {pending, generating, completed, failed}, default pending |
+
+#### Scenario: Valid asset is persisted
+
+- GIVEN a tenant exists
+- WHEN an asset with `asset_type` `host` is inserted
+- THEN the row is stored with `status` `active`
+
+#### Scenario: Invalid scan type is rejected
+
+- GIVEN a tenant and asset exist
+- WHEN a scan with `scan_type` `other` is inserted
+- THEN the insert is rejected
+
+#### Scenario: Vulnerability links to scan
+
+- GIVEN a scan exists
+- WHEN a vulnerability is inserted with that `scan_id`
+- THEN the row is stored
+
+#### Scenario: Report links to asset
+
+- GIVEN an asset exists
+- WHEN a report is inserted with that `asset_id`
+- THEN the row is stored
+
+### Requirement: Cascading deletes
+
+The system MUST delete `scans` and `reports` when their `asset` is deleted, `vulnerabilities` when their `scan` is deleted, and all four tables when a `tenant` is deleted.
+
+#### Scenario: Asset deletion cascades
+
+- GIVEN an asset has scans and reports
+- WHEN the asset is deleted
+- THEN the scans and reports are also deleted
+
+### Requirement: Tenant isolation
+
+The system MUST enforce row-level tenant isolation on the four F2 tables so a non-superadmin session only accesses rows whose `tenant_id` matches the session's current tenant.
+
+#### Scenario: Cross-tenant read is blocked
+
+- GIVEN assets exist for tenants A and B
+- WHEN a session scoped to tenant A queries assets
+- THEN only tenant A's assets are returned
+
+### Requirement: Query indexes
+
+The system MUST create indexes on `tenant_id` and on each parent foreign-key column.
+
+#### Scenario: Tenant-scoped query is indexed
+
+- GIVEN an F2 table contains rows for many tenants
+- WHEN a query filters by `tenant_id`
+- THEN the database uses the tenant index

--- a/openspec/specs/f2-tenant-plan-extension/spec.md
+++ b/openspec/specs/f2-tenant-plan-extension/spec.md
@@ -1,0 +1,43 @@
+# F2 Tenant Plan Extension Specification
+
+## Purpose
+
+Extends `tenants` with columns that govern scan frequency, AI enrichment tier, and enabled report types.
+
+## Requirements
+
+### Requirement: Tenant plan columns
+
+The system MUST add these columns to `tenants`:
+
+| Column | Type | Nullable | Default |
+|---|---|---|---|
+| `scans_per_day` | integer | NO | `1` |
+| `ai_enrichment_level` | string (max 50) | NO | `basic` |
+| `report_types` | JSONB | YES | `["vulnerability"]` |
+
+#### Scenario: New tenant uses defaults
+
+- GIVEN a tenant is created without plan columns
+- WHEN the row is inserted
+- THEN `scans_per_day` is `1`, `ai_enrichment_level` is `basic`, and `report_types` is `["vulnerability"]`
+
+### Requirement: Backfill existing tenants
+
+The system MUST set `report_types` to `["vulnerability"]` for every existing tenant whose `report_types` is NULL after the column is added.
+
+#### Scenario: Existing tenant is backfilled
+
+- GIVEN an existing tenant has NULL `report_types`
+- WHEN the migration upgrade runs
+- THEN the value becomes `["vulnerability"]`
+
+### Requirement: Reversible extension
+
+The system MUST be able to remove the three tenant columns on downgrade.
+
+#### Scenario: Downgrade removes columns
+
+- GIVEN the tenant extension is applied
+- WHEN the migration is downgraded by one revision
+- THEN the three columns no longer exist

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,7 @@ os.environ.setdefault("POSTGRES_DB", "soc360_test")
 os.environ.setdefault("REDIS_URL", "redis://localhost:6379/15")
 
 from app.main import create_app
-from app.core.database import Base, set_tenant_context
+from app.core.database import Base
 from app.core.redis import get_redis
 from app.dependencies import get_db, get_db_with_tenant
 from app.modules.users.models import User
@@ -52,9 +52,11 @@ def _seed_password_hash(password: str) -> str:
 # ✅ SYNC fixture — usa asyncio.run() para no contaminar ningún loop de test
 @pytest.fixture(scope="session", autouse=True)
 def prepare_database():
-    from app.modules.tenants.models import Tenant  # noqa: F401
-    from app.modules.users.models import User       # noqa: F401
+    from app.modules.assets.models import Asset  # noqa: F401
     from app.modules.auth.models import RefreshToken  # noqa: F401
+    from app.modules.scans.models import Scan  # noqa: F401
+    from app.modules.tenants.models import Tenant  # noqa: F401
+    from app.modules.users.models import User  # noqa: F401
 
     async def _setup() -> None:
         engine = create_async_engine(MIGRATION_DATABASE_URL, echo=False, poolclass=NullPool)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(scope="session", autouse=True)
+def prepare_database():
+    """Override tests/conftest.py prepare_database — no-op for unit tests."""
+    pass

--- a/tests/unit/test_f2_models.py
+++ b/tests/unit/test_f2_models.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from sqlalchemy.dialects.postgresql import JSONB
+
+from app.modules.assets.models import Asset
+from app.modules.scans.models import Scan
+from app.modules.tenants.models import Tenant
+
+
+# ---------------------------------------------------------------------------
+# Helpers for model inspection (DB-free — no session needed)
+# ---------------------------------------------------------------------------
+
+
+def _non_nullable_columns(model_cls: Any) -> set[str]:
+    return {str(c.name) for c in model_cls.__mapper__.columns if not c.nullable}
+
+
+def _nullable_columns(model_cls: Any) -> set[str]:
+    return {str(c.name) for c in model_cls.__mapper__.columns if c.nullable}
+
+
+def _check_constraint_names(model_cls: Any) -> set[str]:
+    return {
+        str(c.name)
+        for c in model_cls.__table__.constraints
+        if c.name is not None
+    }
+
+
+def _column_default(table: Any, col_name: str) -> Any:
+    """Return the Python-side ColumnDefault arg or None."""
+    col = getattr(table.c, col_name)
+    if col.default is not None:
+        return col.default.arg
+    return None
+
+
+def _column_type(table: Any, col_name: str) -> type[Any]:
+    """Return the SQLAlchemy column type class."""
+    return getattr(table.c, col_name).type.__class__
+
+
+# ---------------------------------------------------------------------------
+# Asset
+# ---------------------------------------------------------------------------
+
+
+class TestAssetModel:
+    """DB-free inspection tests for the Asset model."""
+
+    def test_tablename(self) -> None:
+        assert Asset.__tablename__ == "assets"
+
+    def test_required_columns(self) -> None:
+        nn = _non_nullable_columns(Asset)
+        assert "id" in nn
+        assert "tenant_id" in nn
+        assert "name" in nn
+        assert "asset_type" in nn
+        assert "status" in nn
+        assert "created_at" in nn
+        assert "updated_at" in nn
+
+    def test_nullable_columns(self) -> None:
+        n = _nullable_columns(Asset)
+        assert "hostname" in n
+        assert "asset_metadata" in n
+
+    def test_column_defaults(self) -> None:
+        assert _column_default(Asset.__table__, "status") == "active"
+
+    def test_jsonb_fields(self) -> None:
+        assert _column_type(Asset.__table__, "asset_metadata") is JSONB
+
+    def test_check_constraint_names(self) -> None:
+        names = _check_constraint_names(Asset)
+        assert "chk_assets_asset_type" in names
+        assert "chk_assets_status" in names
+
+    def test_fk_columns(self) -> None:
+        fks = {
+            fk.column.table.name: fk.parent.name
+            for fk in Asset.__table__.foreign_keys
+        }
+        assert fks["tenants"] == "tenant_id"
+
+    def test_repr_format(self) -> None:
+        asset = Asset(
+            id=uuid.uuid4(),
+            tenant_id=uuid.uuid4(),
+            name="server-01",
+            asset_type="host",
+        )
+        result = repr(asset)
+        assert "Asset" in result
+        assert "server-01" in result
+
+
+# ---------------------------------------------------------------------------
+# Scan
+# ---------------------------------------------------------------------------
+
+
+class TestScanModel:
+    """DB-free inspection tests for the Scan model."""
+
+    def test_tablename(self) -> None:
+        assert Scan.__tablename__ == "scans"
+
+    def test_required_columns(self) -> None:
+        nn = _non_nullable_columns(Scan)
+        assert "id" in nn
+        assert "tenant_id" in nn
+        assert "asset_id" in nn
+        assert "name" in nn
+        assert "scan_type" in nn
+        assert "status" in nn
+        assert "created_at" in nn
+        assert "updated_at" in nn
+
+    def test_nullable_columns(self) -> None:
+        n = _nullable_columns(Scan)
+        assert "config" in n
+        assert "started_at" in n
+        assert "completed_at" in n
+
+    def test_column_defaults(self) -> None:
+        assert _column_default(Scan.__table__, "status") == "pending"
+
+    def test_jsonb_fields(self) -> None:
+        assert _column_type(Scan.__table__, "config") is JSONB
+
+    def test_check_constraint_names(self) -> None:
+        names = _check_constraint_names(Scan)
+        assert "chk_scans_scan_type" in names
+        assert "chk_scans_status" in names
+
+    def test_fk_columns(self) -> None:
+        """Verify foreign keys point to expected parent tables."""
+        fks = {
+            fk.column.table.name: fk.parent.name
+            for fk in Scan.__table__.foreign_keys
+        }
+        assert fks["tenants"] == "tenant_id"
+        assert fks["assets"] == "asset_id"
+
+    def test_repr_format(self) -> None:
+        scan = Scan(
+            id=uuid.uuid4(),
+            tenant_id=uuid.uuid4(),
+            asset_id=uuid.uuid4(),
+            name="scan-01",
+            scan_type="vulnerability",
+        )
+        result = repr(scan)
+        assert "Scan" in result
+        assert "scan-01" in result
+
+
+# ---------------------------------------------------------------------------
+# Tenant plan extension
+# ---------------------------------------------------------------------------
+
+
+class TestTenantPlanExtension:
+    """DB-free inspection tests for the tenant plan-extension columns."""
+
+    def test_tablename(self) -> None:
+        assert Tenant.__tablename__ == "tenants"
+
+    def test_required_columns(self) -> None:
+        nn = _non_nullable_columns(Tenant)
+        assert "scans_per_day" in nn
+        assert "ai_enrichment_level" in nn
+
+    def test_report_types_is_nullable(self) -> None:
+        n = _nullable_columns(Tenant)
+        assert "report_types" in n
+
+    def test_scans_per_day_server_default(self) -> None:
+        col = getattr(Tenant.__table__.c, "scans_per_day")
+        assert col.server_default is not None
+        assert "1" in str(col.server_default.arg)
+        assert _column_default(Tenant.__table__, "scans_per_day") == 1
+
+    def test_ai_enrichment_level_server_default(self) -> None:
+        col = getattr(Tenant.__table__.c, "ai_enrichment_level")
+        assert col.server_default is not None
+        assert "basic" in str(col.server_default.arg)
+        assert _column_default(Tenant.__table__, "ai_enrichment_level") == "basic"
+
+    def test_report_types_server_default(self) -> None:
+        col = getattr(Tenant.__table__.c, "report_types")
+        assert col.server_default is not None
+        assert "vulnerability" in str(col.server_default.arg)
+        default_factory = _column_default(Tenant.__table__, "report_types")
+        assert default_factory is not None
+        assert default_factory(None) == ["vulnerability"]


### PR DESCRIPTION
## Linked Issue

Closes #91

## PR Type

- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Adds the first F2 models/migration slice: Asset and Scan.
- Extends Tenant with scan/report plan fields.
- Adds Alembic R1 plus DB-free unit coverage and SDD artifacts.

## Changes

| File | Change |
|------|--------|
| `app/modules/assets/models.py` | Adds Asset ORM model |
| `app/modules/scans/models.py` | Adds Scan ORM model |
| `app/modules/tenants/models.py` | Adds F2 tenant plan columns |
| `migrations/env.py` | Registers Asset and Scan models |
| `migrations/versions/20260625_1400_f2_assets_scans_tenant_8f2c1a4b9d7e.py` | Adds R1 migration |
| `tests/unit/test_f2_models.py` | Adds DB-free model tests |
| `openspec/changes/feat-f2-models-migration/` | Adds proposal/design/tasks/verify report |

## Test Plan

- [x] `uv run pytest tests/unit/test_f2_models.py -q` — 22 passed
- [x] `uv run pytest tests/unit -m "not integration"` — 265 passed
- [x] `uv run pytest -m "not integration"` — 371 passed, 84 deselected
- [x] `uv run ruff check tests/conftest.py tests/unit/test_f2_models.py app/modules/tenants/models.py`
- [x] `uv run mypy --follow-imports=skip tests/unit/test_f2_models.py app/modules/tenants/models.py`
- [x] `uv run alembic heads` — single head `8f2c1a4b9d7e`
- [x] Offline Alembic upgrade/downgrade SQL generation passed
- [x] Live PostgreSQL migration upgrade/downgrade passed during SDD verify

## Notes

- PR-B will add Vulnerability, Report, and R2 in a follow-up branch.
- ORM `relationship()` declarations are intentionally deferred to later slices.
- Existing unrelated untracked files are not included.

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one type:* label
- [x] Ran relevant checks
- [x] Docs/spec artifacts updated
- [x] Conventional commit format
- [x] No Co-Authored-By trailers