### PR TITLE
fix(auth): set RLS superadmin context in login/refresh (#125)

### DIFF
--- a/app/modules/auth/service.py
+++ b/app/modules/auth/service.py
@@ -24,6 +24,7 @@ from app.modules.auth.models import RefreshToken
 from app.modules.users.models import User
 from app.modules.tenants.models import Tenant
 from app.modules.auth.schemas import TokenResponse
+from app.core.database import set_tenant_context
 from app.core.exceptions import AuthError, ServiceUnavailableError
 from app.core.pii import hash_email, mask_ip
 from app.core.redis import check_redis_healthy
@@ -237,8 +238,14 @@ async def login(
     """Autentica al usuario y delvuelve el access token + refresh token"""
     if not await check_redis_healthy(redis):
         raise ServiceUnavailableError()
+    # Bootstrap RLS context: at login time we don't know the tenant yet, so we
+    # temporarily elevate to superadmin to allow the email-based user lookup.
+    # Mirrors the same pattern in app.dependencies.get_current_user.
+    # The SET LOCAL is transaction-scoped and is reset on commit/rollback,
+    # so it cannot leak across requests.
+    await set_tenant_context(db, tenant_id=None, is_superadmin=True)
     await _check_account_lockout(email, redis)
-    
+
     user = await _get_active_user(email, db)
     
     if not verify_password(password, user.hashed_password):
@@ -295,6 +302,11 @@ async def refresh_tokens(
     """Invalida el anterior y genera uno nuevo"""
     if not await check_redis_healthy(redis):
         raise ServiceUnavailableError()
+    # Bootstrap RLS context: refresh tokens are looked up by token_hash, not by
+    # tenant, so we temporarily elevate to superadmin to allow the lookup.
+    # Mirrors the login() pattern in this module and get_current_user in
+    # app.dependencies. The SET LOCAL is transaction-scoped.
+    await set_tenant_context(db, tenant_id=None, is_superadmin=True)
     token_hash = hashlib.sha256(refresh_token.encode()).hexdigest()
     async def _rotate_refresh_token() -> tuple[User, str]:
         stmt = (

--- a/openspec/changes/archive/2026-06-30-fix-f1-remaining-rls-403-and-email-409/archive-report.md
+++ b/openspec/changes/archive/2026-06-30-fix-f1-remaining-rls-403-and-email-409/archive-report.md
@@ -1,0 +1,109 @@
+# Archive Report: fix-f1-remaining-rls-403-and-email-409
+
+**Change**: `fix-f1-remaining-rls-403-and-email-409`
+**Mode**: OPENSPEC (file-based; Engram has prior phase artifacts)
+**Archived on**: 2026-06-30
+**Source of truth**: PR #124 merged to `main`
+**Archived to**: `openspec/changes/archive/2026-06-30-fix-f1-remaining-rls-403-and-email-409/`
+
+## Outcome
+
+**PASS.** The change is fully planned, implemented, verified, and archived. SDD cycle complete.
+
+## Gates Evaluated
+
+| Gate | Result | Evidence |
+|------|--------|----------|
+| PR #124 merged to `main` | PASS | Change is fully merged to main via PR #124 |
+| Task Completion Gate (no unchecked impl tasks) | PASS | `tasks.md` shows all 23 tasks marked `[x]` across Phases 1-3 |
+| Verify report verdict | PASS WITH WARNINGS | verify-report observation #332 records `PASS WITH WARNINGS` |
+| CRITICAL issues in verify report | NONE | verify-report section "Issues Found → CRITICAL" contains `None` |
+| Delta spec destination | N/A | The change's delta spec (`specs/fix-f1-remaining-rls-403-and-email-409/spec.md`) is scoped to this specific F1 fix, not a new reusable domain. The proposal explicitly declares "New Capabilities: None" and "Modified Capabilities: None" relative to existing `user-management` / `tenant-management` behavior. No main-spec merge was performed; the delta spec is preserved in the archive as an audit trail. |
+| Change folder archived | PASS | `openspec/changes/fix-f1-remaining-rls-403-and-email-409/` contents copied to `openspec/changes/archive/2026-06-30-fix-f1-remaining-rls-403-and-email-409/`. Note: the source folder removal step (rmdir) was not performed in this archive phase because the archive executor did not have shell access; the source folder is now a duplicate of the archive and should be removed by the orchestrator/user as a follow-up housekeeping step. The archive copy itself is the authoritative audit trail. |
+| Archive contains all artifacts | PASS | Archived folder holds `proposal.md`, `design.md`, `tasks.md`, and `specs/fix-f1-remaining-rls-403-and-email-409/spec.md` |
+| No unrelated untracked paths touched | PASS | No changes outside the change folder and its archive destination |
+| No staging, committing, pushing, or PR creation | PASS | `sdd-archive` only writes the archive report and copies files; no `git add`, `git commit`, `git push`, or `gh pr create` was invoked |
+
+## Files Archived
+
+| File | Source | Destination |
+|------|--------|-------------|
+| `proposal.md` | `openspec/changes/fix-f1-remaining-rls-403-and-email-409/proposal.md` | `openspec/changes/archive/2026-06-30-fix-f1-remaining-rls-403-and-email-409/proposal.md` |
+| `design.md` | `openspec/changes/fix-f1-remaining-rls-403-and-email-409/design.md` | `openspec/changes/archive/2026-06-30-fix-f1-remaining-rls-403-and-email-409/design.md` |
+| `tasks.md` | `openspec/changes/fix-f1-remaining-rls-403-and-email-409/tasks.md` | `openspec/changes/archive/2026-06-30-fix-f1-remaining-rls-403-and-email-409/tasks.md` |
+| `specs/fix-f1-remaining-rls-403-and-email-409/spec.md` | `openspec/changes/fix-f1-remaining-rls-403-and-email-409/specs/fix-f1-remaining-rls-403-and-email-409/spec.md` | `openspec/changes/archive/2026-06-30-fix-f1-remaining-rls-403-and-email-409/specs/fix-f1-remaining-rls-403-and-email-409/spec.md` |
+| `archive-report.md` | (created by this phase) | `openspec/changes/archive/2026-06-30-fix-f1-remaining-rls-403-and-email-409/archive-report.md` |
+
+## Specs Synced
+
+| Domain | Action | Details |
+|--------|--------|---------|
+| (none) | none | Proposal explicitly states `New Capabilities: None` and `Modified Capabilities: None`. The delta spec documents the R01–R10 requirements specific to this F1 fix; it is not a new reusable domain. The delta spec is preserved in the archive as an audit trail alongside `proposal.md` and `design.md`. No main spec (`openspec/specs/`) was modified. |
+
+## Capabilities Touched
+
+| Capability | Type | Notes |
+|------------|------|-------|
+| `user-management` | Documented (no spec file change) | Cross-tenant 403 contract (R01, R02, R03) and email 409 contract (R07) are enforced by code but the canonical `user-management` spec was not created. The behavior is captured in the archived delta spec as an audit trail. |
+| `tenant-management` | Documented (no spec file change) | Cross-tenant 403 contract for `GET /tenants/{id}` (RK-6) is enforced. The behavior is captured in the archived delta spec. |
+
+## Production Code Landed via PR #124
+
+The change was delivered as a chained PR stack per `tasks.md`:
+
+1. **PR-0** — `fix(rls): prevent session poisoning across pooled connections` (commit `7007cbf` on `fix/heal-f1`). Commit prerequisite: `app/core/database.py`, `app/dependencies.py`, `tests/integration/test_auth_login_event_flow.py`.
+2. **PR-A** — `fix(users,tenants): return 403 on cross-tenant access via service-layer pre-check` (commit `cf72d73` on `fix/heal-f1`). Service-layer pre-check + new FastAPI Depends; R01–R06, RK-6.
+3. **PR-B** — `fix(users): translate unique_violation to 409 on duplicate email` (commit `37b8cc1` on `fix/heal-f1`). IntegrityError → 409 translator + rollback; R07, R08, R09.
+
+Plus a test fix in `tests/integration/test_tenants.py` (`404 → 403`) aligned with the unified 403 contract.
+
+**CI suite**: 540 passed, 0 failed.
+
+## Key Risk Callouts (RK)
+
+- **RK-1** — Service-layer signature change (functions now take `current_user` and a pre-checked `target`). All callers were updated in PR-A.
+- **RK-2** — Superadmin elevation window between `set_config(..., true)` SET LOCAL and `set_tenant_context` restore. `try/finally` guarantees context restoration on exception.
+- **RK-3** — `e.orig.pgcode` is asyncpg-specific. Code uses `getattr(exc.orig, "pgcode", None) == "23505"` so a missing attribute falls through to `raise` (no silent mistranslation).
+- **RK-6** — Cross-tenant tenant GET now returns 403 (was 404). The test at `test_tenants_integration.py:406` was updated in the same PR.
+- **RK-7** — `update_user` and `deactivate_user` now take pre-checked `target`; bypassing the Depends is mitigated via signature requirements and code comments.
+
+## Persisted Artifact IDs (Engram traceability)
+
+This report itself is persisted to Engram with:
+- `title`: `sdd/fix-f1-remaining-rls-403-and-email-409/archive-report`
+- `topic_key`: `sdd/fix-f1-remaining-rls-403-and-email-409/archive-report`
+- `type`: `architecture`
+- `project`: `soc360-pymes`
+- `capture_prompt`: `false` (automated SDD artifact)
+
+Predecessor artifacts persisted by prior SDD phases (live under matching topic keys in Engram):
+- `#321` — `sdd/fix-f1-remaining-rls-403-and-email-409/proposal` (architecture)
+- `#324` — `sdd/fix-f1-remaining-rls-403-and-email-409/design` (architecture)
+- `#327` — `sdd/fix-f1-remaining-rls-403-and-email-409/tasks` (architecture)
+- `#329` — `sdd/fix-f1-remaining-rls-403-and-email-409/apply-progress` (architecture, PR-A)
+- `#332` — `sdd/fix-f1-remaining-rls-403-and-email-409/verify-report` (architecture)
+
+All observation IDs are recorded here for downstream traceability.
+
+## Accepted Warnings Carried Forward
+
+These WARNINGs are non-blocking by the strict archive policy. They were recorded in the verify report and carry through to the archive:
+
+1. **`test_email_unique_globally_returns_409` failure during PR-A** — Expected; this test is PR-B scope. After PR-B landed, full CI suite passed (540/0).
+2. **Pre-existing ruff F821 on `EventBus` forward reference** — Confirmed pre-existing per apply-progress note; not introduced by PR-A or PR-B.
+3. **ruff reports 27 errors** — All pre-existing in `app/` and `tests/`; 0 introduced by this change.
+
+## Cycle Status
+
+| Phase | Status |
+|-------|--------|
+| explore | done (via prior sessions) |
+| propose | done (proposal.md) |
+| spec | done (specs/fix-f1-remaining-rls-403-and-email-409/spec.md) |
+| design | done (design.md) |
+| tasks | done (23/23) |
+| apply | done (23/23; PR-0 + PR-A + PR-B all merged via PR #124) |
+| verify | done (PASS WITH WARNINGS; no CRITICAL) |
+| archive | done (this report) |
+
+SDD cycle complete for `fix-f1-remaining-rls-403-and-email-409`. Ready for the next change.

--- a/openspec/changes/archive/2026-06-30-fix-f1-remaining-rls-403-and-email-409/design.md
+++ b/openspec/changes/archive/2026-06-30-fix-f1-remaining-rls-403-and-email-409/design.md
@@ -1,0 +1,602 @@
+# Design: fix-f1-remaining-rls-403-and-email-409
+
+## 1. Architecture overview
+
+El cambio introduce una nueva FastAPI dependency que hace el **cross-tenant pre-check** para endpoints que apuntan a usuarios, más una dependency paralela que hace lo mismo para endpoints que apuntan a tenants. Cada dependency eleva la DB session del request a contexto superadmin por la duración del SELECT, lee la fila target, compara `tenant_id` con el `tenant_id` del caller (para users) o compara el tenant id mismo con `current_user.tenant_id` (para tenants), después restaura el contexto de tenant del caller antes de que la función de servicio corra la mutación o read real. La capa de servicio queda libre de concerns de auth; confía en que la fila que se le pasa ya está autorizada para el caller.
+
+El contrato 403 es uniforme cross endpoints de user-targeting y tenant-targeting: acceso cross-tenant siempre devuelve 403 (con un log line por intento bloqueado) y nunca 404. Esto unifica la señal de audit para que intentos cross-tenant sean indistinguibles de "fila genuinamente faltante" en la capa HTTP.
+
+### Request flow (cross-tenant GET / PATCH / DELETE on users)
+
+```
+  Client
+    |
+    v
+  Router (app/modules/users/router.py)
+    |  1. extract current_user (Depends get_current_user)
+    |  2. extract user_for_admin (NEW Depends get_user_for_admin_dep)
+    |        |  -- SET LOCAL app.is_superadmin = 'true'
+    |        |  -- SET LOCAL app.current_tenant = ''
+    |        |  -- SELECT * FROM users WHERE id = :target_id
+    |        |  -- compare target.tenant_id vs current_user.tenant_id
+    |        |  -- on mismatch: log + raise HTTPException(403)
+    |        |  -- restore: set_tenant_context(db, current_user.tenant_id, current_user.is_superadmin)
+    |        v
+    |     returns User row (or 403)
+    v
+  Service (app/modules/users/service.py)
+    |  -- receives the pre-checked row
+    |  -- runs the actual mutation / read
+    |  -- no auth code in here
+    v
+  DB
+```
+
+### Request flow (cross-tenant GET on tenants)
+
+```
+  Client
+    |
+    v
+  Router (app/modules/tenants/router.py)
+    |  1. extract current_user (Depends get_current_user)
+    |  2. extract tenant_for_admin (NEW Depends get_tenant_for_admin_dep)
+    |        |  -- target_tenant_id != current_user.tenant_id (non-superadmin)
+    |        |  -- compare (no SELECT needed: target id is the URL param)
+    |        |  -- on mismatch: log + raise HTTPException(403)
+    |        |  -- on match: SELECT * FROM tenants WHERE id = :target_id
+    |        |     (row is reachable under caller's tenant context, RLS passes)
+    |        |  -- if None: raise 404
+    |        v
+    |     returns Tenant row (or 403/404)
+    v
+  Service (app/modules/tenants/service.py)
+    v
+  DB
+```
+
+### Request flow (same-tenant GET / PATCH / DELETE on users)
+
+```
+  Client
+    |
+    v
+  Router
+    |  1. extract current_user
+    |  2. extract user_for_admin via NEW Depends
+    |        |  -- target.tenant_id == current_user.tenant_id
+    |        |  -- no SET LOCAL needed, RLS already lets the SELECT through
+    |        |  -- restore is a no-op (current context is already correct)
+    |        v
+    |     returns User row
+    v
+  Service -> DB
+```
+
+### Dónde se dispara cada cosa
+
+- **403 raise site (users):** dentro de la nueva Depends `get_user_for_admin`, inmediatamente después de detectar el mismatch de `tenant_id`.
+- **403 raise site (tenants):** dentro de la nueva Depends `get_tenant_for_admin`, cuando `target_tenant_id != current_user.tenant_id` y el caller no es superadmin.
+- **Log line:** `logger.warning("cross_tenant_access_blocked", caller_id=..., target_id=..., method=..., endpoint=...)` en cada 403 raise site. El campo target id es el User id para la user Depends, el Tenant id para la tenant Depends.
+- **RLS en juego para users same-tenant:** cada request same-tenant nunca toca elevación superadmin, así que RLS sigue siendo la única fuente de verdad para reads in-tenant.
+- **RLS en juego para callers superadmin:** el path superadmin usa `get_user_internal` (sin pre-check), el SELECT corre bajo elevación superadmin que ya está seteada por `get_current_user` vía `set_tenant_context(... , True)`.
+- **RLS en juego para tenants same-tenant:** leer el tenant id del propio caller está permitido por `rls_tenants` porque `id::text = current_setting('app.current_tenant', TRUE)` matchea; no se necesita elevación en ese caso. La Depends chequea el id de la URL contra `current_user.tenant_id` ANTES de emitir el SELECT así que la elevación superadmin solo se requiere para el path cross-tenant (y solo importa para users ahí — ver sección 3).
+
+## 2. La nueva Depends
+
+Vive en `app/dependencies.py`. Modelada sobre el bloque de elevación existente en `get_current_user` en `app/dependencies.py:90-93` (las dos llamadas `set_config(..., true)`) y sobre `get_db_with_tenant` en `app/dependencies.py:135-144` (misma shape: pull `current_user`, do work, yield/return).
+
+### Signature — user Depends
+
+```python
+async def get_user_for_admin(
+    user_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db_with_tenant),
+) -> User: ...
+```
+
+### Signature — tenant Depends
+
+```python
+async def get_tenant_for_admin(
+    tenant_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db_with_tenant),
+) -> Tenant: ...
+```
+
+### Step-by-step behavior — get_user_for_admin
+
+1. Leer `current_user` (ya validado, tiene `tenant_id` y `is_superadmin`).
+2. Si `current_user.is_superadmin`: SELECT la fila bajo el contexto de tenant (ya superadmin) del caller. Sin elevación adicional. Devolver fila o elevar 404.
+3. Si `current_user.tenant_id is None` y no es superadmin: imposible por invariante de `get_current_user`; 403 defensivo.
+4. Si `current_user.tenant_id == user_id`'s tenant (la lectura requiere elevación porque el target puede estar en otro tenant): emitir `SELECT set_config('app.is_superadmin', 'true', true)` + `SELECT set_config('app.current_tenant', '', true)` (el par SET LOCAL de `app/dependencies.py:92-93`).
+5. `SELECT * FROM users WHERE id = :user_id`. RLS ahora permite la fila sin importar el tenant.
+6. Si la fila es None: restaurar contexto de tenant, elevar 404.
+7. Comparar `row.tenant_id` con `current_user.tenant_id`. En mismatch: log + elevar 403 (mensaje `"Permisos insuficientes"`, en español según `app/modules/users/router.py:117`).
+8. **Siempre restaurar contexto de tenant** vía `await set_tenant_context(db, current_user.tenant_id, current_user.is_superadmin)` antes de devolver la fila. Esto re-establece el contexto canónico del caller para la mutación de capa de servicio que sigue. (Incluso si los pasos 4-6 elevan, el SET LOCAL garantiza que la elevación se limpia en el próximo COMMIT/ROLLBACK; el restore explícito es belt-and-suspenders para el happy path.)
+9. Devolver la fila.
+
+### Step-by-step behavior — get_tenant_for_admin
+
+1. Leer `current_user`.
+2. Si `current_user.is_superadmin`: SELECT la fila bajo el contexto de tenant del caller. Sin elevación adicional. Devolver fila o elevar 404.
+3. Si `current_user.tenant_id is None` y no es superadmin: imposible por invariante; 403 defensivo.
+4. **Comparar `tenant_id` (URL param) con `current_user.tenant_id`** ANTES de cualquier SELECT. Esta es la inversión de la user Depends: el target de comparación es el id de la URL mismo, no el `tenant_id` column de una fila. Los dos son el mismo concepto — el id de la URL ES el tenant id que estamos chequeando.
+5. En mismatch: log + elevar 403 (mensaje `"Permisos insuficientes"`, en español, matcheando la user Depends y `app/dependencies.py:160`). **No se performa DB SELECT** — el pre-check dispara en Python antes de tocar la DB.
+6. En match: SELECT `* FROM tenants WHERE id = :tenant_id`. Bajo el contexto de tenant del caller, RLS deja pasar esto (la policy es `id::text = current_setting('app.current_tenant', TRUE)`). Si None: elevar 404. Devolver fila.
+7. Devolver la fila.
+
+**Por qué no elevación RLS para el caso tenant cross-tenant:** la comparación corre en Python antes del SELECT, así que nunca necesitamos leer una fila que el contexto de tenant del caller oculta. Esto es más eficiente que el path de la user Depends (un par `set_config` extra se ahorra en el caso 403 cross-tenant) e igualmente correcto. La user Depends necesita elevación solo porque el pre-check debe mirar una fila cuya existencia y `tenant_id` column son ambos desconocidos hasta que el SELECT corre.
+
+### SET LOCAL semantics
+
+El tercer argumento `true` a `set_config` produce un `SET LOCAL` (setting transaction-local). Se revierte automáticamente en `COMMIT` o `ROLLBACK`. Esto significa:
+
+- Un request distinto que reuse la misma conexión pooled no puede ver el estado elevado.
+- Una excepción elevada dentro del bloque de elevación deja la sesión fallida; la siguiente operación dispara ROLLBACK y el SET LOCAL se limpia.
+- Igual llamamos `set_tenant_context` explícitamente después para ser defensivos y re-establecer el contexto de request canónico para la mutación.
+
+### Code pattern (skeleton, NOT full implementation) — get_user_for_admin
+
+```python
+# app/dependencies.py — appended after get_db_with_tenant
+async def get_user_for_admin(
+    user_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db_with_tenant),
+) -> User:
+    # Superadmin path: row is already visible under the elevated session
+    # established by get_current_user + get_db_with_tenant.
+    if current_user.is_superadmin:
+        row = (await db.execute(select(User).where(User.id == user_id))).scalar_one_or_none()
+        if row is None:
+            raise HTTPException(status_code=404, detail="Usuario no encontrado")
+        return row
+
+    # Non-superadmin: elevate to read the cross-tenant row (modeled on
+    # app/dependencies.py:90-93 — the SET LOCAL pair inside get_current_user).
+    await db.execute(text("SELECT set_config('app.is_superadmin', 'true', true)"))
+    await db.execute(text("SELECT set_config('app.current_tenant', '', true)"))
+    try:
+        row = (await db.execute(select(User).where(User.id == user_id))).scalar_one_or_none()
+    finally:
+        # Always restore — SET LOCAL is cleared on COMMIT/ROLLBACK, but
+        # we re-set the canonical context so the next statement in the
+        # request runs under the caller's tenant.
+        await set_tenant_context(db, current_user.tenant_id, False)
+
+    if row is None:
+        raise HTTPException(status_code=404, detail="Usuario no encontrado")
+    if row.tenant_id != current_user.tenant_id:
+        logger.warning(
+            "cross_tenant_access_blocked",
+            caller_id=str(current_user.id),
+            target_id=str(user_id),
+            method="GET",  # filled by caller (see router pattern below)
+            endpoint=f"/users/{user_id}",
+        )
+        raise HTTPException(status_code=403, detail="Permisos insuficientes")
+    return row
+```
+
+### Code pattern (skeleton, NOT full implementation) — get_tenant_for_admin
+
+```python
+# app/dependencies.py — appended after get_user_for_admin
+async def get_tenant_for_admin(
+    tenant_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db_with_tenant),
+) -> Tenant:
+    # Superadmin path: caller is already elevated, no extra work.
+    if current_user.is_superadmin:
+        row = (await db.execute(select(Tenant).where(Tenant.id == tenant_id))).scalar_one_or_none()
+        if row is None:
+            raise HTTPException(status_code=404, detail="Tenant no encontrado")
+        return row
+
+    # Non-superadmin: pre-check the URL id against caller's tenant_id BEFORE
+    # touching the DB. The id is the comparison key, so no SELECT is needed
+    # to discover the target's tenant.
+    if current_user.tenant_id is None:
+        # Defensive: get_current_user guarantees this is unreachable, but
+        # we mirror the same defensive branch as get_user_for_admin.
+        raise HTTPException(status_code=403, detail="Permisos insuficientes")
+
+    if tenant_id != current_user.tenant_id:
+        logger.warning(
+            "cross_tenant_access_blocked",
+            caller_id=str(current_user.id),
+            target_id=str(tenant_id),  # tenant id, not user id
+            method="GET",               # filled by router wrapper
+            endpoint=f"/tenants/{tenant_id}",
+        )
+        raise HTTPException(status_code=403, detail="Permisos insuficientes")
+
+    # Same-tenant path: RLS lets the SELECT through under the caller's tenant.
+    row = (await db.execute(select(Tenant).where(Tenant.id == tenant_id))).scalar_one_or_none()
+    if row is None:
+        raise HTTPException(status_code=404, detail="Tenant no encontrado")
+    return row
+```
+
+### Router pattern (the method/endpoint hint)
+
+Los campos `method` y `endpoint` del log necesitan el verbo HTTP y el path. Dos opciones:
+
+- **Opción A (elegida):** envolver la dependency en un factory pequeño que los capture. Añadir `get_user_for_admin_get`, `get_user_for_admin_patch`, `get_user_for_admin_delete` como wrappers de una línea que llaman al helper core con el valor correcto de `method=`. El endpoint path es un string constante por router. Mismo factory para tenants: `get_tenant_for_admin_get`.
+- **Opción B:** leer `request: Request = Depends(...)` dentro de la dependency y extraer `request.method` / `request.url.path`. Ahorra wrappers pero acopla la dependency al FastAPI `Request` object y hace la dependency más difícil de unit-testear.
+
+Tradeoff: Opción A son unos pocos wrappers triviales de una línea pero mantiene la dependency pure-typed y unit-testable. Opción B son menos líneas pero más difícil de testear (hay que fakear un `Request`).
+
+**Decisión:** Opción A. El costo son un puñado de wrappers de 3 líneas; los unit tests pueden driver el helper subyacente directamente.
+
+```python
+# app/dependencies.py
+def _user_for_admin(method: str):
+    async def _dep(
+        user_id: uuid.UUID,
+        current_user: User = Depends(get_current_user),
+        db: AsyncSession = Depends(get_db_with_tenant),
+    ) -> User:
+        return await _get_user_for_admin(user_id, current_user, db, method=method, endpoint=f"/users/{user_id}")
+    return _dep
+
+get_user_for_admin_get = _user_for_admin("GET")
+get_user_for_admin_patch = _user_for_admin("PATCH")
+get_user_for_admin_delete = _user_for_admin("DELETE")
+
+def _tenant_for_admin(method: str):
+    async def _dep(
+        tenant_id: uuid.UUID,
+        current_user: User = Depends(get_current_user),
+        db: AsyncSession = Depends(get_db_with_tenant),
+    ) -> Tenant:
+        return await _get_tenant_for_admin(tenant_id, current_user, db, method=method, endpoint=f"/tenants/{tenant_id}")
+    return _dep
+
+# Tenants only have one targeted endpoint (GET /tenants/{id}) in PR-A.
+# PATCH and DELETE on tenants remain superadmin-only and do not need the
+# cross-tenant pre-check (the superadmin branch already covers them).
+get_tenant_for_admin_get = _tenant_for_admin("GET")
+```
+
+## 3. Cambios en capa de servicio
+
+### Para users (`app/modules/users/service.py`)
+
+#### `get_user_for_admin`
+
+```python
+async def get_user_for_admin(
+    current_user: User,
+    target_id: uuid.UUID,
+    db: AsyncSession,
+) -> User:
+    """Pre-checked user read for admin endpoints.
+
+    Caller (a Depends) has already elevated the session and verified
+    that the target row's tenant_id matches current_user.tenant_id.
+    This function is a thin wrapper for symmetry with get_user_internal
+    and to keep the router signature uniform.
+
+    Raises UserError(404) if the row has vanished between the pre-check
+    SELECT and this call (TOCTOU window, very rare).
+    """
+    row = (await db.execute(select(User).where(User.id == target_id))).scalar_one_or_none()
+    if row is None:
+        raise UserError("Usuario no encontrado", status_code=404)
+    return row
+```
+
+#### `get_user_internal`
+
+```python
+async def get_user_internal(
+    target_id: uuid.UUID,
+    db: AsyncSession,
+) -> User | None:
+    """System/superadmin read. NO pre-check.
+
+    Trusts the caller — used by the superadmin branch of the new Depends
+    and by any future system-level code (background jobs, admin tools).
+    """
+    return (await db.execute(select(User).where(User.id == target_id))).scalar_one_or_none()
+```
+
+#### `update_user` rewrite
+
+```python
+async def update_user(
+    current_user: User,
+    target: User,           # pre-checked by the Depends
+    data: UserUpdate,
+    db: AsyncSession,
+    redis: Redis,
+) -> User:
+    """Update a pre-checked user row.
+
+    The router passes in the User row already validated by
+    get_user_for_admin. This function is now auth-clean: it only
+    applies field changes and (if deactivating) revokes tokens.
+    """
+    # The self-409 and admin-modifies-superadmin checks move to the
+    # router (they were already there in router.py:140-175 and stay there).
+    update_data = data.model_dump(exclude_unset=True)
+    # ... existing field-application logic, unchanged ...
+    await db.flush()
+    # ... existing token-revocation logic, unchanged ...
+    await db.refresh(target)
+    return target
+```
+
+#### `deactivate_user` rewrite
+
+```python
+async def deactivate_user(
+    current_user: User,
+    target: User,           # pre-checked by the Depends
+    db: AsyncSession,
+    redis: Redis,
+) -> None:
+    """Deactivate a pre-checked user row. Auth-clean."""
+    if not target.is_active:
+        raise UserError("El usuario ya está desactivado", status_code=409)
+    target.is_active = False
+    await db.flush()
+    # ... existing token-revocation logic, unchanged ...
+```
+
+#### `_log_cross_tenant_attempt` helper
+
+```python
+def _log_cross_tenant_attempt(
+    caller_id: uuid.UUID,
+    target_id: uuid.UUID,
+    method: str,
+    endpoint: str,
+) -> None:
+    """Single chokepoint for the 403 log line (OQ-1).
+
+    The same helper covers both user-targeting and tenant-targeting
+    attempts: `target_id` is whichever id the pre-check operated on
+    (a user id for the user Depends, a tenant id for the tenant Depends).
+    """
+    logger.warning(
+        "cross_tenant_access_blocked",
+        caller_id=str(caller_id),
+        target_id=str(target_id),
+        method=method,
+        endpoint=endpoint,
+        # NO tenant_id: sensitive info avoidance (OQ-1)
+    )
+```
+
+Llamado desde la nueva Depends en el momento en que se detecta el mismatch. Ya no hay un helper de tenant separado — ambas Depends comparten el mismo chokepoint porque los campos del log son idénticos excepto por el valor de `target_id`.
+
+#### Router signature después del rewrite
+
+```python
+# app/modules/users/router.py
+
+@router.get("/{user_id}", response_model=UserResponse)
+async def get_user(
+    user: User = Depends(get_user_for_admin_get),  # pre-checked
+    # db removed — Depends already has it
+) -> User:
+    return user
+
+@router.patch("/{user_id}", response_model=UserResponse)
+async def update_user(
+    body: UserUpdate,
+    current_user: CurrentUserDep,
+    user: User = Depends(get_user_for_admin_patch),  # pre-checked
+    db: DBWithTenantDep,
+    redis: RedisDep,
+) -> User:
+    # The existing in-router checks (self-deactivation 409, admin-modifies-superadmin
+    # 403, role hierarchy 403) STAY HERE — they are policy rules, not tenant rules.
+    if current_user.is_superadmin and user.id == current_user.id and body.is_active is False:
+        raise HTTPException(status_code=409, detail="No puedes desactivarte a ti mismo")
+    # ... existing role/admin checks, unchanged ...
+    updated = await service.update_user(current_user=current_user, target=user, data=body, db=db, redis=redis)
+    # ...
+
+@router.delete("/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def deactivate_user(
+    user: User = Depends(get_user_for_admin_delete),  # pre-checked
+    current_user: AdminDep,
+    db: DBWithTenantDep,
+    redis: RedisDep,
+) -> None:
+    if user.id == current_user.id:
+        raise HTTPException(status_code=409, detail="No puedes desactivarte a ti mismo")
+    # ... existing admin-vs-admin check, unchanged ...
+    await service.deactivate_user(current_user=current_user, target=user, db=db, redis=redis)
+    # ...
+```
+
+### Para tenants (`app/modules/tenants/router.py`)
+
+La decisión de diseño (RK-6) es **unificar el contrato 403 cross user y tenant endpoints**: reads cross-tenant sobre `/tenants/{id}` DEBEN también devolver 403, no 404. La Depends de arriba (`get_tenant_for_admin`) implementa esto. PATCH y DELETE sobre tenants quedan superadmin-only y no necesitan el pre-check (el `SuperadminDep` existente es la gate).
+
+#### Tenant router rewrite
+
+```python
+# app/modules/tenants/router.py
+
+@router.get(
+    "/{tenant_id}",
+    response_model=schemas.TenantResponse,
+    summary="Obtener tenant por id",
+)
+async def get_tenant(
+    current_user: CurrentUserDep,
+    tenant: Tenant = Depends(get_tenant_for_admin_get),  # pre-checked
+) -> schemas.TenantResponse:
+    return schemas.TenantResponse.model_validate(tenant)
+```
+
+El viejo check inline en `tenants/router.py:64-66` (que elevaba 404 para non-superadmin cross-tenant) se REMUEVE — la Depends ahora hace el mismo check y devuelve 403 en su lugar. El viejo path 404 en `tenants/router.py:71-76` (que elevaba 404 cuando RLS ocultaba la fila) también se REMUEVE — el SELECT de la Depends corre bajo el contexto de tenant del caller (caso same-tenant) o se skipea enteramente (caso cross-tenant, la Depends devuelve 403 primero), así que el único 404 legítimo es cuando `current_user.tenant_id == tenant_id` pero la fila de tenant no existe (imposible por la FK constraint que users tienen sobre `tenants.id`, pero la Depends lo cubre por seguridad).
+
+**Test update required:** `tests/integration/test_tenants_integration.py:406` DEBE actualizarse de `assert resp.status_code == 404` a `assert resp.status_code == 403`. Esto está in scope para PR-A según la decisión RK-6.
+
+#### Qué NO cambia para tenants
+
+- `POST /tenants/` (create) — superadmin only, no pre-check necesario.
+- `GET /tenants/` (list) — superadmin only, no pre-check necesario.
+- `PATCH /tenants/{id}` y `DELETE /tenants/{id}` — superadmin only, el `SuperadminDep` existente es suficiente.
+- La capa de servicio `get_tenant_by_id`, `update_tenant`, `deactivate_tenant` — quedan auth-clean. La Depends maneja el caso cross-tenant para GET; los otros endpoints son superadmin-only a nivel de router.
+
+## 4. PR-B design (email 409)
+
+En `app/modules/users/service.py:create_user`, envolver `db.flush()` en un try/except que traduzca `IntegrityError` con `pgcode == '23505'` a `UserError(409)`.
+
+### Bloque try/except exacto
+
+```python
+# app/modules/users/service.py — create_user, around line 67
+
+db.add(user)
+try:
+    await db.flush()
+except IntegrityError as exc:
+    # asyncpg-specific: e.orig.pgcode is '23505' for unique_violation,
+    # '23503' for FK violation, '23514' for check violation.
+    # Pin asyncpg in the dependency manifest (RK-3 mitigation).
+    if getattr(exc.orig, "pgcode", None) == "23505":
+        await db.rollback()  # clear failed session state (R09)
+        raise UserError("El email ya está registrado", status_code=409) from exc
+    raise  # other IntegrityError variants propagate unchanged (R08)
+await db.refresh(user)
+return user
+```
+
+### Dónde se ubica el rollback
+
+Después del `except IntegrityError` y ANTES del `raise UserError(...)`. El orden importa: la sesión de SQLAlchemy está en estado fallido tras un flush que pegó una UNIQUE constraint, y cualquier `db.execute` subsiguiente elevaría `PendingRollbackError`. Necesitamos limpiar ese estado antes de re-elevar la excepción user-facing para que el router pueda hacer trabajo de seguimiento (no lo hará, pero el global exception handler podría loguear metadata vía queries adicionales).
+
+### Cómo funciona el path del test
+
+`test_users_integration.py:527` (`test_email_unique_globally_returns_409`):
+
+1. Primer POST con `email=duplicate@test.test` en tenant A → 201 (pre-check pasa, INSERT tiene éxito).
+2. Segundo POST con el mismo `email` (cualquier tenant) → pre-check lo captura → 409 (este path ya funciona hoy vía `_is_email_taken`).
+3. (Implícito) El path de race condition: dos POSTs concurrentes ambos pasan el pre-check, el segundo pega la DB UNIQUE constraint, el handler de IntegrityError devuelve 409.
+
+El nuevo path de código cubre el paso 3, que el test no ejercita directamente pero es la razón del cambio. El pre-check sigue cubriendo el paso 2. No se necesitan cambios de test para PR-B en la capa de integración; el test existente pasa por el pre-check hoy y seguirá pasando tras el refactor (el nuevo handler es no-op cuando el pre-check ya capturó el duplicado).
+
+## 5. Test design
+
+### PR-A — unit tests en `tests/unit/test_dependencies.py` (o `tests/unit/test_users_service.py`)
+
+- `test_log_cross_tenant_attempt_includes_required_fields` — assert la log call tiene caller_id, target_id, method, endpoint, no tenant_id.
+- `test_get_user_for_admin_returns_row_on_match` — same tenant, devuelve la fila.
+- `test_get_user_for_admin_raises_403_on_tenant_mismatch` — non-superadmin, target en otro tenant, eleva 403.
+- `test_get_user_for_admin_returns_row_for_superadmin` — superadmin caller, target en cualquier tenant, devuelve la fila.
+- `test_get_user_for_admin_raises_404_on_missing_row` — id no existente, eleva 404.
+- `test_get_user_internal_does_not_pre_check` — system path, target en otro tenant, sin error (devuelve fila).
+- `test_update_user_does_not_call_flush_on_403` — patchear el target en otro tenant no debe mutar la DB. (Drives el nuevo Depends path.)
+- `test_deactivate_user_does_not_call_flush_on_403` — mismo para DELETE.
+
+### PR-A — unit tests para la tenants Depends en `tests/unit/test_dependencies.py` (o `tests/unit/test_tenants_service.py`)
+
+- `test_get_tenant_for_admin_returns_own_tenant` — non-superadmin, propio tenant_id, devuelve fila.
+- `test_get_tenant_for_admin_returns_403_for_cross_tenant` — non-superadmin, otro tenant_id, eleva 403 (NO 404 — este es el cambio de contrato decidido por el usuario).
+- `test_get_tenant_for_admin_returns_row_for_superadmin` — superadmin, cualquier tenant_id, devuelve fila.
+- `test_get_tenant_for_admin_raises_404_on_missing_row_when_same_tenant` — non-superadmin, propio tenant_id, fila genuinamente ausente, eleva 404 (defensivo — FK hace difícil llegar, pero la Depends lo cubre).
+- `test_get_tenant_for_admin_emits_log_line_on_cross_tenant` — assert `cross_tenant_access_blocked` log con caller_id, target_id (= tenant id), method, endpoint, no tenant_id.
+
+### PR-A — integration tests ya en su lugar (sin cambios)
+
+- `tests/integration/test_tenants_integration.py:382` — `test_cross_tenant_isolation_complete` — ya assert 403 en el user GET (línea 402).
+- `tests/integration/test_users_integration.py:280` — `test_admin_a_never_access_tenant_b_resources` — ya assert 403 para GET, PATCH, DELETE.
+- `tests/integration/test_users_integration.py:615` — `test_admin_cannot_deactivate_superadmin_via_patch` — ya assert 403.
+
+### PR-A — integration test change required (decisión de usuario sobre RK-6)
+
+- `tests/integration/test_tenants_integration.py:406` — `assert resp.status_code == 404` DEBE cambiarse a `assert resp.status_code == 403`. Esta es la consecuencia user-facing de añadir la tenant Depends. Sin este cambio, el test fallaría porque la Depends ahora devuelve 403 para el caso cross-tenant que el test ejercita. Esta es la decisión explícita del usuario: el test sigue al contrato, el contrato no sigue al test.
+
+### PR-B — unit tests en `tests/unit/test_users_service.py`
+
+- `test_create_user_translates_unique_violation_to_409` — fake un `IntegrityError` con `pgcode='23505'` desde un `db.flush()` mockeado; assert `UserError(409)` se eleva.
+- `test_create_user_propagates_non_unique_integrity_error` — fake `pgcode='23503'` (FK violation); assert el `IntegrityError` original se propaga sin traducir.
+- `test_create_user_rolls_back_failed_session` — fake el IntegrityError, assert `db.rollback()` fue llamado antes del raise (usar un spy sobre el AsyncSession mock).
+
+### PR-B — integration test en su lugar
+
+- `tests/integration/test_users_integration.py:527` — `test_email_unique_globally_returns_409` — assert 201 después 409. Sin cambio de test necesario; pasa vía el pre-check existente hoy, seguirá pasando tras PR-B.
+
+## 6. Plan de rollout
+
+### Orden de merge (mandatory)
+
+1. **PR-0** (prerequisito) — commit los 3 archivos sin commitear de RLS session-poisoning: `app/core/database.py`, `app/dependencies.py`, `tests/integration/test_auth_login_event_flow.py`. Conventional commit message: `fix(rls): prevent session poisoning across pooled connections`. Sin cambios de diseño, sin tocar spec. **DEBE mergear primero** porque el patrón de elevación en la nueva Depends depende de las garantías de sesión RLS que estos archivos establecen.
+2. **PR-A** — RLS service-layer refactor + tenant pre-check. Toca:
+   - `app/dependencies.py` (nueva Depends + factory para users y tenants)
+   - `app/modules/users/service.py` (split functions, signature changes)
+   - `app/modules/users/router.py` (usa la nueva Depends)
+   - `app/modules/tenants/router.py` (usa la nueva tenant Depends; remueve el inline 404 check)
+   - `tests/integration/test_tenants_integration.py:406` (assert 404 → 403)
+   - `tests/unit/test_dependencies.py` (nuevos unit tests para users y tenants Depends)
+   - Conventional commit message: `fix(users,tenants): return 403 on cross-tenant access via service-layer pre-check`
+3. **PR-B** — email 409 translation. Toca solo `app/modules/users/service.py:create_user` (añade try/except alrededor de `db.flush()`) y el archivo de unit tests. Conventional commit message: `fix(users): translate unique_violation to 409 on duplicate email`.
+
+PR-A y PR-B pueden revisarse en cualquier orden pero PR-A DEBE aterrizar primero para evitar rebase churn en `service.py`. PR-B no depende del comportamiento runtime de PR-A — solo se beneficia de que PR-A ya haya estabilizado el archivo.
+
+### Database migrations
+
+**Ninguna.** Según la spec y el out-of-scope de la propuesta, este diseño NO DEBE añadir nuevas migraciones alembic. Las policies RLS en `migrations/versions/20260312_2052_initial_schema_712a827b0929.py:94-118` son referencias read-only.
+
+### Feature flag
+
+**No** se añade nuevo feature flag en este diseño. El patrón de elevación es requerido por el contrato 403 — gatearlo detrás de un flag significaría que los 4 tests fallan cuando el flag está off, derrotando el propósito. Rollback es vía git revert (PR-A revert devuelve el contrato 404 en users y revierte el cambio de test en línea 406 si el cambio de test se mergeó atómicamente con la implementación).
+
+Si un incidente futuro hace del patrón de elevación la causa raíz sospechada, el rollback es:
+- `git revert <PR-A merge commit>` — restaura el contrato 404 en users (y revierte el cambio de test en línea 406 si el cambio se mergeó atómicamente).
+- PR-0 sin mergear se queda — su fix de RLS session poisoning es independientemente seguro.
+
+## 7. Riesgos y mitigaciones
+
+| ID | Riesgo | Mitigation |
+|----|--------|------------|
+| RK-1 | El cambio de signature de función de servicio rompe callers directos. Grep results: solo `app/modules/users/router.py` y `app/modules/tenants/router.py` importan de `app.modules.users.service`. El router se actualiza en el mismo PR. | PR-A es atómico; los tests corren en cada commit. |
+| RK-2 | La ventana de elevación entre `set_config` y `set_tenant_context` expone la sesión a scope superadmin. | El par SET LOCAL se revierte en COMMIT/ROLLBACK; el bloque `try/finally` en la Depends garantiza que el restore corre incluso en excepción. Un comentario de código nombra la garantía de `SET LOCAL`. |
+| RK-3 | `e.orig.pgcode` es asyncpg-específico. | Pin asyncpg; añadir un comentario; la función usa `getattr(exc.orig, "pgcode", None) == "23505"` así que un atributo faltante cae a `raise` (sin mis-traducción silenciosa). |
+| RK-4 | La nueva Depends introduce un `db.execute` extra por request para elevación incluso en requests same-tenant. | La Depends chequea `current_user.tenant_id == row.tenant_id` y devuelve early; la elevación solo dispara para requests cross-tenant (que son el slow path y el caso raro). Para callers superadmin, no se necesita elevación porque el `set_tenant_context(... , True)` existente de `get_current_user` está en efecto. |
+| RK-5 | El factory de Depends crea tres wrappers casi idénticos (`get_user_for_admin_get`, `_patch`, `_delete`). Futuros devs podrían añadir un nuevo HTTP method y olvidarse de añadir un wrapper, dejando el log line con un `method=` incorrecto. | Los tres wrappers viven en `app/dependencies.py` al lado del helper core; el unit test suite cubre cada wrapper. Un docstring en `_user_for_admin` dice "add a new wrapper when adding a new HTTP method to user routes." |
+| RK-6 | Tenant cross-access devuelve 403 (consistente con user cross-tenant endpoint). Test `test_tenants_integration.py:406` actualizado. Pre-check para endpoints /tenants añadido en el tenant router. | La Depends reemplaza el viejo check inline 404. El test en línea 406 se actualiza en el mismo PR. El cambio unifica la señal de audit — intentos cross-tenant sobre /users o /tenants aparecen como la misma línea de log `cross_tenant_access_blocked` con la misma respuesta HTTP 403. |
+| RK-7 | `update_user` y `deactivate_user` ya no fetchean su propia fila target — la reciben como argumento. Futuros devs podrían llamarlas con un `User` construido a mano y saltarse el pre-check. | Las nuevas signatures hacen `current_user` y `target` parámetros requeridos (sin defaults), y un comentario dice "the router MUST obtain `target` via the new Depends, not via `get_user_internal`." Una regla de linter (manual por ahora) flaguea imports de service desde el router fuera de la nueva Depends. |
+| RK-8 | La Depends emite un `db.execute` extra incluso cuando la fila está en el tenant del caller. | El costo es un par `SELECT set_config(...)` (barato) más el mismo SELECT que el viejo `get_user_by_id` habría emitido. Sin regresión medible en el hot path. La tenant Depends NO eleva en 403 cross-tenant — la comparación corre en Python antes de cualquier llamada a DB, ahorrando los dos roundtrips de `set_config` en el path 403. |
+| RK-9 | Un caller superadmin leyendo su propio tenant es el nuevo happy path para la tenant Depends — pero los superadmins históricamente bypasean el check inline 404 en el router. La nueva Depends preserva ese path (la branch `is_superadmin` devuelve la fila sin pre-check) así que el flujo superadmin existente queda preservado. | Unit test `test_get_tenant_for_admin_returns_row_for_superadmin` cubre este caso. |
+
+## 8. Out of scope (explícito)
+
+- Trabajo de F2 bajo `openspec/changes/prd-v2-vertical-f2/`.
+- Cualquier cambio a las policies RLS en `migrations/versions/20260312_2052_initial_schema_712a827b0929.py:94-118`.
+- Los 3 archivos sin commitear de RLS session-poisoning (`app/core/database.py`, `app/dependencies.py`, `tests/integration/test_auth_login_event_flow.py`) — salen como PR-0 y no se tocan en PR-A o PR-B.
+- Nuevas migraciones alembic o cambios de schema.
+- UNIQUE parcial por tenant sobre `email` (Opción C de la propuesta queda descartada).
+- Enrichment de audit-log más allá de la única línea `cross_tenant_access_blocked` (sin métricas, sin traces, sin audit table separada).
+- Replicación multi-region, rate limiting, cambios de jerarquía de roles.
+- PATCH y DELETE sobre `/tenants/{id}` — quedan superadmin-only a nivel de router; el pre-check cross-tenant no se extiende a ellos (la superadmin gate es suficiente y ningún test ejercita actualmente una mutación de tenant no-superadmin cross-tenant).
+
+## 9. Open architectural questions
+
+Sin preguntas arquitectónicas abiertas restantes tras la resolución de RK-6. Los 4 OQs de la spec quedan respondidos en el record de decisiones (`sdd/fix-f1-remaining-rls-403-and-email-409/decisions`):
+- OQ-1 resuelto: los campos del log son `caller_id`, `target_id`, `method`, `endpoint`. Sin `tenant_id`.
+- OQ-2 resuelto: la elevación vive en una NUEVA FastAPI Depends; la capa de servicio queda limpia.
+- OQ-3 resuelto: `get_user_by_id` se parte en `get_user_for_admin` (pre-check) y `get_user_internal` (system path, sin pre-check).
+- OQ-4 resuelto: los 3 archivos sin commitear salen como PR-0; orden de merge PR-0 → PR-A → PR-B.
+
+RK-6 también queda resuelto: tenant cross-access ahora devuelve 403, consistente con el user cross-tenant endpoint. La asimetría 404-on-tenant-cross-access se elimina con esta revisión.
+
+## 10. Resumen del test plan para PR-B
+
+| Requirement | Test file (new) | Test file (existing) | Line |
+|-------------|-----------------|----------------------|------|
+| R07 | `tests/unit/test_users_service.py::test_create_user_translates_unique_violation_to_409` | `tests/integration/test_users_integration.py` | 527 |
+| R08 | `tests/unit/test_users_service.py::test_create_user_propagates_non_unique_integrity_error` | — | — |
+| R09 | `tests/unit/test_users_service.py::test_create_user_rolls_back_failed_session` | — | — |

--- a/openspec/changes/archive/2026-06-30-fix-f1-remaining-rls-403-and-email-409/proposal.md
+++ b/openspec/changes/archive/2026-06-30-fix-f1-remaining-rls-403-and-email-409/proposal.md
@@ -1,0 +1,131 @@
+# Propuesta: fix-f1-remaining-rls-403-and-email-409
+
+## Intención
+
+Cerrar los últimos 4 tests de integración fallando en `fix/heal-f1` para dejar la rama verde antes de mergear. Los 3 tests RLS-403 (#1, #2, #4) asumen que acceso cross-tenant y PATCH de superadmin devuelven 403, pero la policy `rls_users` actual filtra la fila invisible, así que la capa de servicio devuelve 404. El test de email-409 (#3) espera 409 en email duplicado, pero el pre-check de `_is_email_taken` tiene una carrera TOCTOU y la UNIQUE constraint de la DB dispara sin catch como 500. Ninguno es un bug de correctness en producción; son desalineaciones entre tests y contrato RLS (casos RLS) y un traductor de excepciones faltante (caso email).
+
+El cambio debe ser quirúrgico: 6 commits de cleanup ya aterrizaron en esta rama (commit 7007cbf), y el trabajo sin commitear de RLS session poisoning ya bajó los fallos de 7 a 4. Esta propuesta cubre solo los 4 restantes.
+
+## Alcance
+
+### In Scope
+
+- Decidir y aplicar una aproximación por cluster de fallos:
+  - **Cluster A (RLS 403 vs 404, tests #1, #2, #4)** — elegir Opción A (alinear tests) u Opción B (pre-check en capa de servicio).
+  - **Cluster B (email 409, test #3)** — elegir Opción A (try/except IntegrityError), Opción B (savepoint wrapper), u Opción C (UNIQUE parcial por tenant — listada por completitud, NO recomendada porque el test `test_email_unique_globally_returns_409` afirma unicidad global).
+- Actualizar los 3 tests afectados por RLS y el 1 test de email para que pasen.
+- Mantener intactos los 3 archivos sin commitear (database.py / dependencies.py / test_auth_login_event_flow.py — el fix de RLS session poisoning); esta propuesta no los re-cubre.
+
+### Out of Scope
+
+- Cualquier cambio a las policies RLS en `migrations/versions/20260312_2052_initial_schema_712a827b0929.py:94-118`.
+- Cualquier trabajo de F2 (`openspec/changes/prd-v2-vertical-f2/`).
+- Reescribir el módulo de users más allá del mínimo necesario para traducir IntegrityError a 409 (si se elige Opción A/B para email) o para añadir un pre-check de tenant mismatch (si se elige Opción B para RLS).
+- Cambiar la semántica de producto de unicidad de email (sigue global según el contrato del test).
+- Nuevas migraciones a menos que el usuario solicite explícitamente Opción C.
+- Refactor de `_is_email_taken` más allá del mínimo necesario.
+
+## Capacidades
+
+### Nuevas Capacidades
+
+Ninguna.
+
+### Capacidades Modificadas
+
+- `user-management` (existente): el requisito `GET/PATCH/DELETE sobre usuario de otro tenant devuelve 403` puede reinterpretarse como `404 porque RLS oculta la fila` (si Opción A) O enforcedse en la capa de servicio con un tenant-match check explícito (si Opción B). El contrato del test es la fuente de verdad — la opción que se elija, el comportamiento documentado de acceso cross-tenant en la capacidad user-management debe actualizarse para coincidir.
+- `user-management`: el requisito `email duplicado en create devuelve 409` ya existe; solo se corrige el gap de implementación (falta el handler de IntegrityError). Sin cambio a nivel de spec si Opción A/B; si Opción C, el requisito mismo cambia de `globalmente único` a `único por tenant`.
+
+## Opciones de Aproximación
+
+### Cluster A — RLS 403 vs 404 (tests #1, #2, #4)
+
+**Opción A — Alinear tests con el diseño RLS actual (cambio solo en tests)**
+Cambiar las 4 ocurrencias de `assert == 403` a `assert == 404` en:
+- `tests/integration/test_tenants_integration.py:382` (1 ocurrencia)
+- `tests/integration/test_users_integration.py:280` (3 ocurrencias para GET / PATCH / DELETE)
+
+Sin cambios en código de producción. RLS es la fuente de verdad y la policy `tenant_id::text = current_setting('app.current_tenant', TRUE)` ya devuelve UNKNOWN para filas cross-tenant, que Postgres trata como "no visible". El path 404 del router es por lo tanto el comportamiento correcto e intencional. También es consistente con `test_tenants_integration.py:406` que ya espera 404 para `GET /tenants/{id}` cross-tenant bajo RLS.
+
+- **Pro 1**: Diff mínimo posible (~4 líneas en tests, sin cambio de producción). Cero riesgo de regresión en flujos de cara al usuario.
+- **Pro 2**: Coherente con la filosofía de diseño RLS existente — protección en la capa de framework, no duplicada en código de app. Evita una clase futura de bugs donde el pre-check Python y la policy DB se desincronicen.
+- **Con 1**: Pierde el contrato explícito 403. Auditores/reviewers de seguridad que grepean `403` para verificar aislamiento de tenant no lo encontrarán en el path de user-management.
+- **Con 2**: 404 filtra menos información que 403, lo cual es bueno para seguridad, pero una necesidad futura de loguear acceso cross-tenant como un intento potencial de privilege-escalation requerirá una señal diferente (ej. un check de `tenant_id` mismatch en la capa de audit log).
+
+**Opción B — Re-arquitecturar la capa de servicio para enforced tenant checks en Python antes de RLS**
+Añadir un parámetro `current_user: User` a `get_user_by_id`, `update_user` (y `deactivate_user`); comparar `current_user.tenant_id` con el `tenant_id` del usuario target y raise 403 en mismatch antes de cualquier SELECT. Requiere elevar la sesión de request a un rol superadmin de DB (similar al fix sin commitear en `app/dependencies.py`) para que el pre-check pueda leer la fila target; de lo contrario el SELECT mismo devolverá None bajo RLS y el check es inalcanzable.
+
+- **Pro 1**: Restaura el contrato explícito 403. Acceso cross-tenant se convierte en un evento logueado y distinguible en código de app.
+- **Pro 2**: Hace la policy de tenant-isolation explícita en la capa de servicio, que es el lugar convencional donde futuros engineers buscarán reglas de autorización.
+- **Con 1**: Refactor mayor — toca `app/modules/users/service.py`, el user router, y 3 tests. By-pasea la propiedad de RLS de "ningún código de app puede leakear cross tenants" elevando a sesión superadmin solo para el check de auth, lo cual expande la superficie de bypass.
+- **Con 2**: Duplica la protección: código de app chequea tenant_id Y RLS sigue filtrando filas. Dos fuentes de verdad que deben mantenerse sincronizadas. Riesgo de regresión cuando se añadan endpoints nuevos y olviden el pre-check Python.
+
+### Cluster B — Email 409 (test #3)
+
+**Opción A — Try/except IntegrityError alrededor de `db.flush()` en `create_user`**
+Después de `db.add(user)` y `await db.flush()`, envolver el flush en `try/except IntegrityError`, inspeccionar `e.orig.pgcode == '23505'`, re-raise como `UserError("El email ya está registrado", status_code=409)`. ~5 líneas, sin migración.
+
+- **Pro 1**: Quirúrgico, sin migración, sin cambio de test, corrige el bug de producción real (un duplicado concurrente haría 500 hoy). El pre-check en `_is_email_taken` sigue ayudando el caso común.
+- **Pro 2**: Suficientemente genérico para reusarse en cualquier UNIQUE constraint futura que añadamos a users.
+- **Con 1**: Depende de que `e.orig.pgcode` esté poblado; si asyncpg cambia la shape de su excepción el código rompe silenciosamente. Debería añadir un comentario de que `pgcode` es asyncpg-específico.
+- **Con 2**: La sesión queda en estado fallido tras `IntegrityError` en flush; hace falta `await db.rollback()` antes de raise la nueva excepción, de lo contrario la siguiente operación en el mismo request también fallará. Esta es la parte sutil — fácil de olvidar.
+
+**Opción B — SAVEPOINT wrapper alrededor del INSERT**
+Misma lógica que A pero usa `async with db.begin_nested():` para que el rollback quede scoped al savepoint y la transacción exterior quede limpia. Semánticas marginalmente más limpias para operaciones anidadas.
+
+- **Pro 1**: Igual que A, pero las semánticas de rollback las garantiza SQLAlchemy en vez de `db.rollback()` manual.
+- **Pro 2**: Future-proof si la función crece para hacer múltiples writes donde rollback parcial importa.
+- **Con 1**: Un round-trip extra para setear el savepoint; medible solo a QPS muy altos, que el path de creación de usuarios no es.
+- **Con 2**: Más código, más conceptos que enseñar en la función.
+
+**Opción C — UNIQUE parcial por tenant sobre email**
+Soltar el `users_email_key` global, añadir `CREATE UNIQUE INDEX ... ON users (lower(email)) WHERE tenant_id IS NOT NULL` más un índice único separado para superadmins. Requiere migración alembic y cambia el contrato de producto — `test_email_unique_globally_returns_409` tendría que actualizarse porque el nombre del test afirma unicidad global.
+
+- **Pro 1**: Permite que dos tenants distintos usen el mismo email (común en B2B SaaS donde la misma persona puede pertenecer a múltiples tenants).
+- **Con 1**: Cambia un invariante de producto. Out of scope para "fix tests" y el nombre del test lo contradice explícitamente.
+- **Con 2**: Riesgo de migración, más el nuevo contrato de test es una decisión de producto que el usuario no ha aprobado.
+
+## Recomendación
+
+Sin recomendación. El usuario pidió explícitamente pros y contras para elegir. El orchestrator debe correr una ronda de preguntas, después volver para finalizar las opciones elegidas en la propuesta antes de la fase de spec.
+
+Si se forzara a elegir defaults, la combinación más probable es **Cluster A → Opción A** (diff mínimo, consistente con el patrón RLS existente en `test_tenants_integration.py:406`) y **Cluster B → Opción A** (diff mínimo que corrige un bug real, sin migración).
+
+## Preguntas Abiertas — Ronda Pre-Proposal
+
+1. **Unicidad de email (regla de producto del Cluster B):** ¿Es "email globalmente único" un requisito de producto duro, o es un artefacto del schema original y el usuario está abierto a relajarlo a unicidad por tenant en un cambio futuro? Esto determina si la Opción C es alguna vez viable.
+2. **Señalización de acceso cross-tenant (audit/compliance del Cluster A):** ¿Algún requisito de audit, compliance o seguridad exige que acceso cross-tenant produzca un 403 explícito en respuestas HTTP (en vez de 404) para que aparezca como señal distinta en access logs?
+3. **PATCH/DELETE cross-tenant (edge case del Cluster A):** ¿Es 404 aceptable para GET / PATCH / DELETE cross-tenant, o el 404 debería reservarse para "la fila no existe" mientras que acceso cross-tenant recibe un código diferente (ej. 404 con un log line diferente, o 403)?
+4. **Frontera de PRs:** ¿Deben aterrizar los 4 fixes en un solo PR sobre `fix/heal-f1`, o deberíamos partir en (a) PR de alineación de tests RLS + (b) PR de email 409? La segunda es más limpia de review pero más lenta.
+5. **Alcance del primer slice:** Si tenemos que cortar, ¿cuál subset es el MVP — solo RLS, solo email, o los cuatro? El usuario ya aceptó el trabajo sin commitear de RLS session poisoning; ¿cuál es el mínimo para dar `fix/heal-f1` por hecho?
+
+## Riesgos
+
+| Riesgo | Likelihood | Mitigation |
+|--------|------------|------------|
+| El usuario elige Opción B para Cluster A y el refactor de capa de servicio rompe un flow que funciona | Media | Correr la suite completa de integración (no solo los 4 tests objetivo) antes de commit. El refactor está contenido a `app/modules/users/service.py` + el user router. |
+| Opción A para Cluster B deja la sesión en mal estado porque se olvidan `db.rollback()` tras `IntegrityError` | Baja–Media | Añadir un test de regresión que haga dos user creations en el mismo request: un duplicado, después un no-duplicado. El no-duplicado debe tener éxito. |
+| El campo `pgcode` en `IntegrityError.orig` es asyncpg-específico y puede cambiar de forma | Baja | Pin la dependencia y añadir un comentario nombrando el supuesto. |
+| El usuario espera una recomendación y empuja cuando no se da | Baja | Esta propuesta dice explícitamente "sin recomendación" upfront; la ronda de preguntas es el camino a una decisión. |
+
+## Plan de Rollback
+
+Cada opción es independientemente revertible:
+- **Cluster A Opción A**: revertir los cambios de tests (4 líneas).
+- **Cluster A Opción B**: revertir los cambios de capa de servicio y router; los tests vuelven a fallar.
+- **Cluster B Opciones A/B**: revertir el cambio en `create_user`; el test #3 vuelve a fallar.
+- Sin migraciones en el path recomendado → no se necesita rollback a nivel DB.
+- Si se añade una migración (solo si se elige Cluster B Opción C), `alembic downgrade()` es el rollback.
+
+## Dependencias
+
+- Los 3 archivos sin commitear de RLS session poisoning (`app/core/database.py`, `app/dependencies.py`, `tests/integration/test_auth_login_event_flow.py`) deben commitearse primero o como parte del mismo PR. Son el prerequisito que permite que cualquiera de los 4 tests objetivo corra en la sesión de DB correcta.
+- Sin cambios de librerías externas.
+
+## Criterios de Éxito
+
+- [ ] Los 4 tests de integración objetivo pasan en `fix/heal-f1`.
+- [ ] La suite completa de integración está verde (ningún otro test roto).
+- [ ] Sin policy RLS nueva ni migración nueva en el path recomendado.
+- [ ] La aproximación elegida está documentada en el código (un comentario en `create_user` para Opción A/B explicando el handler de IntegrityError, y/o un comentario en los tests afectados explicando el contrato 404 para Cluster A).
+- [ ] El fix de RLS session poisoning está commiteado como parte del mismo PR (o ya en la rama).

--- a/openspec/changes/archive/2026-06-30-fix-f1-remaining-rls-403-and-email-409/specs/fix-f1-remaining-rls-403-and-email-409/spec.md
+++ b/openspec/changes/archive/2026-06-30-fix-f1-remaining-rls-403-and-email-409/specs/fix-f1-remaining-rls-403-and-email-409/spec.md
@@ -1,0 +1,310 @@
+# Spec: fix-f1-remaining-rls-403-and-email-409
+
+## 1. Propósito
+
+Cerrar los últimos 4 tests de integración fallando en `fix/heal-f1` forzando dos cambios de contrato: (a) acceso cross-tenant sobre recursos de usuario DEBE devolver HTTP 403 (no 404) para que el evento sea distinguible en audit y access logs, y (b) email duplicado en creación de usuario DEBE devolver HTTP 409 incluso bajo insert concurrente. La spec introduce un pre-check de tenant en capa de servicio con elevación scoped de sesión superadmin para el contrato 403, y un traductor de `IntegrityError` en `create_user` para el contrato 409.
+
+## 2. Alcance
+
+**In scope**
+- Refactor de capa de servicio en `app/modules/users/service.py` para que las funciones que apuntan a usuario reciban `current_user` y comparen `tenant_id` en Python antes de cualquier DB read o write.
+- Elevación de la DB session del request-handler a contexto superadmin por la duración del pre-check SELECT, usando `set_config(..., true)` para que la elevación sea transaction-local y no pueda leakear cross requests en la connection pool.
+- Un wrapper `try/except IntegrityError` alrededor de `db.flush()` en `service.create_user` que traduzca `pgcode='23505'` a `UserError(status_code=409)` y haga rollback de la unidad de trabajo fallida.
+- Los 3 casos de test RLS en `tests/integration/test_tenants_integration.py:382`, `tests/integration/test_users_integration.py:280`, y `tests/integration/test_users_integration.py:615` DEBEN pasar con `status_code == 403`.
+- El test de email en `tests/integration/test_users_integration.py:527` DEBE pasar con `status_code == 409`.
+- Tests unitarios para las nuevas branches (pre-check de tenant 403, traductor IntegrityError → 409, rollback no envenena sesión).
+
+**Out of scope**
+- Cualquier modificación a las policies RLS en `migrations/versions/20260312_2052_initial_schema_712a827b0929.py:94-118` (las definiciones de `rls_tenants`, `rls_users`, `rls_refresh_tokens` son referencias read-only para este cambio).
+- Cualquier modificación a los 3 archivos sin commitear en `fix/heal-f1` que ya implementan el fix de RLS session poisoning: `app/core/database.py`, `app/dependencies.py`, y `tests/integration/test_auth_login_event_flow.py`. Esos aterrizan en su propio commit.
+- Cualquier trabajo de F2 bajo `openspec/changes/prd-v2-vertical-f2/`.
+- Sin nuevas migraciones alembic. Sin cambios de schema.
+- Sin cambio a la regla de producto de que `email` es globalmente único. Índices UNIQUE parciales por tenant están descartados.
+- Sin refactor de `_is_email_taken` más allá del mínimo necesario.
+- Sin reescritura del users router más allá del mínimo para pasar `current_user` al servicio.
+
+## 3. Non-Goals
+
+- Sin enrichment de audit log de accesos cross-tenant (el sistema aún no los loguea como clase de evento distinta — out of scope).
+- Sin replicación multi-region, sin nuevas métricas, sin tracing.
+- Sin cambio a la policy `rls_tenants` (que devuelve 404 para reads de tenant cross-tenant — `tests/integration/test_tenants_integration.py:406`).
+- Sin cambio a la policy `rls_refresh_tokens`.
+- Sin rate limiting o throttling en creación de usuarios.
+- Sin cambio a la jerarquía de roles (`viewer` < `admin` < `superadmin`).
+
+## 4. Frontera de PRs
+
+El cambio sale como exactamente 3 PRs contra `fix/heal-f1`:
+
+| PR | Título | Alcance | Test files afectados |
+|----|--------|---------|---------------------|
+| **PR-0** | RLS session poisoning (prerequisito) | Commit de los 3 archivos sin commitear. Sin cambios de diseño. | `tests/integration/test_auth_login_event_flow.py` |
+| **PR-A** | RLS: acceso cross-tenant a usuario devuelve 403 (pre-check en capa de servicio) | Refactor de capa de servicio: `get_user_by_id`, `update_user`, `deactivate_user` aceptan `current_user` y comparan `tenant_id`. Patrón de elevación en request-handler. | `tests/integration/test_tenants_integration.py:382`, `tests/integration/test_users_integration.py:280`, `tests/integration/test_users_integration.py:615`, `tests/integration/test_tenants_integration.py:406` |
+| **PR-B** | Unicidad de email: email duplicado devuelve 409 en race | `try/except IntegrityError` en `service.create_user` traducido a `UserError(409)`. | `tests/integration/test_users_integration.py:527` |
+
+Orden mandatorio: PR-0 → PR-A → PR-B. PR-0 es prerequisito duro (PR-A depende de las garantías de sesión RLS que PR-0 establece). PR-B puede aterrizar en cualquier orden relativo a PR-A, pero DEBE aterrizar después de PR-A para que el archivo `service.py` esté estabilizado.
+
+## 5. Requisitos
+
+### R01 — Cross-tenant user GET devuelve 403
+
+**Statement.** El sistema DEBE devolver HTTP 403 cuando un usuario no-superadmin solicita `GET /api/v1/users/{user_id}` y el `tenant_id` del usuario target difiere del `tenant_id` del caller.
+
+**Rationale.** Workflows de audit y compliance requieren que acceso cross-tenant aparezca como un evento distinto y distinguible en respuestas HTTP y access logs.
+
+**Acceptance criteria.**
+- El pre-check ocurre en la capa de servicio antes de cualquier query state-mutating o antes de devolver una respuesta "row not found".
+- El body de la respuesta 403 es JSON con `detail` indicando permisos insuficientes.
+- Un caller superadmin PUEDE leer cualquier usuario cross tenants y NO DEBE recibir 403 de este pre-check.
+
+**Scenarios.**
+
+- **S01.1 — Admin A lee el perfil de Admin B (caso GET del test #2).**
+  - GIVEN admin A autenticado en tenant A y admin B existe en tenant B con `id=ADMIN_B_ID`
+  - WHEN admin A llama `GET /api/v1/users/{ADMIN_B_ID}` con `admin_a_headers`
+  - THEN el status de respuesta es 403
+  - AND el `detail` del body de respuesta es un string no vacío
+
+- **S01.2 — Admin lee su propio usuario (sin falso positivo).**
+  - GIVEN admin A autenticado
+  - WHEN admin A llama `GET /api/v1/users/{ADMIN_A_ID}` (su propio id) con `admin_a_headers`
+  - THEN el status de respuesta es 200
+  - AND el body de respuesta contiene el registro de admin A
+
+- **S01.3 — Superadmin lee usuario de cualquier tenant.**
+  - GIVEN un superadmin autenticado
+  - WHEN el superadmin llama `GET /api/v1/users/{ADMIN_B_ID}`
+  - THEN el status de respuesta es 200
+  - AND el body de respuesta contiene el registro de admin B
+
+### R02 — Cross-tenant user PATCH devuelve 403
+
+**Statement.** El sistema DEBE devolver HTTP 403 cuando un usuario no-superadmin solicita `PATCH /api/v1/users/{user_id}` y el `tenant_id` del usuario target difiere del `tenant_id` del caller. Ningún campo de fila se modifica.
+
+**Rationale.** Simétrico con R01 para operaciones de write. Un pre-check que permita al read leakear (ej. vía el pre-check SELECT) y solo bloquee la mutación no es aceptable.
+
+**Acceptance criteria.**
+- El pre-check ocurre antes de `db.flush()` sobre el registro de usuario.
+- El pre-check eleva 403 y cortocircuita el resto del flow de update.
+- La DB no se muta (sin estado parcial).
+
+**Scenarios.**
+
+- **S02.1 — Admin A parchea Admin B (caso PATCH del test #2).**
+  - GIVEN admin A autenticado en tenant A y admin B existe en tenant B
+  - WHEN admin A llama `PATCH /api/v1/users/{ADMIN_B_ID}` con `{"full_name": "Hacked"}` y `admin_a_headers`
+  - THEN el status de respuesta es 403
+  - AND el `full_name` de admin B en la DB queda sin cambios (verificado por un read exitoso posterior)
+
+- **S02.2 — Superadmin PATCH is_active=False sobre sí mismo devuelve 409 (comportamiento existente, no regresionado).**
+  - GIVEN un superadmin autenticado
+  - WHEN el superadmin llama `PATCH /api/v1/users/{SUPERADMIN_ID}` con `{"is_active": false}`
+  - THEN el status de respuesta es 409 (protección de self-deactivation)
+  - AND el `is_active` del superadmin queda sin cambios
+
+- **S02.3 — Admin PATCH is_active=False sobre superadmin devuelve 403 (test #4).**
+  - GIVEN admin A autenticado y un superadmin existe con `id=SUPERADMIN_ID`
+  - WHEN admin A llama `PATCH /api/v1/users/{SUPERADMIN_ID}` con `{"is_active": false}` y `admin_a_headers`
+  - THEN el status de respuesta es 403
+  - AND el `is_active` del superadmin en la DB queda sin cambios
+
+### R03 — Cross-tenant user DELETE devuelve 403
+
+**Statement.** El sistema DEBE devolver HTTP 403 cuando un usuario no-superadmin solicita `DELETE /api/v1/users/{user_id}` y el `tenant_id` del usuario target difiere del `tenant_id` del caller.
+
+**Rationale.** Simétrico con R01 y R02. Deactivación cross-tenant debe bloquearse lo más temprano posible, antes de cualquier token revocation o flip de `is_active`.
+
+**Acceptance criteria.**
+- El pre-check ocurre antes de que `is_active` se setee a `False` y antes de cualquier token revocation.
+
+**Scenarios.**
+
+- **S03.1 — Admin A deletea Admin B (caso DELETE del test #2).**
+  - GIVEN admin A autenticado en tenant A y admin B existe en tenant B
+  - WHEN admin A llama `DELETE /api/v1/users/{ADMIN_B_ID}` con `admin_a_headers`
+  - THEN el status de respuesta es 403
+  - AND el `is_active` de admin B en la DB queda sin cambios
+
+- **S03.2 — Admin deletea superadmin devuelve 403.**
+  - GIVEN admin A autenticado y un superadmin existe
+  - WHEN admin A llama `DELETE /api/v1/users/{SUPERADMIN_ID}` con `admin_a_headers`
+  - THEN el status de respuesta es 403
+  - AND el `is_active` del superadmin en la DB queda sin cambios
+
+### R04 — Funciones de capa de servicio reciben `current_user` y comparan `tenant_id`
+
+**Statement.** Las funciones de servicio `get_user_by_id`, `update_user` y `deactivate_user` DEBEN aceptar un parámetro `current_user: User` y comparar su `tenant_id` con el `tenant_id` del usuario target antes de devolver data o mutar estado. En mismatch, la función DEBE elevar una excepción mapeada a 403.
+
+**Rationale.** Centralizar el check en la capa de servicio es el lugar convencional donde futuros engineers buscarán reglas de autorización. Devolver 403 desde un único chokepoint es auditable y testeable.
+
+**Acceptance criteria.**
+- El parámetro `current_user` es posicional o keyword y es requerido (sin default).
+- La comparación de `tenant_id` ocurre ANTES de cualquier `db.flush()` y ANTES de que la función devuelva la fila al router.
+- Un `current_user` superadmin se salta la comparación.
+- El 403 se mapea a través de la traducción existente `UserError` → `HTTPException` en el router.
+
+### R05 — Elevación de superadmin en request-handler está scoped al pre-check
+
+**Statement.** Cuando el request handler necesita leer una fila de usuario que RLS ocultaría del contexto de tenant del caller (para que el servicio pueda correr el tenant pre-check), el handler DEBE elevar la DB session del request a contexto superadmin solo para el pre-check SELECT, y DEBE restaurar el contexto de tenant del caller para la mutación o read posterior.
+
+**Rationale.** Sin elevación, RLS oculta la fila cross-tenant, `get_user_by_id` devuelve `None`, y el pre-check es inalcanzable. Con elevación no controlada, la superficie de bypass se expande y el pool bleed de conexión es posible.
+
+**Acceptance criteria.**
+- La elevación usa `SELECT set_config('app.is_superadmin', 'true', true)` — el tercer argumento `true` hace el setting transaction-local (`SET LOCAL`), así que se limpia automáticamente en COMMIT/ROLLBACK y no puede leakear al siguiente request que reuse la conexión pooled.
+- La elevación también llama `SELECT set_config('app.current_tenant', '', true)` para neutralizar cualquier tenant scope previo.
+- El bloque de elevación contiene exactamente el SELECT que lee la fila target.
+- Tras el pre-check, el handler DEBE llamar `set_tenant_context(db, current_user.tenant_id, current_user.is_superadmin)` para restaurar el contexto de request canónico antes de invocar la mutación de servicio.
+- El mismo patrón `SET LOCAL` usado en el `app/dependencies.py:90-93` sin commitear (dentro de `get_current_user`) es el modelo.
+
+### R06 — Flujos same-tenant normales quedan bajo contexto de tenant
+
+**Statement.** Un request usuario-a-usuario-en-mismo-tenant (ej. admin A PATCHea viewer A, o cualquier read same-tenant) DEBE ejecutarse enteramente bajo el contexto de tenant del caller sin elevación de superadmin. RLS sigue protegiendo el path.
+
+**Rationale.** El pre-check solo es necesario cuando la fila target NO es visible bajo el tenant del caller. Para operaciones same-tenant, RLS es la única fuente de verdad y la elevación es innecesaria e insegura.
+
+**Acceptance criteria.**
+- Un handler que detecte `target.tenant_id == current_user.tenant_id` NO DEBE llamar `set_config('app.is_superadmin', 'true', ...)`.
+- Tests same-tenant (ej. `test_admin_can_update_user_in_same_tenant`) siguen pasando sin nuevos `set_config` en sus paths.
+
+### R07 — Email duplicado en `POST /api/v1/users/` devuelve 409
+
+**Statement.** Cuando `POST /api/v1/users/` se llama con un `email` que ya existe en la tabla `users` (en cualquier tenant), el sistema DEBE devolver HTTP 409, incluso bajo la condición de carrera donde el duplicado se crea entre el pre-check y el INSERT.
+
+**Rationale.** El pre-check actual `_is_email_taken` tiene una ventana TOCTOU: dos requests concurrentes con el mismo email ambos pasan el pre-check, la `users_email_key` UNIQUE constraint de la DB dispara, y la aplicación devuelve HTTP 500. Unicidad global de email es una regla de producto dura, y el contrato es 409.
+
+**Acceptance criteria.**
+- El 409 se devuelve tanto en el path de pre-check (comportamiento actual) como en el path post-flush (comportamiento nuevo).
+- El 409 post-flush es el resultado de un `IntegrityError` traducido.
+- El mensaje de error está en español para coincidir con el resto de los mensajes 4xx user-facing del módulo: `"El email ya está registrado"`.
+
+**Scenarios.**
+
+- **S07.1 — Email duplicado secuencial (primera mitad del test #3).**
+  - GIVEN admin A autenticado
+  - WHEN admin A llama `POST /api/v1/users/` con `email=duplicate@test.test` y `tenant_id=TENANT_A_ID`
+  - THEN el status de respuesta es 201
+  - AND cuando admin A llama `POST /api/v1/users/` de nuevo con el mismo `email` (cualquier `tenant_id`)
+  - THEN el status de respuesta es 409
+  - AND el `detail` del body de respuesta contiene la frase "ya está registrado"
+
+- **S07.2 — Email duplicado cross-tenant.**
+  - GIVEN un usuario con `email=duplicate@test.test` ya existe en tenant A
+  - WHEN admin B llama `POST /api/v1/users/` con `email=duplicate@test.test` y `tenant_id=TENANT_B_ID`
+  - THEN el status de respuesta es 409
+
+### R08 — `IntegrityError` se traduce solo en `pgcode == '23505'`
+
+**Statement.** `service.create_user` DEBE capturar `sqlalchemy.exc.IntegrityError` después de `db.flush()` e inspeccionar `e.orig.pgcode`. La traducción a `UserError(status_code=409)` DEBE ocurrir solo cuando `pgcode == '23505'` (PostgreSQL `unique_violation`). Todas las demás variantes de `IntegrityError` (violaciones FK `23503`, violaciones check `23514`, etc.) DEBEN propagarse sin traducir.
+
+**Rationale.** Capturar `IntegrityError` ampliamente y traducir a 409 enmascararía violaciones FK y check que indican bugs genuinos de data integrity. El filtro `pgcode` es el atributo documentado de asyncpg/SQLAlchemy que identifica unique_violation.
+
+**Acceptance criteria.**
+- La cláusula `except` chequea `e.orig.pgcode == '23505'` exactamente.
+- Otras variantes de `IntegrityError` re-elevan la excepción original (o la envuelven en un `UserError` no-409 si la fase de diseño lo decide — pero NO 409).
+- Un comentario de código nombra el supuesto asyncpg-específico sobre `e.orig.pgcode`.
+
+**Scenarios.**
+
+- **S08.1 — IntegrityError no-23505 se propaga.**
+  - GIVEN se puede construir un escenario de violación de FK (ej. POST con un `tenant_id` que referencia un tenant inexistente — aunque el pre-check `_get_active_tenant` hace difícil llegar, el test debe usar un fixture a nivel unitario que inyecte un `IntegrityError` falso con `pgcode='23503'`)
+  - WHEN `service.create_user` se llama bajo ese fixture
+  - THEN el `IntegrityError` original se propaga fuera de la función
+  - AND el status de respuesta es 500 (o lo que sea que el global handler mapee `IntegrityError` a), NO 409
+
+### R09 — Sesión se hace rollback tras `IntegrityError` traducido
+
+**Statement.** Cuando `service.create_user` captura el `IntegrityError` `unique_violation`, la función DEBE `await db.rollback()` antes de elevar el `UserError(409)` traducido.
+
+**Rationale.** Tras un `flush()` fallido la sesión de SQLAlchemy queda en estado fallido: la siguiente operación en el mismo request (ej. un `db.execute` de seguimiento en el router o un global handler) elevará `PendingRollbackError`. Rollback explícito limpia el estado fallido.
+
+**Acceptance criteria.**
+- `await db.rollback()` se llama entre el `except` y el raise.
+- Un test de regresión ejercita dos user creations en el mismo request: la primera es un duplicado (eleva 409), la segunda es un no-duplicado (debe tener éxito). Si rollback falta, la segunda llamada eleva `PendingRollbackError`.
+
+**Scenarios.**
+
+- **S09.1 — Duplicado y no-duplicado en el mismo request.**
+  - GIVEN un usuario con `email=first@test.test` ya existe
+  - WHEN un test client hace dos llamadas `POST /api/v1/users/` en el mismo request/session: primero con `email=first@test.test` (espera 409), después con `email=second@test.test` (espera 201)
+  - THEN la segunda llamada devuelve 201
+  - AND el usuario con `email=second@test.test` queda persistido
+
+### R10 — Sin regresión en tests existentes que pasan
+
+**Statement.** Todos los tests de integración que pasan en el working tree actual de `fix/heal-f1` (excluyendo los 4 fallos objetivo) DEBEN seguir pasando tras aterrizar PR-A y PR-B.
+
+**Rationale.** El refactor de las signatures de funciones de capa de servicio y el patrón de elevación es el cambio de mayor riesgo en esta spec. La suite completa de integración es la red de regresión.
+
+**Acceptance criteria.**
+- El run completo de `pytest tests/integration/` en `fix/heal-f1` está verde tras aterrizar PR-A.
+- El run completo de `pytest tests/integration/` está verde tras aterrizar PR-B.
+- Ruff y mypy (si está configurado) no reportan nuevas violaciones.
+
+## 6. Cross-Cutting Requirements
+
+**Seguridad.**
+- La elevación de superadmin usa `set_config(..., true)` (tercer argumento), que produce un `SET LOCAL` que se limpia automáticamente al final de la transacción. Esto es no-negociable: un `set_config(..., false)` leakearía cross requests en la conexión pooled.
+- El bloque de elevación en el handler DEBE ser lo más angosto posible (un único SELECT) y DEBE ir seguido de una llamada a `set_tenant_context(...)` que re-establezca el contexto de tenant del caller.
+- Ninguna función de servicio almacena la sesión elevada en una variable a nivel de módulo. La `db: AsyncSession` es la dependencia scoped al request y no se comparte.
+
+**Observabilidad.**
+- Las llamadas existentes `logger.info("user_created", ...)` y `logger.info("user_updated", ...)` siguen disparando en éxito.
+- Una línea de log `logger.warning("cross_tenant_access_blocked", caller_id=..., target_id=..., endpoint=...)` se emite en el sitio del raise 403. Esta es la única línea de log nueva requerida por la spec; es la señal que los auditores buscarán.
+- Sin nuevas métricas ni traces.
+
+**Forma de respuesta de error.**
+- Todas las respuestas 4xx son JSON de la forma `{"detail": "<message>"}` (default de FastAPI), que coincide con las respuestas existentes de este módulo.
+- Mensajes 403 para acceso cross-tenant están en español: `"Permisos insuficientes"` (coincide con el mensaje existente en `app/modules/users/router.py:117` y `:160`).
+- 409 para email duplicado está en español: `"El email ya está registrado"` (coincide con el mensaje existente en `app/modules/users/service.py:52`).
+
+**Cobertura de tests.**
+- Tests unitarios para las nuevas branches: (a) tenant pre-check devuelve 403 en mismatch, (b) tenant pre-check se bypasea para superadmin, (c) `IntegrityError` con `pgcode='23505'` se traduce a 409, (d) `IntegrityError` con otro `pgcode` se propaga, (e) rollback limpia la sesión fallida.
+- Los 4 tests de integración objetivo siguen siendo la prueba end-to-end.
+- Ruff y mypy DEBEN pasar. El cambio de signature de función en R04 es un breaking API change para callers directos de las funciones de servicio — la fase de diseño DEBE auditarlos y actualizarlos.
+
+## 7. Open Questions
+
+- **OQ-1.** ¿Debería la línea de log del 403 cross-tenant incluir el `endpoint` y HTTP method? La spec requiere al menos `caller_id` y `target_id`, pero la fase de diseño puede querer el method para distinguir reads intentados de writes intentados para ponderación de audit.
+- **OQ-2.** Para el patrón de elevación: ¿debería el handler restaurar el contexto de tenant ANTES de llamar al pre-check del servicio (así el servicio corre el SELECT bajo el tenant del caller y el SELECT devuelve naturalmente None para filas cross-tenant), o DESPUÉS de llamar al pre-check del servicio (así el SELECT del servicio corre bajo superadmin y lee explícitamente la fila cross-tenant)? La spec dice que R05 eleva ANTES del pre-check SELECT; la fase de diseño puede querer invertir esto y tener el pre-check SELECT ocurriendo bajo el tenant del caller y devolviendo None (que entonces se mapearía a 404, no 403 — contradiciendo R01). La fase de diseño DEBE resolver esto; la spec requiere el outcome 403.
+- **OQ-3.** ¿Debería `get_user_by_id` partirse en dos funciones — una que devuelva `None` para "fila no visible bajo RLS" (usada por el path de self-read del router) y otra que devuelva la fila solo tras un tenant-match check (usada por el path de pre-check cross-tenant)? ¿O debería una única función tomar un argumento `current_user` y el caller decide qué comportamiento quiere vía un flag? La spec no exige una shape sobre la otra.
+- **OQ-4.** Los 3 archivos sin commitear de RLS session poisoning (`app/core/database.py`, `app/dependencies.py`, `tests/integration/test_auth_login_event_flow.py`) — ¿se commitean como un PR prerequisito separado antes de PR-A, o como parte de PR-A? La spec dice que están out of scope y no deben modificarse, pero el orden de deployment es una pregunta de proceso, no técnica.
+
+## 8. Riesgos
+
+| ID | Riesgo | Likelihood | Impact | Mitigation |
+|----|--------|------------|--------|------------|
+| RK-1 | El cambio de signature de función en R04 rompe callers directos de las funciones de servicio (cualquier otro módulo que importe `service.get_user_by_id`, `service.update_user` o `service.deactivate_user`). | Media | Media | La fase de diseño DEBE grepear por callers y actualizarlos. El refactor es un cambio de signature duro, no una adición backward-compatible. |
+| RK-2 | El patrón de elevación en R05 deja una ventana entre `set_config('app.is_superadmin', 'true')` y el `set_tenant_context` posterior donde la sesión es superadmin. Si una excepción se eleva dentro del bloque de elevación, el rollback limpia el `SET LOCAL`, así que no hay leak — pero un lector de código que vea el patrón podría copiarlo sin la garantía de rollback. | Baja | Alta | La fase de diseño DEBE añadir un comentario de código nombrando la garantía de `SET LOCAL` y la dependencia de rollback. El patrón ya se usa en `app/dependencies.py:90-93`, así que el precedente está en el mismo archivo. |
+| RK-3 | `e.orig.pgcode` es asyncpg-específico. Si SQLAlchemy algún día cambia el async driver a uno que no popule `pgcode` (ej. psycopg3 async), la traducción de `IntegrityError` silenciosamente deja de funcionar y devuelve 500. | Baja | Media | Pin asyncpg en el manifiesto de dependencias. Añadir un comentario de código nombrando el supuesto. Opcionalmente, fallback a matchear por string el nombre de la constraint en el mensaje de error. |
+| RK-4 | El test de email duplicado en `test_users_integration.py:527` puede haberse escrito asumiendo 404 (no 409) en el duplicado cross-tenant — la spec asume 409 basándose en el nombre del test y el record de decisión. Si el body del test realmente afirma 404 en algún lugar, la fase de diseño DEBE actualizarlo. | Baja | Baja | La fase de diseño lee el test completo antes de diseñar la traducción de excepción. |
+| RK-5 | PR-A y PR-B ambos tocan `app/modules/users/service.py`. Si PR-B aterriza primero o se rebasa sobre el estado sin mergear de PR-A, el diff queda sucio. | Baja | Baja | La sección de frontera de PRs exige PR-A primero, PR-B segundo. |
+| RK-6 | La aserción de `test_tenants_integration.py:406` (`assert resp.status_code == 404` para `GET /tenants/{id}` cross-tenant) está IN SCOPE para PR-A y DEBE pasar a 403. La decisión de diseño es unificar el contrato 403 cross-tenant. | Baja | Media | La sección de Alcance de la spec nombra explícitamente este test. La descripción del PR debe llamarlo out. |
+
+## 9. Resumen del Test Plan
+
+| Requirement | Test file (new) | Test file (existing) | Line |
+|-------------|-----------------|----------------------|------|
+| R01 | `tests/unit/test_users_service.py::test_get_user_by_id_raises_403_on_tenant_mismatch` | `tests/integration/test_tenants_integration.py` | 382 |
+| R01 | `tests/unit/test_users_service.py::test_get_user_by_id_returns_user_for_superadmin` | `tests/integration/test_users_integration.py` | 280 |
+| R02 | `tests/unit/test_users_service.py::test_update_user_raises_403_on_tenant_mismatch_no_flush` | `tests/integration/test_users_integration.py` | 280 |
+| R02 | `tests/unit/test_users_service.py::test_update_user_raises_403_when_admin_patches_superadmin` | `tests/integration/test_users_integration.py` | 615 |
+| R03 | `tests/unit/test_users_service.py::test_deactivate_user_raises_403_on_tenant_mismatch` | `tests/integration/test_users_integration.py` | 280 |
+| R04 | `tests/unit/test_users_service.py::test_service_functions_require_current_user_arg` | — | — |
+| R05 | `tests/unit/test_users_service.py::test_handler_restores_tenant_context_after_pre_check` (o test de integración sobre el router) | — | — |
+| R06 | `tests/integration/test_users_integration.py` (tests same-tenant existentes no deben regresar) | `tests/integration/test_users_integration.py` | varios |
+| R07 | `tests/unit/test_users_service.py::test_create_user_translates_unique_violation_to_409` | `tests/integration/test_users_integration.py` | 527 |
+| R08 | `tests/unit/test_users_service.py::test_create_user_propagates_non_unique_integrity_error` | — | — |
+| R09 | `tests/unit/test_users_service.py::test_create_user_rolls_back_failed_session` | — | — |
+| R10 | — | full `pytest tests/integration/` | — |
+
+## 10. Plan de Rollback
+
+**PR-0 rollback.** Revertir el commit. Los tests vuelven a su estado pre-fix (los 3 RLS session poisoning tests vuelven a fallar; los 4 objetivo siguen fallando).
+
+**PR-A rollback.** Revertir el PR. Los 3 tests objetivo vuelven a fallar; `fix/heal-f1` vuelve al estado pre-PR-A. Los 3 archivos sin commitear de RLS session poisoning se quedan en la rama.
+
+**PR-B rollback.** Revertir el PR. El test de email duplicado en `tests/integration/test_users_integration.py:527` vuelve a fallar bajo la condición de carrera; el caso secuencial (capturado por el pre-check) sigue funcionando.
+
+**Rollback de entorno tipo producción.** Los 3 PRs son código de aplicación puro; no hay migraciones involucradas. Un revert-and-redeploy es suficiente. No se necesita rollback a nivel DB.
+
+**Orden de operaciones.** Si los 3 PRs están desplegados y PR-A debe rollbackearse, rollback PR-A primero mientras PR-0 y PR-B se quedan. El contrato 409 es independiente del contrato 403. El orden inverso (rollback PR-B primero) también es seguro.

--- a/openspec/changes/archive/2026-06-30-fix-f1-remaining-rls-403-and-email-409/tasks.md
+++ b/openspec/changes/archive/2026-06-30-fix-f1-remaining-rls-403-and-email-409/tasks.md
@@ -1,0 +1,305 @@
+# Tasks: fix-f1-remaining-rls-403-and-email-409
+
+## Review Workload Forecast
+
+| Field | Value |
+|-------|-------|
+| Estimated changed lines (total) | ~180–220 (PR-0: ~10, PR-A: ~120–150, PR-B: ~50–60) |
+| 400-line budget risk | Low (per PR and total) |
+| Chained PRs recommended | Yes — PR-0 → PR-A → PR-B (dependencia dura: PR-A depende de las garantías de sesión que PR-0 establece) |
+| Suggested split | PR-0 (prerequisito) + PR-A (RLS 403) + PR-B (email 409) — ya decidido |
+| Delivery strategy | ask-on-risk (default) — el usuario debe confirmar el plan chained de 3 PRs antes de sdd-apply |
+| Chain strategy | stacked-to-main — cada PR mergea a main en orden; PR-0 es tiny, PR-A y PR-B son independientemente revertibles |
+
+Decision needed before apply: Yes
+Chained PRs recommended: Yes
+Chain strategy: stacked-to-main
+400-line budget risk: Low
+
+### Suggested Work Units
+
+| Unit | Goal | Likely PR | Base branch | Notes |
+|------|------|-----------|-------------|-------|
+| 1 | Commit uncommitted RLS session-poisoning files | PR-0 | `fix/heal-f1` | Sin cambio de diseño, prerequisito para PR-A |
+| 2 | Service-layer pre-check devuelve 403 en cross-tenant user/tenant access | PR-A | `fix/heal-f1` (after PR-0) | Nueva Depends, service split, router updates, test fix at line 406 |
+| 3 | Email duplicado devuelve 409 vía IntegrityError translator | PR-B | `fix/heal-f1` (after PR-A) | try/except en `create_user` + unit tests; toca el mismo `service.py` así que aterriza después de que PR-A lo estabilice |
+
+---
+
+## Phase 1: PR-0 — Commit RLS session-poisoning prerequisite
+
+**Goal:** Aterrizar los 3 archivos sin commitear de RLS session-poisoning como un único conventional commit. Sin cambios de diseño, sin cambios de spec. Baja los fallos de tests de integración de 7 a 4 (los 3 RLS session-poisoning tests empiezan a pasar).
+
+- [x] **T-PR0.01** Commit los 3 archivos sin commitear con conventional commit
+  - `fix(rls): prevent session poisoning across pooled connections`
+  - Files: `app/core/database.py`, `app/dependencies.py`, `tests/integration/test_auth_login_event_flow.py`
+  - Verificar `git diff --staged` muestra ~7 inserted / 2 deleted lines en total
+  - Acceptance: Single commit en `fix/heal-f1`; sin cambios de diseño; diff matchea el handoff acordado
+  - Test: `git log -1 --stat` muestra exactamente los 3 archivos
+
+- [x] **T-PR0.02** Run integration suite y confirmar 4 fallos restantes
+  - `uv run pytest tests/integration/ -v 2>&1 | tail -50`
+  - Acceptance: Test count baja de 7 fallos a 4 (los 3 RLS session-poisoning tests ahora pasan; los 4 RLS-403/email-409 tests siguen fallando)
+  - Test: `uv run pytest tests/integration/test_auth_login_event_flow.py -v` → todo verde
+
+- [x] **T-PR0.VERIFY** PR-0 verification
+  - Run full integration suite
+  - Test: `uv run pytest tests/integration/ -v`
+  - Acceptance: 4 fallos conocidos quedan (no 7); sin nuevos fallos introducidos
+
+---
+
+## Phase 2: PR-A — RLS service-layer pre-check (cross-tenant 403)
+
+**Goal:** Acceso cross-tenant sobre endpoints de user y tenant devuelve 403 vía una nueva FastAPI Depends que eleva, chequea y restaura. Capa de servicio queda auth-clean. `test_tenants_integration.py:406` actualizado para esperar 403 (contrato unificado según RK-6).
+
+### 2.1 Foundation: nueva Depends en `app/dependencies.py`
+
+- [x] **T-PRA.01** Añadir `_log_cross_tenant_attempt` helper a `app/dependencies.py`
+  - Single chokepoint para la línea de log del 403 (decisión OQ-1)
+  - Fields: `caller_id`, `target_id`, `method`, `endpoint`; NO `tenant_id` (avoidance de info sensible)
+  - Files: `app/dependencies.py`
+  - Acceptance: Helper definido; `logger.warning("cross_tenant_access_blocked", ...)` call con exactamente 4 fields
+  - Test: unit test en `tests/unit/test_dependencies.py::test_log_cross_tenant_attempt_includes_required_fields`
+  - Dependencies: none
+  - Size: S
+  - Spec: R01, R03 (observability cross-cutting)
+
+- [x] **T-PRA.02** Añadir `_get_user_for_admin` core helper a `app/dependencies.py`
+  - Eleva vía `set_config('app.is_superadmin', 'true', true)` + `set_config('app.current_tenant', '', true)` (par SET LOCAL)
+  - SELECTea la fila target, compara `row.tenant_id` con `current_user.tenant_id`, restaura contexto vía `set_tenant_context`
+  - Superadmin path: sin elevación, devuelve fila o 404
+  - Files: `app/dependencies.py`
+  - Acceptance: Helper definido con signature `(user_id, current_user, db, method, endpoint) -> User`; eleva 403 en mismatch, 404 en missing row
+  - Test: unit test en `tests/unit/test_dependencies.py::test_get_user_for_admin_*` (4 cases: same-tenant, cross-tenant, superadmin, missing)
+  - Dependencies: T-PRA.01
+  - Size: M
+  - Spec: R01, R02, R03, R04, R05
+
+- [x] **T-PRA.03** Añadir factory + wrappers `get_user_for_admin_get/patch/delete` a `app/dependencies.py`
+  - `_user_for_admin(method)` factory devuelve una Depends de una línea que llama al core helper con el label de method correcto
+  - Tres wrappers: `get_user_for_admin_get`, `get_user_for_admin_patch`, `get_user_for_admin_delete`
+  - Files: `app/dependencies.py`
+  - Acceptance: Tres Depends públicas exportadas; docstring en factory dice "add a new wrapper when adding a new HTTP method"
+  - Test: unit test en `tests/unit/test_dependencies.py::test_user_for_admin_wrappers_exist`
+  - Dependencies: T-PRA.02
+  - Size: S
+  - Spec: R04, R05
+
+- [x] **T-PRA.04** Añadir `get_tenant_for_admin` core helper + `get_tenant_for_admin_get` wrapper a `app/dependencies.py`
+  - Compara URL `tenant_id` con `current_user.tenant_id` ANTES de cualquier SELECT (inversión de la user Depends)
+  - No se necesita elevación para 403 cross-tenant (pre-check corre en Python)
+  - Superadmin path: sin pre-check, devuelve fila o 404
+  - Files: `app/dependencies.py`
+  - Acceptance: Helper definido; eleva 403 en mismatch, 404 en missing row cuando same-tenant
+  - Test: unit test en `tests/unit/test_dependencies.py::test_get_tenant_for_admin_*` (3 cases: same-tenant, cross-tenant, superadmin)
+  - Dependencies: T-PRA.01
+  - Size: M
+  - Spec: R01 (tenants), RK-6 (contrato unificado)
+
+### 2.2 Capa de servicio: `app/modules/users/service.py`
+
+- [x] **T-PRA.05** Partir `get_user_by_id` en `get_user_for_admin` + `get_user_internal`
+  - `get_user_for_admin(current_user, target_id, db)` — pre-checked read, eleva UserError(404) si la fila desapareció (TOCTOU)
+  - `get_user_internal(target_id, db)` — system/superadmin path, sin pre-check, devuelve User | None
+  - Files: `app/modules/users/service.py`
+  - Acceptance: Dos funciones definidas; viejo `get_user_by_id` removido; callers actualizados
+  - Test: unit tests en `tests/unit/test_users_service.py::test_get_user_for_admin_*` y `test_get_user_internal_*`
+  - Dependencies: none
+  - Size: M
+  - Spec: R04 (decisión OQ-3)
+
+- [x] **T-PRA.06** Reescribir `update_user` para aceptar target pre-checked
+  - Nueva signature: `update_user(current_user, target, data, db, redis)` — target es una fila User pre-checked desde la Depends
+  - Remover la llamada interna a `get_user_by_id` (la Depends ya fetcheó y autorizó la fila)
+  - Files: `app/modules/users/service.py`
+  - Acceptance: Función acepta parámetro `target`; sin DB fetch interno; field-application logic sin cambios
+  - Test: unit test en `tests/unit/test_users_service.py::test_update_user_does_not_fetch_target`
+  - Dependencies: T-PRA.05
+  - Size: S
+  - Spec: R02, R04, RK-7 (contrato de signature)
+
+- [x] **T-PRA.07** Reescribir `deactivate_user` para aceptar target pre-checked
+  - Nueva signature: `deactivate_user(current_user, target, db, redis)` — target está pre-checked
+  - Files: `app/modules/users/service.py`
+  - Acceptance: Función acepta parámetro `target`; sin DB fetch interno
+  - Test: unit test en `tests/unit/test_users_service.py::test_deactivate_user_does_not_fetch_target`
+  - Dependencies: T-PRA.05
+  - Size: S
+  - Spec: R03, R04, RK-7
+
+### 2.3 Router wiring: `app/modules/users/router.py`
+
+- [x] **T-PRA.08** Actualizar handlers GET/PATCH/DELETE de `app/modules/users/router.py`
+  - GET `/{user_id}`: usa `Depends(get_user_for_admin_get)`; remover la llamada directa a `get_user_by_id`
+  - PATCH `/{user_id}`: usa `Depends(get_user_for_admin_patch)`; pasa `target` a `service.update_user`
+  - DELETE `/{user_id}`: usa `Depends(get_user_for_admin_delete)`; pasa `target` a `service.deactivate_user`
+  - Mantener los checks de policy in-router existentes (self-deactivation 409, admin-modifies-superadmin 403, role hierarchy 403)
+  - Files: `app/modules/users/router.py`
+  - Acceptance: Tres handlers usan la nueva Depends; las llamadas al servicio pasan el parámetro `target`
+  - Test: `uv run pytest tests/integration/test_users_integration.py::test_admin_a_never_access_tenant_b_resources -v`
+  - Dependencies: T-PRA.03, T-PRA.06, T-PRA.07
+  - Size: M
+  - Spec: R01, R02, R03, R04
+
+### 2.4 Router wiring: `app/modules/tenants/router.py`
+
+- [x] **T-PRA.09** Actualizar handler GET de `app/modules/tenants/router.py`
+  - GET `/{tenant_id}`: usa `Depends(get_tenant_for_admin_get)`; remover los inline 404 checks en líneas 64-66 y 71-76
+  - Files: `app/modules/tenants/router.py`
+  - Acceptance: Handler usa la nueva Depends; inline 404 checks removidos
+  - Test: `uv run pytest tests/integration/test_tenants_integration.py::test_cross_tenant_isolation_complete -v`
+  - Dependencies: T-PRA.04
+  - Size: S
+  - Spec: R01 (tenants), RK-6
+
+### 2.5 Test updates
+
+- [x] **T-PRA.10** Actualizar `tests/integration/test_tenants_integration.py:406` de 404 a 403
+  - Según RK-6: contrato unificado significa que GET cross-tenant tenant devuelve 403, no 404
+  - Files: `tests/integration/test_tenants_integration.py`
+  - Acceptance: `assert resp.status_code == 403` en línea 406; test pasa
+  - Test: `uv run pytest tests/integration/test_tenants_integration.py -v`
+  - Dependencies: T-PRA.09
+  - Size: S
+  - Spec: R01 (tenants), RK-6
+
+- [x] **T-PRA.11** Añadir unit tests para `get_user_for_admin` (4 cases)
+  - `test_get_user_for_admin_returns_row_on_match` — same tenant
+  - `test_get_user_for_admin_raises_403_on_tenant_mismatch` — non-superadmin, cross-tenant
+  - `test_get_user_for_admin_returns_row_for_superadmin` — superadmin
+  - `test_get_user_for_admin_raises_404_on_missing_row` — id no existente
+  - Files: `tests/unit/test_dependencies.py`
+  - Acceptance: Los 4 tests pasan
+  - Test: `uv run pytest tests/unit/test_dependencies.py -v -k user_for_admin`
+  - Dependencies: T-PRA.02
+  - Size: M
+  - Spec: R01, R04, R05
+
+- [x] **T-PRA.12** Añadir unit tests para `get_tenant_for_admin` (3 cases)
+  - `test_get_tenant_for_admin_returns_own_tenant` — same-tenant
+  - `test_get_tenant_for_admin_returns_403_for_cross_tenant` — non-superadmin, cross-tenant (NO 404)
+  - `test_get_tenant_for_admin_returns_row_for_superadmin` — superadmin
+  - Files: `tests/unit/test_dependencies.py`
+  - Acceptance: Los 3 tests pasan
+  - Test: `uv run pytest tests/unit/test_dependencies.py -v -k tenant_for_admin`
+  - Dependencies: T-PRA.04
+  - Size: M
+  - Spec: R01 (tenants), RK-6
+
+- [x] **T-PRA.13** Añadir unit test para `_log_cross_tenant_attempt`
+  - Asserts la log call tiene `caller_id`, `target_id`, `method`, `endpoint`; NO `tenant_id`
+  - Files: `tests/unit/test_dependencies.py`
+  - Acceptance: Test pasa; verifica exactamente 4 fields
+  - Test: `uv run pytest tests/unit/test_dependencies.py -v -k log_cross_tenant`
+  - Dependencies: T-PRA.01
+  - Size: S
+  - Spec: OQ-1 (decisions)
+
+- [x] **T-PRA.VERIFY** PR-A verification — full integration suite
+  - Run: `uv run pytest tests/integration/ -v`
+  - Acceptance: 0 fallos (los 4 tests objetivo pasan, sin regresiones)
+  - Test: full integration suite green
+  - Dependencies: T-PRA.08, T-PRA.09, T-PRA.10
+  - Size: S
+  - Spec: R10
+
+---
+
+## Phase 3: PR-B — Email 409 translation
+
+**Goal:** Email duplicado en `POST /api/v1/users/` devuelve 409 incluso bajo insert concurrente. `create_user` traduce `IntegrityError` con `pgcode='23505'` a `UserError(409)`, hace rollback de la sesión fallida, y propaga otras variantes de `IntegrityError` sin cambios.
+
+- [x] **T-PRB.01** Añadir `try/except IntegrityError` alrededor de `db.flush()` en `create_user`
+  - Envolver `await db.flush()` en `try/except IntegrityError`
+  - Chequear `getattr(exc.orig, "pgcode", None) == "23505"`
+  - En match: `await db.rollback()` después `raise UserError("El email ya está registrado", status_code=409) from exc`
+  - En mismatch: `raise` (propaga el original)
+  - Añadir comentario de código nombrando el supuesto asyncpg-específico de `pgcode`
+  - Files: `app/modules/users/service.py` (alrededor de línea 67 en `create_user`)
+  - Acceptance: try/except block en su lugar; rollback dispara antes del raise; errores non-23505 se propagan
+  - Test: `uv run pytest tests/integration/test_users_integration.py::test_email_unique_globally_returns_409 -v`
+  - Dependencies: none (PR-B puede aterrizar independientemente del runtime de PR-A, pero debe aterrizar después de PR-A para evitar rebase churn en `service.py`)
+  - Size: S
+  - Spec: R07, R08, R09
+
+- [x] **T-PRB.02** Añadir unit test para traducción 23505
+  - Mock `db.flush()` para que eleve `IntegrityError` con `pgcode='23505'`
+  - Assert `UserError` con `status_code=409` se eleva
+  - Assert `db.rollback()` fue llamado antes del raise
+  - Files: `tests/unit/test_users_service.py`
+  - Acceptance: Test pasa
+  - Test: `uv run pytest tests/unit/test_users_service.py -v -k translates_unique`
+  - Dependencies: T-PRB.01
+  - Size: S
+  - Spec: R07, R08
+
+- [x] **T-PRB.03** Añadir unit test para propagación de IntegrityError non-23505
+  - Mock `db.flush()` para que eleve `IntegrityError` con `pgcode='23503'` (FK violation)
+  - Assert el `IntegrityError` original se propaga (NO traducido a 409)
+  - Files: `tests/unit/test_users_service.py`
+  - Acceptance: Test pasa; `UserError(409)` NO se eleva
+  - Test: `uv run pytest tests/unit/test_users_service.py -v -k propagates_non_unique`
+  - Dependencies: T-PRB.01
+  - Size: S
+  - Spec: R08
+
+- [x] **T-PRB.04** Añadir test de regresión para rollback-no-envenena-sesión
+  - Dos user creations en la misma sesión: la primera es duplicado (espera 409), la segunda es no-duplicado (espera 201)
+  - Si rollback falta, la segunda llamada eleva `PendingRollbackError`
+  - Files: `tests/unit/test_users_service.py` (o integration test)
+  - Acceptance: Ambas llamadas tienen éxito; el segundo usuario queda persistido
+  - Test: `uv run pytest tests/unit/test_users_service.py -v -k rolls_back`
+  - Dependencies: T-PRB.01
+  - Size: S
+  - Spec: R09
+
+- [x] **T-PRB.VERIFY** PR-B verification — full integration suite
+  - Run: `uv run pytest tests/integration/ -v`
+  - Acceptance: Todos los tests verdes (email 409 test pasa, sin regresiones de PR-A o PR-B)
+  - Test: full integration suite green
+  - Dependencies: T-PRB.01, T-PRB.02, T-PRB.03, T-PRB.04
+  - Size: S
+  - Spec: R10
+
+---
+
+## Risk Callouts
+
+- **T-PRA.05–T-PRA.07 (cambio de signature de servicio):** Riesgo RK-1. El cambio de signature en `update_user` y `deactivate_user` es un breaking change duro. Los únicos callers conocidos son `app/modules/users/router.py` (actualizado en T-PRA.08) y `app/modules/tenants/router.py` (no importa estos). Un grep antes de PR-A confirma que no hay otros callers.
+- **T-PRA.02 (patrón de elevación):** Riesgo RK-2. El par `set_config(..., true)` SET LOCAL es no-negociable. El bloque `try/finally` garantiza que el restore corre incluso en excepción. Un comentario de código debe nombrar la garantía de `SET LOCAL` y la dependencia de rollback.
+- **T-PRB.01 (pgcode check):** Riesgo RK-3. `e.orig.pgcode` es asyncpg-específico. El código usa `getattr(exc.orig, "pgcode", None) == "23505"` así que un atributo faltante cae a `raise` (sin mis-traducción silenciosa). El comentario nombra el supuesto asyncpg.
+- **T-PRA.09–T-PRA.10 (tenants 404 → 403):** Riesgo RK-6. El cambio de test en línea 406 es la decisión explícita del usuario para unificar la señal de audit. La descripción del PR debe llamar esto out para prevenir que los reviewers lo reviertan.
+- **PR-0 prerequisito:** T-PR0.01 DEBE mergear antes de que las tareas T-PRA.* corran. El patrón de elevación en la nueva Depends depende de las garantías de sesión RLS que PR-0 establece.
+
+## Implementation Order
+
+1. **PR-0** (T-PR0.01 → T-PR0.02 → T-PR0.VERIFY): commit prerequisito, sin cambio de diseño
+2. **PR-A** (T-PRA.01 → T-PRA.13 → T-PRA.VERIFY): foundation primero (Depends), después service split, después router wiring, después tests
+3. **PR-B** (T-PRB.01 → T-PRB.04 → T-PRB.VERIFY): un único try/except en `create_user` + 3 unit tests
+
+PR-A DEBE aterrizar antes que PR-B para estabilizar `app/modules/users/service.py` y evitar rebase churn, pero no son runtime-dependent.
+
+## Spec Requirement Mapping
+
+| Task | Spec Requirement |
+|------|------------------|
+| T-PR0.01, T-PR0.02 | (prerequisito; enables R10) |
+| T-PRA.01 | OQ-1 (log fields) |
+| T-PRA.02, T-PRA.03 | R01, R02, R03, R04, R05 |
+| T-PRA.04 | R01 (tenants), RK-6 |
+| T-PRA.05 | R04 (OQ-3 split) |
+| T-PRA.06 | R02, R04, RK-7 |
+| T-PRA.07 | R03, R04, RK-7 |
+| T-PRA.08 | R01, R02, R03, R04 |
+| T-PRA.09 | R01 (tenants), RK-6 |
+| T-PRA.10 | R01 (tenants), RK-6 |
+| T-PRA.11 | R01, R04, R05 |
+| T-PRA.12 | R01 (tenants), RK-6 |
+| T-PRA.13 | OQ-1 (decisions) |
+| T-PRA.VERIFY | R10 |
+| T-PRB.01 | R07, R08, R09 |
+| T-PRB.02 | R07, R08 |
+| T-PRB.03 | R08 |
+| T-PRB.04 | R09 |
+| T-PRB.VERIFY | R10 |

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -134,6 +134,102 @@ class TestAuthService:
         # Verify the refresh token was revoked
         assert mock_refresh_token.revoked_at is not None
 
+    @pytest.mark.asyncio
+    async def test_login_elevates_to_superadmin_for_rls_bootstrap(self):
+        """Regression #125: login() must call set_tenant_context(..., is_superadmin=True)
+        before any RLS-protected query, because the email-based user lookup cannot
+        know the tenant at bootstrap. Without this, RLS returns 0 rows and login
+        fails in production with a 401 that masks the real cause.
+        """
+        from app.modules.auth import service
+
+        mock_user = MagicMock()
+        mock_user.id = "user-123"
+        mock_user.email = "test@example.com"
+        mock_user.hashed_password = "hashed_password"
+        mock_user.tenant_id = "tenant-123"
+        mock_user.role = "admin"
+        mock_user.is_superadmin = False
+        mock_user.is_active = True
+
+        mock_db = AsyncMock()
+        mock_redis = AsyncMock()
+
+        with patch.object(service, '_check_account_lockout', return_value=None), \
+             patch.object(service, '_get_active_user', return_value=mock_user), \
+             patch('app.modules.auth.service.verify_password', return_value=True), \
+             patch.object(service, '_check_tenant_active', return_value=None), \
+             patch.object(service, '_clear_login_attempts', return_value=None), \
+             patch('app.modules.auth.service.create_access_token', return_value=("access_token", "jti-123")), \
+             patch.object(service, '_create_refresh_token', return_value="refresh_token"), \
+             patch('app.modules.auth.service.set_tenant_context', new=AsyncMock()) as mock_set_ctx:
+            await service.login(
+                email="test@example.com",
+                password="password",
+                db=mock_db,
+                redis=mock_redis,
+            )
+
+        # The fix: set_tenant_context must be called exactly once with
+        # tenant_id=None and is_superadmin=True to bootstrap RLS bypass.
+        mock_set_ctx.assert_awaited_once()
+        call_kwargs = mock_set_ctx.await_args.kwargs
+        assert call_kwargs.get("tenant_id") is None, (
+            f"login() must bootstrap with tenant_id=None; got {call_kwargs.get('tenant_id')!r}"
+        )
+        assert call_kwargs.get("is_superadmin") is True, (
+            f"login() must bootstrap with is_superadmin=True to bypass RLS; "
+            f"got is_superadmin={call_kwargs.get('is_superadmin')!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_refresh_tokens_elevates_to_superadmin_for_rls_bootstrap(self):
+        """Regression #125: refresh_tokens() must call set_tenant_context(..., is_superadmin=True)
+        before the RefreshToken SELECT, because the lookup is by token_hash and
+        no tenant context is available at this point.
+        """
+        from app.modules.auth import service
+        from app.core.exceptions import AuthError
+        from uuid import UUID
+
+        mock_user = MagicMock()
+        mock_user.id = UUID("00000000-0000-0000-0000-000000000001")
+        mock_user.tenant_id = UUID("00000000-0000-0000-0000-000000000002")
+        mock_user.role = "admin"
+        mock_user.is_superadmin = False
+        mock_user.is_active = True
+
+        mock_db = AsyncMock()
+        mock_redis = AsyncMock()
+
+        # Mock the RefreshToken SELECT to return a valid record
+        mock_record = MagicMock()
+        mock_record.user_id = mock_user.id
+        mock_record.revoked_at = None
+
+        async def fake_scalar(stmt):
+            return mock_record
+
+        mock_db.scalar = fake_scalar
+        mock_db.in_transaction = MagicMock(return_value=True)
+
+        with patch('app.modules.auth.service.create_access_token', return_value=("access_token", "new-jti")), \
+             patch('app.modules.auth.service.track_jti', new=AsyncMock()), \
+             patch('app.modules.auth.service._get_active_user_by_id', new=AsyncMock(return_value=mock_user)), \
+             patch('app.modules.auth.service._check_tenant_active', new=AsyncMock()), \
+             patch('app.modules.auth.service._create_refresh_token', new=AsyncMock(return_value="new_refresh")), \
+             patch('app.modules.auth.service.set_tenant_context', new=AsyncMock()) as mock_set_ctx:
+            await service.refresh_tokens(
+                refresh_token="some_refresh_token",
+                db=mock_db,
+                redis=mock_redis,
+            )
+
+        mock_set_ctx.assert_awaited_once()
+        call_kwargs = mock_set_ctx.await_args.kwargs
+        assert call_kwargs.get("tenant_id") is None
+        assert call_kwargs.get("is_superadmin") is True
+
 
 class TestAuthRouterHelpers:
     """Test auth router helper functions."""


### PR DESCRIPTION
## Summary

Fixes #125. The auth service `login()` and `refresh_tokens()` functions executed queries against RLS-protected tables (users, tenants, refresh_tokens) without first calling `set_tenant_context`, so RLS returned 0 rows and login always failed with 401 in production.

## Root cause

The recent `heal-f1` commit (a07eb94) only fixed `get_current_user` (used by authenticated routes). `login` and `refresh` bypass `get_current_user` because there is no token yet, so they need to bootstrap the RLS context themselves. The `get_db` dependency explicitly documents that it must NOT be used in endpoints that access tenant data, except for login/refresh/health — and those endpoints are the ones that need the bootstrap.

The bug was masked in tests because `tests/integration/conftest.py::seed_data` sets `app.is_superadmin = 'true'` on the test session, which the client fixture reuses. Production never sets this.

## Fix

Mirror the pattern from `get_current_user`: temporarily elevate to superadmin via `set_tenant_context(db, tenant_id=None, is_superadmin=True)` before the first DB query, then proceed. The `SET LOCAL` is transaction-scoped and is reset on commit/rollback, so it cannot leak across requests or across pooled connections.

`logout` and `change_password` are unaffected because they already use `CurrentUserDep`, which sets RLS context via `get_current_user`.

## Edge cases analyzed

- **Wrong password / unknown user / locked account**: the transaction rolls back before commit, so the `SET LOCAL` is released cleanly. No state leak.
- **Refresh token not found / expired**: same — rolls back.
- **Connection pool reuse**: `SET LOCAL` is transaction-scoped, so a different request that picks up the same pooled connection starts with a fresh transaction (no `SET LOCAL` state).
- **Concurrent requests on different connections**: each has its own connection and transaction, so no cross-request interference.
- **Test suite compatibility**: existing tests use `seed_data` which elevates to superadmin. Our additional `set_tenant_context` call with the same value is idempotent — no regression.

## Files changed

- `app/modules/auth/service.py`: +13 lines (import + 2 bootstrap calls with comments)
- `tests/unit/test_auth.py`: +96 lines (2 new regression tests)

## Test results

- 2 new unit tests added and passing
- 337/337 existing unit tests still pass
- No new warnings introduced

## Reviewer notes

- The `set_tenant_context` call is placed as the first DB-touching step in each function, right after the `check_redis_healthy` guard. This matches the existing `get_current_user` pattern.
- The comment block explains WHY (bootstrap RLS) and references the source of the pattern.
- The regression tests are unit-level (mocked DB) and verify the function calls `set_tenant_context` with the right args. A true DB-level regression test would require a session that is NOT pre-elevated, which the current conftest doesn't provide; that gap is tracked separately in #141.