### PR TITLE
fix(users): enforce bcrypt 72-byte password boundary at schema level (#130)

### DIFF
--- a/app/core/security.py
+++ b/app/core/security.py
@@ -11,6 +11,7 @@ from passlib.context import CryptContext
 from redis.asyncio import Redis
 
 from app.core.config import settings
+from app.core.exceptions import UserError
 from app.core.logging import get_logger
 
 logger = get_logger(__name__)
@@ -33,6 +34,18 @@ _pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
 def hash_password(plain: str) -> str:
     return _pwd_context.hash(plain)
+
+
+def validate_password_length(password: str) -> None:
+    """Service-level backstop for bcrypt's 72-byte password input limit."""
+    if len(password.encode("utf-8")) > 72:
+        raise UserError(
+            {
+                "code": "password_too_long",
+                "message": "Password exceeds 72 bytes (UTF-8). Choose a shorter password.",
+            },
+            status_code=400,
+        )
 
 
 def verify_password(plain: str, hashed: str) -> bool:

--- a/app/modules/auth/schemas.py
+++ b/app/modules/auth/schemas.py
@@ -30,6 +30,16 @@ class ChangePasswordRequest(BaseModel):
 
     @field_validator("new_password")
     @classmethod
+    def validate_new_password_bytes(cls, v: str) -> str:
+        """Reject passwords over bcrypt's 72-byte input limit."""
+        if len(v.encode("utf-8")) > 72:
+            raise ValueError(
+                "Password exceeds 72 bytes (UTF-8). Choose a shorter password."
+            )
+        return v
+
+    @field_validator("new_password")
+    @classmethod
     def validate_strength(cls, v: str) -> str:
         if len(v) < 12:
             raise ValueError("La contraseña debe de tener al menos 12 caracteres")

--- a/app/modules/auth/service.py
+++ b/app/modules/auth/service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import secrets
 from datetime import datetime, timezone, timedelta
+from typing import TYPE_CHECKING
 from uuid import UUID
 
 from redis.asyncio import Redis
@@ -15,6 +16,7 @@ from app.core.security import (
     create_access_token,
     verify_password,
     hash_password,
+    validate_password_length,
     revoke_access_token,
     track_jti,
     untrack_jti,
@@ -35,6 +37,9 @@ LOGIN_ATTEMPTS_WINDOW_SECONDS = 900
 LOGIN_ATTEMPTS_MAX = 10
 
 logger = get_logger(__name__)
+
+if TYPE_CHECKING:
+    from app.event_bus import EventBus
 
 
 async def get_event_bus() -> "EventBus":
@@ -413,6 +418,7 @@ async def change_password(
             detail="La contraseña actual es incorrecta.",
         )
     
+    validate_password_length(new_password)
     user.hashed_password = hash_password(new_password)
     
     await _revoke_all_user_tokens(user_id, db)

--- a/app/modules/users/schemas.py
+++ b/app/modules/users/schemas.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime
 from enum import Enum
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from app.core.types import EmailStr
 
 
@@ -23,6 +23,16 @@ class UserCreate(BaseModel):
     role: RoleEnum = Field(..., description="Rol del usuario")
     tenant_id: uuid.UUID | None = Field(None, description="None solo si is_superadmin=True")
     is_superadmin: bool = Field(False)
+
+    @field_validator("password")
+    @classmethod
+    def validate_password_bytes(cls, v: str) -> str:
+        """Reject passwords over bcrypt's 72-byte input limit."""
+        if len(v.encode("utf-8")) > 72:
+            raise ValueError(
+                "Password exceeds 72 bytes (UTF-8). Choose a shorter password."
+            )
+        return v
     
     @model_validator(mode="after")
     def check_superadmin_consistency(self) -> UserCreate:

--- a/app/modules/users/service.py
+++ b/app/modules/users/service.py
@@ -9,7 +9,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
 from app.core.exceptions import UserError
-from app.core.security import hash_password, revoke_all_user_access_tokens
+from app.core.security import (
+    hash_password,
+    revoke_all_user_access_tokens,
+    validate_password_length,
+)
 from app.modules.auth.service import _revoke_all_user_tokens
 from app.modules.tenants.models import Tenant
 from app.modules.users.models import User
@@ -54,6 +58,8 @@ async def create_user(data: UserCreate, db: AsyncSession) -> User:
     
     if not data.is_superadmin and data.tenant_id is not None:
         await _get_active_tenant(db, data.tenant_id)
+
+    validate_password_length(data.password)
     
     user = User(
         tenant_id=data.tenant_id,

--- a/tests/unit/test_security.py
+++ b/tests/unit/test_security.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from app.modules.auth.schemas import ChangePasswordRequest
+from app.modules.users.schemas import RoleEnum, UserCreate
+
+
+class TestUserCreatePasswordSchema:
+    """Pydantic-level validation of password length (issue #130)."""
+
+    def test_71_bytes_ok(self):
+        # 71 ASCII chars = 71 bytes UTF-8
+        password = "a" * 71
+        user = UserCreate(
+            email="a@b.com",
+            password=password,
+            full_name="Test User",
+            role=RoleEnum.admin,
+            tenant_id=uuid4(),
+        )
+
+        assert user.password == password
+
+    def test_72_bytes_ok(self):
+        # 72 ASCII chars = 72 bytes UTF-8 (the boundary)
+        password = "a" * 72
+        user = UserCreate(
+            email="a@b.com",
+            password=password,
+            full_name="Test User",
+            role=RoleEnum.admin,
+            tenant_id=uuid4(),
+        )
+
+        assert user.password == password
+
+    def test_73_bytes_raises_validation_error(self):
+        # 73 ASCII chars = 73 bytes UTF-8 (just over the limit)
+        with pytest.raises(ValidationError) as exc:
+            UserCreate(
+                email="a@b.com",
+                password="a" * 73,
+                full_name="Test User",
+                role=RoleEnum.admin,
+                tenant_id=uuid4(),
+            )
+
+        assert "password" in str(exc.value).lower() or "72" in str(exc.value)
+
+    def test_multibyte_at_boundary_ok(self):
+        # "ñ" is 2 bytes in UTF-8; 36 "ñ"s = 72 bytes (boundary)
+        password = "ñ" * 36
+        user = UserCreate(
+            email="a@b.com",
+            password=password,
+            full_name="Test User",
+            role=RoleEnum.admin,
+            tenant_id=uuid4(),
+        )
+
+        assert user.password == password
+
+    def test_multibyte_over_boundary_raises(self):
+        # 37 "ñ"s = 74 bytes (over the limit)
+        with pytest.raises(ValidationError):
+            UserCreate(
+                email="a@b.com",
+                password="ñ" * 37,
+                full_name="Test User",
+                role=RoleEnum.admin,
+                tenant_id=uuid4(),
+            )
+
+
+class TestChangePasswordRequestPasswordSchema:
+    """Pydantic-level validation of changed password byte length."""
+
+    def test_72_bytes_ok(self):
+        # Includes uppercase, lowercase, and digit for strength validation.
+        password = "Aa1" + ("b" * 69)
+        request = ChangePasswordRequest(
+            current_password="OldPassword123!",
+            new_password=password,
+        )
+
+        assert request.new_password == password
+
+    def test_multibyte_over_boundary_raises(self):
+        # 3 ASCII bytes + 35 "ñ" chars * 2 bytes = 73 bytes.
+        password = "Aa1" + ("ñ" * 35)
+
+        with pytest.raises(ValidationError):
+            ChangePasswordRequest(
+                current_password="OldPassword123!",
+                new_password=password,
+            )
+
+
+class TestPasswordLengthBoundaryDefenseInDepth:
+    """Service-level validation of password length (issue #130 backstop)."""
+
+    def test_72_bytes_hash_ok(self):
+        from app.core.security import validate_password_length
+
+        validate_password_length("a" * 72)
+
+    def test_73_bytes_service_raises(self):
+        from app.core.exceptions import UserError
+        from app.core.security import validate_password_length
+
+        with pytest.raises(UserError) as exc:
+            validate_password_length("a" * 73)
+
+        assert exc.value.status_code == 400


### PR DESCRIPTION
Fixes #130

## Summary
Adds a Pydantic `field_validator` on `UserCreate.password` and `ChangePasswordRequest.new_password` that rejects passwords > 72 bytes (UTF-8). The schema-level check is the primary enforcement; the service-level `validate_password_length()` remains as defense-in-depth.

## Why
bcrypt operates on bytes, not characters, and silently truncates inputs at 72 bytes. `UserCreate.password: str` had no byte-length validator, so users could submit passwords that bcrypt would truncate silently. This created false-security collisions: two different passwords sharing the first 72 bytes produced the same hash.

The schema-level validator catches the violation at request validation, returning a clear 422 error to the client. The service-level check stays as a backstop in case the schema is bypassed (e.g., internal admin tooling).

## Files changed
- `app/modules/users/schemas.py` — `field_validator("password")` on `UserCreate`
- `app/modules/auth/schemas.py` — `field_validator("new_password")` on `ChangePasswordRequest`
- `app/core/security.py` — adds `validate_password_length()` and rejects > 72 bytes
- `app/modules/users/service.py:create_user` — calls `validate_password_length()` before `hash_password`
- `app/modules/auth/service.py:change_password` — same
- `tests/unit/test_security.py` — adds schema-level and service-level boundary tests

## Test plan
- [x] `uv run pytest tests/unit/test_security.py -v -k "TestUserCreatePasswordSchema or TestPasswordLengthBoundaryDefenseInDepth"`
- [x] `uv run pytest tests/unit/test_security.py tests/unit/test_users.py -v`
- [x] `uv run ruff check app/modules/users/schemas.py app/modules/auth/schemas.py app/core/security.py app/modules/users/service.py app/modules/auth/service.py tests/unit/test_security.py`
- [ ] `uv run pytest -m "not integration" -v` — repo has pre-existing environment failures connecting to PostgreSQL on localhost:5433 plus unrelated existing failures; focused changed tests pass.
- [ ] `uv run ruff check .` — repo has pre-existing lint errors outside this change; modified files are clean.

## Risk
If any existing test uses a password > 72 bytes, the schema-level validator will break it. The audit step found no matching over-72-byte test passwords.

## Rollback
Revert the merge commit. Behavior returns to silent truncation.