### PR TITLE
fix(auth): hoist uuid4 import in login event publish (#101)

### DIFF
--- a/app/modules/auth/service.py
+++ b/app/modules/auth/service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import hashlib
 import secrets
 from datetime import datetime, timezone, timedelta
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from redis.asyncio import Redis
 from sqlalchemy import select, update, func, text
@@ -275,7 +275,7 @@ async def login(
         event_bus = await get_event_bus()
         from app.event_schemas import AuthLoginEvent
         await event_bus.publish(AuthLoginEvent(
-            event_id=__import__("uuid").uuid4(),
+            event_id=uuid4(),
             tenant_id=user.tenant_id,
             user_id=str(user.id),
             email_hash=hash_email(user.email),

--- a/tests/unit/test_imports.py
+++ b/tests/unit/test_imports.py
@@ -1,0 +1,210 @@
+"""Regression test for PR-1: ensure no inline `__import__` or hot-path inline imports.
+
+Spec R-15.1:
+  - No `__import__(...)` call inside a function body or hot path in app source.
+  - No `from X import Y` or `import X` inside a hot path (try/except, if/else,
+    consumer loop) outside the top-level module import block.
+
+Narrowly scoped to the four files in PR-1's commit boundary. The deferred
+imports used for circular-import handling (e.g. `from app.dependencies import
+get_event_bus as _get` inside `service.get_event_bus`) are out of scope for
+PR-1 and are explicitly allowlisted.
+"""
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+
+# Project root: this test file is at tests/unit/test_imports.py, project root is ../../.
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+APP_DIR = PROJECT_ROOT / "app"
+
+# Files in PR-1's slice (per the design PR-1 section + the orchestrator scope).
+PR1_TARGETS: list[Path] = [
+    APP_DIR / "modules" / "auth" / "service.py",
+    APP_DIR / "core" / "security.py",
+    APP_DIR / "event_bus.py",
+    APP_DIR / "main.py",
+]
+
+# Allowlist of indented `from ... import ...` statements that are NOT in PR-1
+# scope. These are deferred imports used for circular-import handling or other
+# intentional lazy-loading patterns the design preserves.
+# Format: (file_relpath, line_number, imported_name)
+PR1_INDENT_IMPORT_ALLOWLIST: set[tuple[str, int, str]] = {
+    # `from app.dependencies import get_event_bus as _get` is a deferred import
+    # inside `service.get_event_bus` to avoid a circular import between
+    # `app.modules.auth.service` and `app.dependencies`. PR-1 does not refactor
+    # this pattern.
+    ("app/modules/auth/service.py", 42, "get_event_bus"),
+}
+
+
+def _format_offender(path: Path, lineno: int, line: str) -> str:
+    return f"  {path.relative_to(PROJECT_ROOT)}:{lineno}: {line.strip()}"
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        pytest.param(
+            APP_DIR / "modules" / "auth" / "service.py",
+            id="app/modules/auth/service.py",
+        ),
+        pytest.param(
+            APP_DIR / "core" / "security.py",
+            id="app/core/security.py",
+        ),
+        pytest.param(
+            APP_DIR / "main.py",
+            id="app/main.py",
+        ),
+        pytest.param(
+            APP_DIR / "event_bus.py",
+            id="app/event_bus.py",
+            marks=pytest.mark.xfail(
+                strict=True,
+                reason=(
+                    "event_bus.py L180 uses __import__('datetime') inside the "
+                    "DLQ write block. Belongs to the event_bus cleanup issue, "
+                    "not #101. Remove this xfail mark when that issue is fixed."
+                ),
+            ),
+        ),
+    ],
+)
+def test_no_dunder_import_call(target: Path) -> None:
+    """R-15.1.1: no `__import__(...)` calls inside PR-1 target files."""
+    assert target.exists(), f"PR-1 target file missing: {target}"
+    text = target.read_text(encoding="utf-8")
+    pattern = re.compile(r"\b__import__\s*\(")
+    offenders: list[str] = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        if pattern.search(line):
+            offenders.append(_format_offender(target, lineno, line))
+    assert not offenders, (
+        "Found `__import__(...)` calls in PR-1 target file (R-15.1.1):\n"
+        + "\n".join(offenders)
+    )
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        pytest.param(
+            APP_DIR / "event_bus.py",
+            id="app/event_bus.py",
+        ),
+        pytest.param(
+            APP_DIR / "modules" / "auth" / "service.py",
+            id="app/modules/auth/service.py",
+            marks=pytest.mark.xfail(
+                strict=True,
+                reason=(
+                    "L276 `from app.event_schemas import AuthLoginEvent` is a "
+                    "deferred import inside the login() try block to avoid a "
+                    "circular-import concern. Explicitly out of scope for #101; "
+                    "remove this xfail mark when the circular-import cleanup is "
+                    "done."
+                ),
+            ),
+        ),
+        pytest.param(
+            APP_DIR / "core" / "security.py",
+            id="app/core/security.py",
+            marks=pytest.mark.xfail(
+                strict=True,
+                reason=(
+                    "security.py L195 `from app.core.logging import get_logger` "
+                    "is an indented import inside an except block. Belongs to "
+                    "the security import cleanup issue, not #101. Remove this "
+                    "xfail mark when that issue is fixed."
+                ),
+            ),
+        ),
+        pytest.param(
+            APP_DIR / "main.py",
+            id="app/main.py",
+            marks=pytest.mark.xfail(
+                strict=True,
+                reason=(
+                    "main.py L49 `from app.event_bus import EventBus` is an "
+                    "indented import inside the consumer message loop. Owned "
+                    "by issue #102 (inline imports refactor, 6 ubicaciones). "
+                    "Remove this xfail mark when #102 is fixed."
+                ),
+            ),
+        ),
+    ],
+)
+def test_no_hot_path_indented_imports(target: Path) -> None:
+    """R-15.1.2: no indented `from X import Y` / `import X` outside the top block.
+
+    Walks the AST and flags every `Import`/`ImportFrom` node that is NOT a
+    direct child of the module body (i.e. appears inside a function, class,
+    or other nested scope). TYPE_CHECKING-guarded imports are NOT flagged
+    (they are static-only and not real runtime hot-path imports). The
+    deferred-import allowlist excludes the specific known-false-positive
+    at `service.get_event_bus`.
+    """
+    assert target.exists(), f"PR-1 target file missing: {target}"
+    text = target.read_text(encoding="utf-8")
+    tree = ast.parse(text)
+    relpath = str(target.relative_to(PROJECT_ROOT))
+    offenders: list[str] = []
+
+    # Build a map: import-node-id -> set of ancestor node kinds.
+    # An import is a "TYPE_CHECKING" import iff one of its ancestors is an
+    # `ast.If` whose test is a `Name` with id == "TYPE_CHECKING".
+    def _ancestors(node: ast.AST) -> list[ast.AST]:
+        path: list[ast.AST] = []
+        for parent in ast.walk(tree):
+            for child in ast.iter_child_nodes(parent):
+                if child is node:
+                    path.append(parent)
+                    break
+        return path
+
+    def _is_type_checking_import(node: ast.AST) -> bool:
+        for parent in _ancestors(node):
+            if isinstance(parent, ast.If):
+                test = parent.test
+                if isinstance(test, ast.Name) and test.id == "TYPE_CHECKING":
+                    return True
+        return False
+
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.Import, ast.ImportFrom)):
+            continue
+        # Skip top-level (column 0) imports.
+        if getattr(node, "col_offset", 0) == 0:
+            continue
+        # Skip TYPE_CHECKING-guarded imports (static-only; not runtime hot path).
+        if _is_type_checking_import(node):
+            continue
+        # Pull the imported names so the allowlist can match them precisely.
+        if isinstance(node, ast.Import):
+            names = [alias.name for alias in node.names]
+        else:
+            names = [alias.name for alias in node.names]
+        primary_name = names[0] if names else ""
+        allow_key = (relpath, node.lineno, primary_name.split(".")[0])
+        if allow_key in PR1_INDENT_IMPORT_ALLOWLIST:
+            continue
+        line = text.splitlines()[node.lineno - 1]
+        offenders.append(_format_offender(target, node.lineno, line))
+
+    assert not offenders, (
+        "Found inline imports in PR-1 target file (R-15.1.2):\n"
+        + "\n".join(offenders)
+    )
+
+
+def test_pr1_target_files_exist() -> None:
+    """Sanity check: the four PR-1 target files are present in the working tree."""
+    missing = [str(p.relative_to(PROJECT_ROOT)) for p in PR1_TARGETS if not p.exists()]
+    assert not missing, f"PR-1 target files missing: {missing}"


### PR DESCRIPTION
Closes #101

## Summary

- Hoist `uuid4` to the module-level import in `app/modules/auth/service.py` and replace the inline `__import__("uuid").uuid4()` call with `uuid4()`. Two-line source change; the `event_id` value is still a uuid4 — only how the import is expressed changes.
- Commit the previously-untracked regression test `tests/unit/test_imports.py` as the PR-1 import-hygiene lock. Fix the allowlist off-by-one (L46 → L42, the actual line on `origin/main`). Mark the four out-of-scope parametrized cases `xfail(strict=True)` with ownership reasons referencing their owning issues / concerns.

## Changes

| File | Change |
|------|--------|
| `app/modules/auth/service.py` | L6 `from uuid import UUID` → `from uuid import UUID, uuid4`; L278 `event_id=__import__("uuid").uuid4(),` → `event_id=uuid4(),` |
| `tests/unit/test_imports.py` | New (commit). Allowlist L46 → L42. 4 `xfail(strict=True)` marks on out-of-scope params with ownership reasons. |

## xfail ownership

- `test_no_dunder_import_call[app/event_bus.py]` → event_bus.py L180 `__import__('datetime')` in the DLQ write block. Owned by the event_bus cleanup concern (not tracked with a specific issue number; remove mark when that cleanup lands).
- `test_no_hot_path_indented_imports[app/modules/auth/service.py]` → L276 deferred `from app.event_schemas import AuthLoginEvent` inside `login()` try block. Separate circular-import concern, explicitly out of scope for #101.
- `test_no_hot_path_indented_imports[app/core/security.py]` → security.py L195 `from app.core.logging import get_logger` inside an `except` block. Belongs to the security import cleanup concern.
- `test_no_hot_path_indented_imports[app/main.py]` → main.py L49 `from app.event_bus import EventBus` inside the consumer message loop. Owned by issue #102 ("refactor: eliminar imports inline y moverlos a nivel modulo (6 ubicaciones)").

`strict=True` forces the owning issue to remove the mark when it fixes its case (xpass → FAIL).

## Verification

```text
$ uv run pytest "tests/unit/test_imports.py::test_no_dunder_import_call[app/modules/auth/service.py]" -v
PASSED [100%]
1 passed in 0.01s

$ uv run pytest tests/unit/test_auth_service_event_publish.py -v
test_login_publishes_auth_login_event_on_success       PASSED [ 25%]
test_login_publishes_event_with_user_agent             PASSED [ 50%]
test_login_does_not_block_on_publish_failure           PASSED [ 75%]
test_login_blocked_if_credentials_invalid              PASSED [100%]
4 passed in 0.03s

$ uv run ruff check app/modules/auth/service.py
app/modules/auth/service.py:40:31: F821 Undefined name `EventBus`  (PRE-EXISTING on origin/main; not introduced by this commit)
Found 1 error.

$ uv run pytest tests/unit/test_imports.py -v
test_no_dunder_import_call[app/modules/auth/service.py]                      PASSED [ 11%]
test_no_dunder_import_call[app/core/security.py]                             PASSED [ 22%]
test_no_dunder_import_call[app/main.py]                                      PASSED [ 33%]
test_no_dunder_import_call[app/event_bus.py]                                 XFAIL [ 44%]
test_no_hot_path_indented_imports[app/event_bus.py]                          PASSED [ 55%]
test_no_hot_path_indented_imports[app/modules/auth/service.py]               XFAIL [ 66%]
test_no_hot_path_indented_imports[app/core/security.py]                      XFAIL [ 77%]
test_no_hot_path_indented_imports[app/main.py]                               XFAIL [ 88%]
test_pr1_target_files_exist                                                  PASSED [100%]
5 passed, 4 xfailed in 0.07s
```

## Notes on deviations from design

The design artifact (`sdd/issue-101-uuid4-import-hoist/design`) was verified against a working tree state that included `fix/issue-130-…`'s unmerged changes. On `origin/main` (the actual branch base for this PR per the session decision), the relevant line numbers in `app/modules/auth/service.py` differ by 5:

- `from uuid import UUID` at L6 (design: L7)
- `from app.dependencies import get_event_bus as _get` at L42 (design: L47)
- `from app.event_schemas import AuthLoginEvent` at L276 (design: L281)
- `event_id=__import__("uuid").uuid4()` at L278 (design: L283)

The allowlist entry `("app/modules/auth/service.py", 46, "get_event_bus")` was changed to `("app/modules/auth/service.py", 42, "get_event_bus")` so it matches the actual `origin/main` line. Setting it to L47 (as the design said) would leave the test RED for the wrong reason. This is a mechanical line-number correction, not an architectural change.

Additionally, the design claimed `uv run ruff check app/modules/auth/service.py` was clean on baseline. On `origin/main` it reports 1 pre-existing `F821 Undefined name 'EventBus'` at L40 (the `EventBus` string annotation in `get_event_bus()`). This error is not introduced by this commit; it predates the change. Tracked here for transparency; addressing it is out of scope for #101.

## Spec / Design references

- Spec: `sdd/issue-101-uuid4-import-hoist/spec` (Engram)
- Design: `sdd/issue-101-uuid4-import-hoist/design` (Engram)
- Tasks: `sdd/issue-101-uuid4-import-hoist/tasks` (Engram)