### PR TITLE
refactor: hoist inline imports to module level (#102)

### DIFF
--- a/app/core/security.py
+++ b/app/core/security.py
@@ -192,9 +192,7 @@ async def revoke_all_user_access_tokens(
         try:
             await pipe.execute()
         except Exception:
-            from app.core.logging import get_logger
-            _logger = get_logger(__name__)
-            _logger.exception(
+            logger.exception(
                 "redis_pipeline_failed",
                 extra={"user_id": user_id, "jtis_count": len(jti_strs)},
             )

--- a/app/main.py
+++ b/app/main.py
@@ -9,7 +9,7 @@ from app.core.config import settings
 from app.core.logging import setup_logging, get_logger
 from app.core.middleware import HTTPSRedirectMiddleware, SecurityHeadersMiddleware
 from app.core.redis import ping_redis, close_pool, get_redis_client
-from app.event_bus import EventConsumer, drain_dlq_tasks
+from app.event_bus import EventBus, EventConsumer, drain_dlq_tasks
 from app.modules.auth.router import router as auth_router
 from app.modules.tenants.router import router as tenants_router
 from app.modules.users.router import router as users_router
@@ -46,7 +46,6 @@ async def lifespan(app: FastAPI):
             try:
                 pending = await consumer.read_pending()
                 for msg in pending:
-                    from app.event_bus import EventBus
                     EventBus._dispatch_event("auth.login", msg.get("data", {}), redis_client)
                     await consumer.ack(msg["message_id"])
             except Exception:

--- a/app/modules/auth/service.py
+++ b/app/modules/auth/service.py
@@ -28,6 +28,8 @@ from app.core.database import set_tenant_context
 from app.core.exceptions import AuthError, ServiceUnavailableError
 from app.core.pii import hash_email, mask_ip
 from app.core.redis import check_redis_healthy
+from app.event_bus import EventBus
+from app.event_schemas import AuthLoginEvent
 
 MAX_ACTIVE_SESSIONS = 5
 REFRESH_TOKEN_EXPIRE_DAYS = 7
@@ -273,7 +275,6 @@ async def login(
     # Publish auth.login event (non-blocking on failure)
     try:
         event_bus = await get_event_bus()
-        from app.event_schemas import AuthLoginEvent
         await event_bus.publish(AuthLoginEvent(
             event_id=uuid4(),
             tenant_id=user.tenant_id,

--- a/tests/unit/test_imports.py
+++ b/tests/unit/test_imports.py
@@ -40,7 +40,7 @@ PR1_INDENT_IMPORT_ALLOWLIST: set[tuple[str, int, str]] = {
     # inside `service.get_event_bus` to avoid a circular import between
     # `app.modules.auth.service` and `app.dependencies`. PR-1 does not refactor
     # this pattern.
-    ("app/modules/auth/service.py", 42, "get_event_bus"),
+    ("app/modules/auth/service.py", 44, "get_event_bus"),
 }
 
 
@@ -102,42 +102,14 @@ def test_no_dunder_import_call(target: Path) -> None:
         pytest.param(
             APP_DIR / "modules" / "auth" / "service.py",
             id="app/modules/auth/service.py",
-            marks=pytest.mark.xfail(
-                strict=True,
-                reason=(
-                    "L276 `from app.event_schemas import AuthLoginEvent` is a "
-                    "deferred import inside the login() try block to avoid a "
-                    "circular-import concern. Explicitly out of scope for #101; "
-                    "remove this xfail mark when the circular-import cleanup is "
-                    "done."
-                ),
-            ),
         ),
         pytest.param(
             APP_DIR / "core" / "security.py",
             id="app/core/security.py",
-            marks=pytest.mark.xfail(
-                strict=True,
-                reason=(
-                    "security.py L195 `from app.core.logging import get_logger` "
-                    "is an indented import inside an except block. Belongs to "
-                    "the security import cleanup issue, not #101. Remove this "
-                    "xfail mark when that issue is fixed."
-                ),
-            ),
         ),
         pytest.param(
             APP_DIR / "main.py",
             id="app/main.py",
-            marks=pytest.mark.xfail(
-                strict=True,
-                reason=(
-                    "main.py L49 `from app.event_bus import EventBus` is an "
-                    "indented import inside the consumer message loop. Owned "
-                    "by issue #102 (inline imports refactor, 6 ubicaciones). "
-                    "Remove this xfail mark when #102 is fixed."
-                ),
-            ),
         ),
     ],
 )


### PR DESCRIPTION
## Linked Issue
Closes #102

## PR Type
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation only
- [x] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Hoists the three issue #102 inline imports to module scope.
- Removes the three matching strict xfails from `tests/unit/test_imports.py`; keeps the event_bus dunder xfail untouched.
- Adds module-level `EventBus` in auth service to resolve the pre-existing F821 forward reference.

## Stacked on #156
This PR is stacked on PR #156 (issue #101) and targets `fix/issue-101-uuid4-import-hoist` so the review diff contains only issue #102. Merge #156 to main first, then retarget this PR's base to main and rebase before merging.

## Changes
| File | Change |
|------|--------|
| `app/main.py` | Hoisted `EventBus` into the existing module-level event_bus import. |
| `app/core/security.py` | Reused the module-level `logger` in the Redis pipeline exception path. |
| `app/modules/auth/service.py` | Hoisted `AuthLoginEvent`; added `EventBus` module import for the existing forward reference. |
| `tests/unit/test_imports.py` | Removed the three issue #102 xfails and updated the preserved allowlist line after import insertion. |

## Test Plan
- [x] `uv run pytest tests/unit/test_imports.py -v` — RED before source: 3 failed, 5 passed, 1 xfailed.
- [x] `uv run pytest tests/unit/test_imports.py -v` — GREEN after source: 8 passed, 1 xfailed.
- [x] `uv run ruff check app/core/security.py app/event_bus.py app/modules/auth/service.py app/main.py`
- [x] `GROQ_API_KEY=gsk_dummy uv run python -c "from app.main import create_app; create_app()"`

## Engram
- `sdd/issue-102-hoist-inline-imports/proposal`
- `sdd/issue-102-hoist-inline-imports/spec`
- `sdd/issue-102-hoist-inline-imports/design`
- `sdd/issue-102-hoist-inline-imports/tasks`

## Contributor Checklist
- [x] Linked an approved issue (status:approved waived by maintainer for F1 issues).
- [x] Added exactly one `type:*` label.
- [x] Conventional commit format.
- [x] No `Co-Authored-By` trailers.