### PR TITLE
test(rls): add regression test for superadmin single-roundtrip set_tenant_context (#141)

### DIFF
--- a/tests/integration/test_rls_regression.py
+++ b/tests/integration/test_rls_regression.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+import pytest
+from sqlalchemy import event, text
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
+
+from app.core.database import set_tenant_context
+from tests.conftest import TENANT_A_ID
+
+pytestmark = pytest.mark.integration
+
+
+async def test_set_tenant_context_superadmin_single_roundtrip(
+    db_session: AsyncSession,
+) -> None:
+    """Superadmin RLS context must be set in one database roundtrip."""
+    engine = db_session.bind
+    assert isinstance(engine, AsyncEngine)
+
+    statements: list[str] = []
+
+    def capture_statement(
+        _conn,
+        _cursor,
+        statement: str,
+        _parameters,
+        _context,
+        _executemany,
+    ) -> None:
+        statements.append(statement)
+
+    event.listen(engine.sync_engine, "before_cursor_execute", capture_statement)
+    try:
+        await set_tenant_context(db_session, tenant_id=None, is_superadmin=True)
+    finally:
+        event.remove(engine.sync_engine, "before_cursor_execute", capture_statement)
+
+    set_config_queries = [query for query in statements if "set_config" in query]
+    assert len(set_config_queries) == 1, (
+        f"Expected 1 roundtrip, got {len(set_config_queries)}: {set_config_queries}"
+    )
+    assert "is_superadmin" in set_config_queries[0]
+    assert "current_tenant" in set_config_queries[0]
+
+
+async def test_superadmin_context_does_not_leak_to_next_tenant_request(
+    db_session: AsyncSession,
+) -> None:
+    """Tenant context must clear any prior superadmin flag on the same session."""
+    tenant_id = UUID(TENANT_A_ID)
+
+    # Reproduce el riesgo: una request superadmin seguida por una request tenant
+    # sobre la misma sesión/conexión no debe heredar permisos globales.
+    await set_tenant_context(db_session, tenant_id=None, is_superadmin=True)
+    await set_tenant_context(db_session, tenant_id=tenant_id, is_superadmin=False)
+
+    result = await db_session.execute(text("SELECT current_setting('app.is_superadmin')"))
+
+    assert result.scalar_one() == "false"


### PR DESCRIPTION
Closes #141

## Type
- [x] Maintenance/tooling (`type:chore`)

## Summary
- Adds integration regression coverage for the superadmin `set_tenant_context` single-roundtrip SQL contract.
- Adds a same-session leak guard proving tenant context clears prior superadmin state.
- Keeps the change test-only; no production source files modified.

## Changes
| File | Change |
|------|--------|
| `tests/integration/test_rls_regression.py` | New integration tests for RLS superadmin roundtrip and session-poisoning regression coverage. |

## Test Plan
- [x] `uv run ruff check tests/integration/test_rls_regression.py`
- [x] `uv run python -c "import ast; ast.parse(open('tests/integration/test_rls_regression.py').read())"`
- [x] `uv run pytest --collect-only tests/integration/test_rls_regression.py -q` collected 2 tests
- [ ] Full integration execution: CI only; local PostgreSQL on port 5433 is unavailable.

## SDD Artifacts
- `sdd/issue-141-rls-superadmin-regression-test/proposal`
- `sdd/issue-141-rls-superadmin-regression-test/spec`
- `sdd/issue-141-rls-superadmin-regression-test/design`
- `sdd/issue-141-rls-superadmin-regression-test/tasks`

## Contributor Checklist
- [x] Linked an approved/pre-authorized issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers