### PR TITLE
fix(event-bus): block stream consumer reads

### DIFF
--- a/app/event_bus.py
+++ b/app/event_bus.py
@@ -436,6 +436,52 @@ class EventConsumer:
                 pass
         return result
 
+    async def read_new(self, block: int = 5000) -> list[dict]:
+        """Read new (undelivered) messages using XREADGROUP with blocking.
+
+        Uses XREADGROUP with '>' to read only new messages (never delivered
+        before to any consumer in the group). Blocks for up to `block`
+        milliseconds waiting for new messages, replacing the old busy-poll
+        pattern (issue #133).
+
+        Args:
+            block: Maximum milliseconds to block waiting for messages.
+                   Defaults to 5000 (5 seconds).
+
+        Returns:
+            List of dicts, each containing:
+              - "message_id": bytes
+              - "data": dict with event fields
+            Returns an empty list if no messages available within the timeout.
+        """
+        await self._ensure_group_exists()
+        stream_key = self._stream_key()
+
+        result = await self.redis_client.xreadgroup(
+            self.group_name,
+            self.consumer_name,
+            {stream_key: ">"},
+            count=10,
+            block=block,
+        )
+
+        if not result:
+            return []
+
+        messages: list[dict] = []
+        for _stream_name, stream_messages in result:
+            for msg_id, fields in stream_messages:
+                str_fields = {
+                    k.decode() if isinstance(k, bytes) else k:
+                    v.decode() if isinstance(v, bytes) else v
+                    for k, v in fields.items()
+                }
+                messages.append({
+                    "message_id": msg_id if isinstance(msg_id, bytes) else msg_id.encode(),
+                    "data": str_fields,
+                })
+        return messages
+
     async def reconnect_and_resume(self) -> list[dict]:
         """Reconnect to Redis and resume from last acknowledged position.
 

--- a/app/main.py
+++ b/app/main.py
@@ -20,6 +20,14 @@ logger = get_logger(__name__)
 
 APP_VERSION = "0.1.0"
 
+# Maximum milliseconds XREADGROUP blocks waiting for new messages (issue #133).
+# Replaces the old asyncio.sleep(1) busy-poll.
+_XREADGROUP_BLOCK_MS: int = 5000
+
+# Backoff after an unexpected error in the consumer loop.
+# Intentionally short — just enough to avoid a tight spin if Redis is flaky.
+_ERROR_BACKOFF_SECONDS: float = 0.1
+
 
 async def _consumer_loop(
     *,
@@ -29,14 +37,32 @@ async def _consumer_loop(
 ) -> None:
     """Background loop that processes events until stop_event is set.
 
-    Closes the Redis client exactly once on exit (normal, exception, or cancellation).
-    Re-raises asyncio.CancelledError so the asyncio task machinery handles it correctly.
+    Recovery + blocking read pattern (issue #133):
+      1. Each iteration first drains pending (unacked) messages via
+         ``read_pending()`` so messages stranded by a previous crash are
+         not lost.
+      2. When no pending messages remain, ``read_new(block=_XREADGROUP_BLOCK_MS)``
+         blocks for up to 5 s waiting for new messages — eliminating the
+         old 1 s busy-poll.
+
+    Closes the Redis client exactly once on exit (normal, exception, or
+    cancellation).  Re-raises asyncio.CancelledError so the asyncio task
+    machinery handles it correctly.
     """
     try:
         while not stop_event.is_set():
             try:
+                # Step 1 — recover any pending (unacked) messages first.
+                # read_pending() is non-blocking; when there are no pending
+                # entries the XPENDING call returns an empty list quickly.
                 pending = await consumer.read_pending()
-                for msg in pending:
+                if pending:
+                    messages = pending
+                else:
+                    # Step 2 — no pending work; block for new messages.
+                    messages = await consumer.read_new(block=_XREADGROUP_BLOCK_MS)
+
+                for msg in messages:
                     from app.event_bus import EventBus
 
                     raw_msg_id = msg["message_id"]
@@ -48,14 +74,13 @@ async def _consumer_loop(
                         message_id=msg_id,
                     )
                     await consumer.ack(msg["message_id"])
-                await asyncio.sleep(1)
             except asyncio.CancelledError:
-                # Re-raise immediately so the outer try/finally still runs.
+                logger.info("event_consumer_loop_cancelled")
                 raise
             except Exception:
-                # Log unexpected errors and back off; do not busy-loop.
+                # Log unexpected errors and back off briefly; do not busy-loop.
                 logger.exception("event_consumer_loop_error")
-                await asyncio.sleep(1)
+                await asyncio.sleep(_ERROR_BACKOFF_SECONDS)
     finally:
         # Always close the redis client, even on cancellation or exception.
         await redis_client.aclose()

--- a/tests/unit/test_event_bus_issue_133.py
+++ b/tests/unit/test_event_bus_issue_133.py
@@ -1,0 +1,413 @@
+"""Regression tests for issue #133 — event bus busy-poll replaced by blocking XREADGROUP.
+
+Root cause: the consumer loop used `read_pending()` + `asyncio.sleep(1)` to
+poll for new messages. This caused unnecessary CPU wake-ups every second even
+when no messages were available, and the sleep could swallow CancelledError.
+
+Fix: use `xreadgroup(block=5000)` which blocks for up to 5 seconds waiting
+for new messages, eliminating the busy-poll entirely.  Pending (unacked)
+messages from a previous crash are still recovered by calling
+``read_pending()`` before the blocking read on each iteration.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, call
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# read_new() — blocking XREADGROUP
+# ---------------------------------------------------------------------------
+
+class TestReadNewUsesBlockingXreadgroup:
+    """Verify read_new() passes block=5000 to xreadgroup()."""
+
+    @pytest.mark.asyncio
+    async def test_read_new_passes_block_5000_to_xreadgroup(self):
+        """read_new() MUST call xreadgroup with block=5000 by default."""
+        from app.event_bus import EventConsumer
+
+        mock_redis = AsyncMock()
+        mock_redis.xreadgroup = AsyncMock(return_value=None)
+        mock_redis.xgroup_create = AsyncMock()
+
+        consumer = EventConsumer(
+            redis_client=mock_redis,
+            event_type="auth.login",
+            consumer_name="worker-1",
+            group_name="soc360-consumers",
+        )
+
+        await consumer.read_new()
+
+        mock_redis.xreadgroup.assert_awaited_once()
+        call_kwargs = mock_redis.xreadgroup.call_args.kwargs
+        assert call_kwargs.get("block") == 5000, (
+            f"xreadgroup must be called with block=5000, got {call_kwargs.get('block')}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_read_new_uses_greater_than_id_for_new_messages(self):
+        """read_new() MUST use '>' as the message ID to read only new messages."""
+        from app.event_bus import EventConsumer
+
+        mock_redis = AsyncMock()
+        mock_redis.xreadgroup = AsyncMock(return_value=None)
+        mock_redis.xgroup_create = AsyncMock()
+
+        consumer = EventConsumer(
+            redis_client=mock_redis,
+            event_type="auth.login",
+            consumer_name="worker-1",
+            group_name="soc360-consumers",
+        )
+
+        await consumer.read_new()
+
+        call_args = mock_redis.xreadgroup.call_args
+        # Third positional arg is the streams dict
+        streams_dict = call_args.args[2]
+        stream_key = f"events:{consumer.event_type}"
+        assert streams_dict[stream_key] == ">", (
+            f"read_new must use '>' for new messages, got {streams_dict[stream_key]}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_read_new_returns_empty_list_when_no_messages(self):
+        """read_new() MUST return [] when xreadgroup returns None (timeout)."""
+        from app.event_bus import EventConsumer
+
+        mock_redis = AsyncMock()
+        mock_redis.xreadgroup = AsyncMock(return_value=None)
+        mock_redis.xgroup_create = AsyncMock()
+
+        consumer = EventConsumer(
+            redis_client=mock_redis,
+            event_type="auth.login",
+            consumer_name="worker-1",
+            group_name="soc360-consumers",
+        )
+
+        result = await consumer.read_new()
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_read_new_parses_messages_correctly(self):
+        """read_new() MUST decode bytes fields and return list of dicts."""
+        from app.event_bus import EventConsumer
+
+        mock_redis = AsyncMock()
+        mock_redis.xgroup_create = AsyncMock()
+        # Simulate xreadgroup returning one stream with two messages
+        mock_redis.xreadgroup = AsyncMock(return_value=[
+            (b"events:auth.login", [
+                (b"100-0", {b"user_id": b"u1", b"email_hash": b"a" * 32}),
+                (b"101-0", {b"user_id": b"u2", b"email_hash": b"b" * 32}),
+            ]),
+        ])
+
+        consumer = EventConsumer(
+            redis_client=mock_redis,
+            event_type="auth.login",
+            consumer_name="worker-1",
+            group_name="soc360-consumers",
+        )
+
+        result = await consumer.read_new()
+        assert len(result) == 2
+        assert result[0]["message_id"] == b"100-0"
+        assert result[0]["data"]["user_id"] == "u1"
+        assert result[1]["message_id"] == b"101-0"
+        assert result[1]["data"]["user_id"] == "u2"
+
+    @pytest.mark.asyncio
+    async def test_read_new_accepts_custom_block_value(self):
+        """read_new() MUST allow overriding the block timeout."""
+        from app.event_bus import EventConsumer
+
+        mock_redis = AsyncMock()
+        mock_redis.xreadgroup = AsyncMock(return_value=None)
+        mock_redis.xgroup_create = AsyncMock()
+
+        consumer = EventConsumer(
+            redis_client=mock_redis,
+            event_type="auth.login",
+            consumer_name="worker-1",
+            group_name="soc360-consumers",
+        )
+
+        await consumer.read_new(block=1000)
+
+        call_kwargs = mock_redis.xreadgroup.call_args.kwargs
+        assert call_kwargs.get("block") == 1000
+
+
+# ---------------------------------------------------------------------------
+# _consumer_loop — runtime behaviour (no source inspection)
+# ---------------------------------------------------------------------------
+
+class TestConsumerLoopRuntimeBehavior:
+    """Runtime tests for _consumer_loop — no inspect.getsource().
+
+    These tests drive the loop with mocks and verify *what it calls*,
+    not what its source code looks like.
+    """
+
+    @pytest.mark.asyncio
+    async def test_consumer_loop_calls_read_new_with_block(self):
+        """_consumer_loop MUST call consumer.read_new() with a blocking timeout."""
+        from app.main import _consumer_loop, _XREADGROUP_BLOCK_MS
+
+        mock_redis = AsyncMock()
+        mock_redis.aclose = AsyncMock()
+
+        mock_consumer = AsyncMock()
+        mock_consumer.read_pending = AsyncMock(return_value=[])
+        # Stop after 2 iterations by raising StopAsyncIteration.
+        call_count = 0
+
+        async def read_new_side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 2:
+                raise asyncio.CancelledError()
+            return []
+
+        mock_consumer.read_new = AsyncMock(side_effect=read_new_side_effect)
+
+        stop_event = asyncio.Event()
+
+        with pytest.raises(asyncio.CancelledError):
+            await _consumer_loop(
+                redis_client=mock_redis,
+                consumer=mock_consumer,
+                stop_event=stop_event,
+            )
+
+        # read_new must have been called with the configured block timeout.
+        mock_consumer.read_new.assert_awaited()
+        call_kwargs = mock_consumer.read_new.call_args.kwargs
+        assert call_kwargs.get("block") == _XREADGROUP_BLOCK_MS
+
+    @pytest.mark.asyncio
+    async def test_consumer_loop_recovers_pending_before_blocking(self):
+        """_consumer_loop MUST drain pending messages before calling read_new().
+
+        When pending messages exist, the loop must process them and NOT call
+        read_new() for that iteration — pending recovery takes priority.
+        """
+        from app.main import _consumer_loop
+
+        mock_redis = AsyncMock()
+        mock_redis.aclose = AsyncMock()
+
+        pending_msg = {
+            "message_id": b"50-0",
+            "data": {"user_id": "pending-user"},
+        }
+
+        # Iteration 1: pending exists → process it, no read_new.
+        # Iteration 2: no pending → read_new called, then stop.
+        iteration = 0
+
+        async def read_pending_side_effect():
+            nonlocal iteration
+            iteration += 1
+            if iteration == 1:
+                return [pending_msg]
+            # After iteration 2, stop the loop.
+            raise asyncio.CancelledError()
+
+        mock_consumer = AsyncMock()
+        mock_consumer.read_pending = AsyncMock(side_effect=read_pending_side_effect)
+        mock_consumer.read_new = AsyncMock(return_value=[])
+
+        stop_event = asyncio.Event()
+
+        with pytest.raises(asyncio.CancelledError):
+            await _consumer_loop(
+                redis_client=mock_redis,
+                consumer=mock_consumer,
+                stop_event=stop_event,
+            )
+
+        # read_pending was called at least twice (iteration 1 + iteration 2).
+        assert mock_consumer.read_pending.await_count >= 2
+
+        # On iteration 1, pending was non-empty, so read_new should NOT
+        # have been called.  On iteration 2, pending raised CancelledError
+        # before read_new.  So read_new should have 0 calls.
+        assert mock_consumer.read_new.await_count == 0, (
+            "read_new must NOT be called when pending messages exist"
+        )
+
+        # The pending message must have been acked.
+        mock_consumer.ack.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_consumer_loop_no_sleep_1_busy_poll(self):
+        """_consumer_loop MUST NOT call asyncio.sleep(1) — the old busy-poll.
+
+        Drives the loop with a mock that returns no messages and verifies
+        that asyncio.sleep is never called with 1.0 seconds.
+        """
+        from app.main import _consumer_loop
+
+        mock_redis = AsyncMock()
+        mock_redis.aclose = AsyncMock()
+
+        call_count = 0
+
+        async def read_new_then_stop(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 2:
+                raise asyncio.CancelledError()
+            return []
+
+        mock_consumer = AsyncMock()
+        mock_consumer.read_pending = AsyncMock(return_value=[])
+        mock_consumer.read_new = AsyncMock(side_effect=read_new_then_stop)
+
+        stop_event = asyncio.Event()
+        sleep_calls: list[float] = []
+
+        original_sleep = asyncio.sleep
+
+        async def tracking_sleep(delay: float, *args, **kwargs):
+            sleep_calls.append(delay)
+            await original_sleep(0)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(asyncio, "sleep", tracking_sleep)
+            with pytest.raises(asyncio.CancelledError):
+                await _consumer_loop(
+                    redis_client=mock_redis,
+                    consumer=mock_consumer,
+                    stop_event=stop_event,
+                )
+
+        # No sleep(1) call must appear — the old busy-poll is gone.
+        assert not any(d == 1.0 for d in sleep_calls), (
+            f"asyncio.sleep(1) busy-poll detected in calls: {sleep_calls}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# _consumer_loop — cancellation
+# ---------------------------------------------------------------------------
+
+class TestConsumerLoopCancellation:
+    """Verify _consumer_loop properly handles asyncio.CancelledError."""
+
+    @pytest.mark.asyncio
+    async def test_cancelled_error_is_reraised(self):
+        """_consumer_loop MUST re-raise asyncio.CancelledError after logging."""
+        from app.main import _consumer_loop
+
+        mock_redis = AsyncMock()
+        mock_redis.aclose = AsyncMock()
+
+        mock_consumer = AsyncMock()
+        # read_pending raises CancelledError to simulate task cancellation
+        mock_consumer.read_pending = AsyncMock(side_effect=asyncio.CancelledError())
+
+        stop_event = asyncio.Event()
+
+        with pytest.raises(asyncio.CancelledError):
+            await _consumer_loop(
+                redis_client=mock_redis,
+                consumer=mock_consumer,
+                stop_event=stop_event,
+            )
+
+        # Redis client must still be closed in the finally block
+        mock_redis.aclose.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_cancelled_error_triggers_cleanup(self):
+        """_consumer_loop MUST run finally block (aclose) even on CancelledError."""
+        from app.main import _consumer_loop
+
+        mock_redis = AsyncMock()
+        close_called = False
+
+        async def track_close():
+            nonlocal close_called
+            close_called = True
+
+        mock_redis.aclose = track_close
+
+        mock_consumer = AsyncMock()
+        mock_consumer.read_pending = AsyncMock(side_effect=asyncio.CancelledError())
+
+        stop_event = asyncio.Event()
+
+        with pytest.raises(asyncio.CancelledError):
+            await _consumer_loop(
+                redis_client=mock_redis,
+                consumer=mock_consumer,
+                stop_event=stop_event,
+            )
+
+        assert close_called, "Redis client must be closed even on CancelledError"
+
+
+# ---------------------------------------------------------------------------
+# _consumer_loop — error backoff (non-cancellation)
+# ---------------------------------------------------------------------------
+
+class TestConsumerLoopErrorBackoff:
+    """Verify _consumer_loop backs off on unexpected errors instead of busy-looping."""
+
+    @pytest.mark.asyncio
+    async def test_error_triggers_backoff_sleep(self):
+        """After an unexpected error, _consumer_loop MUST sleep before retrying.
+
+        This ensures the failure path does not become a tight busy loop.
+        """
+        from app.main import _consumer_loop, _ERROR_BACKOFF_SECONDS
+
+        mock_redis = AsyncMock()
+        mock_redis.aclose = AsyncMock()
+
+        call_count = 0
+
+        async def fail_then_stop():
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 2:
+                raise RuntimeError("transient failure")
+            # Third call: stop the loop.
+            raise asyncio.CancelledError()
+
+        mock_consumer = AsyncMock()
+        mock_consumer.read_pending = AsyncMock(side_effect=fail_then_stop)
+        mock_consumer.read_new = AsyncMock(return_value=[])
+
+        stop_event = asyncio.Event()
+        sleep_durations: list[float] = []
+
+        original_sleep = asyncio.sleep
+
+        async def tracking_sleep(delay: float, *args, **kwargs):
+            sleep_durations.append(delay)
+            await original_sleep(0)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(asyncio, "sleep", tracking_sleep)
+            with pytest.raises(asyncio.CancelledError):
+                await _consumer_loop(
+                    redis_client=mock_redis,
+                    consumer=mock_consumer,
+                    stop_event=stop_event,
+                )
+
+        # At least one backoff sleep must have occurred.
+        assert len(sleep_durations) >= 1, "Expected at least one backoff sleep after errors"
+        # The backoff must match the configured constant.
+        assert all(d == _ERROR_BACKOFF_SECONDS for d in sleep_durations), (
+            f"Expected backoff of {_ERROR_BACKOFF_SECONDS}s, got {sleep_durations}"
+        )


### PR DESCRIPTION
Closes #133

## Summary
- Add a blocking Redis Stream read path using XREADGROUP BLOCK 5000.
- Update the lifespan consumer loop to drain pending messages first, then block for new messages instead of sleeping every second.
- Preserve cancellation semantics by explicitly re-raising asyncio.CancelledError and closing Redis in cleanup.

## Why
The previous loop woke every second even when no messages existed. Using Redis blocking reads reduces idle wakeups while keeping pending-message recovery intact.

## Test Plan
- uv run python -m pytest tests/unit/test_event_bus_issue_133.py -v
- uv run python -m pytest tests/unit/test_event_bus*.py -v
- Reliability review passed after pending-message regression was fixed.

## Note
Issue currently lacks status:approved; maintainer will review CI/validation.