### PR TITLE
fix(db): enforce statement and lock timeouts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,10 @@ POSTGRES_PASSWORD=cambia-esto
 POSTGRES_DB=soc360
 DATABASE_URL=postgresql+asyncpg://soc360_app:cambia-esto@localhost:5433/soc360
 DATABASE_URL_MIGRATION=postgresql+asyncpg://soc360_app:cambia-esto@localhost:5433/soc360
+# Per-query timeout for DB statements (ms). 0 or negative is rejected.
+DB_STATEMENT_TIMEOUT_MS=30000
+# Timeout for acquiring row/table locks (ms). 0 or negative is rejected.
+DB_LOCK_TIMEOUT_MS=5000
 
 # Redis
 REDIS_PASSWORD=soc360_redis_dev_password

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -23,6 +23,10 @@ class Settings(BaseSettings):
     POSTGRES_USER: str
     POSTGRES_PASSWORD: str
     POSTGRES_DB: str
+    # Per-connection safety nets (issue #134) — prevent runaway queries and
+    # indefinite lock waits from starving the pool.
+    DB_STATEMENT_TIMEOUT_MS: int = 30_000
+    DB_LOCK_TIMEOUT_MS: int = 5_000
     
     # JWT
     JWT_ALGORITHM: str = "HS256"
@@ -147,6 +151,16 @@ class Settings(BaseSettings):
         if v.lower() not in _PROVIDER_NAMES:
             raise ValueError(f"LLM_PROVIDER debe ser uno de: {sorted(_PROVIDER_NAMES)}")
         return v.lower()
+
+    @field_validator("DB_STATEMENT_TIMEOUT_MS", "DB_LOCK_TIMEOUT_MS")
+    @classmethod
+    def db_timeout_positive(cls, v: int) -> int:
+        if v <= 0:
+            raise ValueError(
+                "DB timeout values must be positive integers (milliseconds); "
+                "PostgreSQL treats 0 as 'disabled', which defeats the safety net"
+            )
+        return v
 
     @model_validator(mode="after")
     def groq_key_required_for_groq(self) -> Settings:

--- a/app/core/database.py
+++ b/app/core/database.py
@@ -19,6 +19,26 @@ from app.core.logging import get_logger
 logger = get_logger(__name__)
 
 #Evita timeouts de firewalls que cierran conexiones inactivas
+# Per-connection safety nets (issue #134): statement_timeout kills runaway
+# queries; lock_timeout prevents indefinite waits on row/table locks.
+# asyncpg forwards server_settings to PostgreSQL in the startup packet so
+# every connection inherits these limits automatically.
+
+
+def _build_connect_args(stmt_timeout_ms: int, lock_timeout_ms: int) -> dict:
+    """Build asyncpg connect_args with server_settings for timeouts.
+
+    Extracted as a pure function so it can be tested without reloading the
+    module or monkeypatching SQLAlchemy internals.
+    """
+    return {
+        "server_settings": {
+            "statement_timeout": str(stmt_timeout_ms),
+            "lock_timeout": str(lock_timeout_ms),
+        },
+    }
+
+
 engine: AsyncEngine = create_async_engine(
     settings.DATABASE_URL,
     echo=settings.ENVIRONMENT == "development",
@@ -27,6 +47,10 @@ engine: AsyncEngine = create_async_engine(
     max_overflow=20,
     pool_timeout=30,
     pool_recycle=1800,
+    connect_args=_build_connect_args(
+        settings.DB_STATEMENT_TIMEOUT_MS,
+        settings.DB_LOCK_TIMEOUT_MS,
+    ),
 )
 
 #expire_on_commit=False: necesario en async - lazy loading no existe

--- a/tests/integration/test_db_statement_timeout.py
+++ b/tests/integration/test_db_statement_timeout.py
@@ -1,0 +1,135 @@
+"""Integration test: statement_timeout kills long-running queries (issue #134).
+
+Requires a real PostgreSQL instance. Skipped automatically when the DB is
+unreachable.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from app.core.config import settings
+
+
+def _pg_available() -> bool:
+    """Return True if the test PostgreSQL is reachable."""
+    import asyncio
+
+    try:
+        import asyncpg
+    except ImportError:
+        return False
+
+    db_url = os.environ.get("DATABASE_URL", "")
+    if not db_url:
+        return False
+
+    # Use SQLAlchemy's URL parser instead of a narrow regex — handles edge
+    # cases like special characters in passwords, IPv6 hosts, etc.
+    try:
+        from sqlalchemy.engine.url import make_url
+        parsed = make_url(db_url)
+    except Exception:
+        return False
+
+    if parsed.drivername != "postgresql+asyncpg":
+        return False
+
+    async def _ping():
+        conn = await asyncpg.connect(
+            user=parsed.username or "",
+            password=parsed.password or "",
+            host=parsed.host or "localhost",
+            port=parsed.port or 5432,
+            database=parsed.database or "",
+            timeout=3,
+        )
+        await conn.close()
+
+    try:
+        asyncio.run(_ping())
+        return True
+    except Exception:
+        return False
+
+
+requires_pg = pytest.mark.skipif(
+    not _pg_available(),
+    reason="PostgreSQL not available",
+)
+
+
+@requires_pg
+class TestStatementTimeoutIntegration:
+    """Verify statement_timeout actually kills long-running queries."""
+
+    @pytest.mark.asyncio
+    async def test_pg_sleep_exceeds_statement_timeout(self):
+        """A query exceeding statement_timeout MUST be cancelled by PostgreSQL.
+
+        We create an engine with a very short statement_timeout (100ms) and
+        run pg_sleep(5) which should be killed well before 5 seconds.
+        """
+        # Use a dedicated engine with a tight timeout for this test
+        test_url = os.environ["DATABASE_URL"]
+        engine = create_async_engine(
+            test_url,
+            connect_args={
+                "server_settings": {
+                    "statement_timeout": "100",   # 100ms
+                    "lock_timeout": "5000",
+                },
+            },
+        )
+        session_factory = async_sessionmaker(
+            bind=engine, class_=AsyncSession, expire_on_commit=False,
+        )
+
+        try:
+            async with session_factory() as session:
+                with pytest.raises(Exception) as exc_info:
+                    await session.execute(text("SELECT pg_sleep(5)"))
+
+                # asyncpg raises asyncpg.QueryCancelled or similar; the key
+                # assertion is that it DID raise, not that it completed.
+                error_msg = str(exc_info.value).lower()
+                assert (
+                    "cancel" in error_msg
+                    or "timeout" in error_msg
+                    or "statement" in error_msg
+                ), f"Expected timeout/cancel error, got: {exc_info.value}"
+        finally:
+            await engine.dispose()
+
+    @pytest.mark.asyncio
+    async def test_fast_query_succeeds_with_timeout_set(self):
+        """A fast query MUST succeed even when statement_timeout is configured."""
+        test_url = os.environ["DATABASE_URL"]
+        engine = create_async_engine(
+            test_url,
+            connect_args={
+                "server_settings": {
+                    "statement_timeout": str(settings.DB_STATEMENT_TIMEOUT_MS),
+                    "lock_timeout": str(settings.DB_LOCK_TIMEOUT_MS),
+                },
+            },
+        )
+        session_factory = async_sessionmaker(
+            bind=engine, class_=AsyncSession, expire_on_commit=False,
+        )
+
+        try:
+            async with session_factory() as session:
+                result = await session.execute(text("SELECT 1 AS ok"))
+                row = result.scalar()
+                assert row == 1
+        finally:
+            await engine.dispose()

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -166,3 +166,35 @@ def call_call_params(call_args) -> dict | None:
     if "params" in call_args[1]:
         return call_args[1]["params"]
     return None
+
+
+class TestBuildConnectArgs:
+    """Verify _build_connect_args produces correct asyncpg server_settings
+    (issue #134).
+
+    The helper is a pure function — no module reload or SQLAlchemy monkeypatch
+    needed. This avoids polluting app.core.database.engine / AsyncSessionLocal
+    with mock-derived globals.
+    """
+
+    def test_returns_statement_and_lock_timeout_as_strings(self):
+        """_build_connect_args MUST return server_settings with string values
+        for statement_timeout and lock_timeout."""
+        from app.core.database import _build_connect_args
+
+        result = _build_connect_args(12345, 6789)
+
+        assert result == {
+            "server_settings": {
+                "statement_timeout": "12345",
+                "lock_timeout": "6789",
+            },
+        }
+
+    def test_default_timeout_values(self):
+        """The module-level engine MUST be created with default timeout values
+        when no env override is set (30s statement, 5s lock)."""
+        from app.core.config import settings
+
+        assert settings.DB_STATEMENT_TIMEOUT_MS == 30_000
+        assert settings.DB_LOCK_TIMEOUT_MS == 5_000

--- a/tests/unit/test_settings_env_override.py
+++ b/tests/unit/test_settings_env_override.py
@@ -28,3 +28,67 @@ class TestSettingsEnvOverride:
         monkeypatch.setenv("EVENT_STREAM_PREFIX", "custom_events")
         local_settings = Settings()
         assert local_settings.EVENT_STREAM_PREFIX == "custom_events"
+
+    def test_db_statement_timeout_ms_default(self):
+        """DB_STATEMENT_TIMEOUT_MS MUST default to 30000 (30s) for safety."""
+        from app.core.config import Settings
+
+        s = Settings()
+        assert s.DB_STATEMENT_TIMEOUT_MS == 30_000
+
+    def test_db_statement_timeout_ms_env_override(self, monkeypatch: pytest.MonkeyPatch):
+        """DB_STATEMENT_TIMEOUT_MS MUST be overridable via environment variable."""
+        from app.core.config import Settings
+
+        monkeypatch.setenv("DB_STATEMENT_TIMEOUT_MS", "15000")
+        s = Settings()
+        assert s.DB_STATEMENT_TIMEOUT_MS == 15_000
+
+    def test_db_lock_timeout_ms_default(self):
+        """DB_LOCK_TIMEOUT_MS MUST default to 5000 (5s) for safety."""
+        from app.core.config import Settings
+
+        s = Settings()
+        assert s.DB_LOCK_TIMEOUT_MS == 5_000
+
+    def test_db_lock_timeout_ms_env_override(self, monkeypatch: pytest.MonkeyPatch):
+        """DB_LOCK_TIMEOUT_MS MUST be overridable via environment variable."""
+        from app.core.config import Settings
+
+        monkeypatch.setenv("DB_LOCK_TIMEOUT_MS", "10000")
+        s = Settings()
+        assert s.DB_LOCK_TIMEOUT_MS == 10_000
+
+    def test_db_statement_timeout_ms_zero_rejected(self, monkeypatch: pytest.MonkeyPatch):
+        """DB_STATEMENT_TIMEOUT_MS=0 MUST be rejected — PostgreSQL treats 0 as
+        'disabled', which silently defeats the safety net."""
+        from app.core.config import Settings
+
+        monkeypatch.setenv("DB_STATEMENT_TIMEOUT_MS", "0")
+        with pytest.raises(Exception):  # pydantic ValidationError
+            Settings()
+
+    def test_db_statement_timeout_ms_negative_rejected(self, monkeypatch: pytest.MonkeyPatch):
+        """DB_STATEMENT_TIMEOUT_MS with a negative value MUST be rejected."""
+        from app.core.config import Settings
+
+        monkeypatch.setenv("DB_STATEMENT_TIMEOUT_MS", "-5000")
+        with pytest.raises(Exception):  # pydantic ValidationError
+            Settings()
+
+    def test_db_lock_timeout_ms_zero_rejected(self, monkeypatch: pytest.MonkeyPatch):
+        """DB_LOCK_TIMEOUT_MS=0 MUST be rejected — PostgreSQL treats 0 as
+        'disabled', which silently defeats the safety net."""
+        from app.core.config import Settings
+
+        monkeypatch.setenv("DB_LOCK_TIMEOUT_MS", "0")
+        with pytest.raises(Exception):  # pydantic ValidationError
+            Settings()
+
+    def test_db_lock_timeout_ms_negative_rejected(self, monkeypatch: pytest.MonkeyPatch):
+        """DB_LOCK_TIMEOUT_MS with a negative value MUST be rejected."""
+        from app.core.config import Settings
+
+        monkeypatch.setenv("DB_LOCK_TIMEOUT_MS", "-1")
+        with pytest.raises(Exception):  # pydantic ValidationError
+            Settings()


### PR DESCRIPTION
Closes #134

## Summary
- Add DB_STATEMENT_TIMEOUT_MS and DB_LOCK_TIMEOUT_MS settings with positive-value validation.
- Configure asyncpg server_settings so every connection gets statement_timeout and lock_timeout.
- Document the new operational knobs in .env.example.

## Why
asyncpg/PostgreSQL defaults allow unbounded statements and lock waits. Engine-level settings protect all request paths, including get_current_user, without touching the blocked dependencies.py file.

## Test Plan
- Unit settings tests for defaults, env overrides, and invalid zero/negative values.
- Unit database tests for asyncpg server_settings construction.
- Integration pg_sleep timeout tests are present and skip deterministically when PostgreSQL is unavailable.
- Reliability review approved after test pollution and validation issues were fixed.

## Note
Issue currently lacks status:approved; maintainer will review CI/validation.