### PR TITLE
feat(rate-limit): progressive lockout for auth endpoints (#178)

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -87,6 +87,10 @@ class Settings(BaseSettings):
     REDIS_STARTUP_MAX_ATTEMPTS: int = 3
     REDIS_STARTUP_BACKOFF_BASE_SECONDS: float = 1.0
     
+    # Rate Limiting (progressive lockout)
+    RATE_LIMIT_ENABLED: bool = True
+    RATE_LIMIT_WINDOW_SECONDS: int = 86400  # 24h — auto-cleanup TTL for rate limit keys
+
     #CORS
     CORS_ORIGINS: list[str] = ["http://localhost:5173"]
 

--- a/app/core/rate_limit.py
+++ b/app/core/rate_limit.py
@@ -1,0 +1,173 @@
+"""Progressive lockout rate limiter for auth endpoints.
+
+Design: dual-key lockout (IP + email) with escalating timeouts.
+- Failed attempts are tracked per IP and per email hash.
+- Lockout duration escalates with each batch of failures.
+- Successful login resets the failure counter.
+- Lockout message is generic (doesn't reveal the duration).
+"""
+from __future__ import annotations
+
+import hashlib
+import time
+from dataclasses import dataclass
+
+from redis.asyncio import Redis
+
+from app.core.config import settings
+from app.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+# Redis key prefixes
+_IP_PREFIX = "ratelimit:ip:"
+_EMAIL_PREFIX = "ratelimit:email:"
+
+# Lockout escalation table: (threshold, lockout_seconds)
+# When cumulative failures reach `threshold`, lockout is `lockout_seconds`.
+_LOCKOUT_TABLE: list[tuple[int, int]] = [
+    (5, 3 * 60),         # 5 failures  → 3 min
+    (10, 15 * 60),       # 10 failures → 15 min
+    (15, 60 * 60),       # 15 failures → 1 hour
+    (20, 4 * 60 * 60),   # 20 failures → 4 hours
+    (25, 24 * 60 * 60),  # 25 failures → 24 hours
+]
+
+
+def _hash_email(email: str) -> str:
+    """Hash email for Redis key — no PII stored."""
+    return hashlib.sha256(email.lower().strip().encode()).hexdigest()[:16]
+
+
+def _get_lockout_seconds(failures: int) -> int:
+    """Return lockout duration for the given failure count.
+
+    Returns 0 if no lockout threshold has been reached.
+    For failures beyond the last threshold, uses the max lockout (24h).
+    
+    Lockout only applies when failures EXCEED the threshold, not when they
+    equal it. This allows one more attempt at the threshold before locking.
+    """
+    # Find the highest threshold that failures has exceeded
+    result = 0
+    for threshold, seconds in _LOCKOUT_TABLE:
+        if failures > threshold:
+            result = seconds
+        else:
+            break
+    return result
+
+
+@dataclass
+class LockoutStatus:
+    """Result of a rate limit check."""
+    is_locked: bool
+    retry_after: int | None = None  # seconds until unlock, None if not locked
+    failures: int = 0
+
+
+class RateLimiter:
+    """Progressive lockout rate limiter backed by Redis.
+
+    Usage:
+        limiter = RateLimiter(redis_client)
+        status = await limiter.check("192.168.1.1", "user@example.com")
+        if status.is_locked:
+            raise HTTPException(429, detail="Too many attempts")
+
+        # After failed login:
+        await limiter.record_failure("192.168.1.1", "user@example.com")
+
+        # After successful login:
+        await limiter.record_success("192.168.1.1", "user@example.com")
+    """
+
+    def __init__(self, redis: Redis) -> None:
+        self._redis = redis
+
+    async def check(self, ip: str, email: str) -> LockoutStatus:
+        """Check if IP or email is currently locked out.
+
+        Returns LockoutStatus with is_locked=True if either key is locked.
+        """
+        ip_key = f"{_IP_PREFIX}{ip}"
+        email_key = f"{_EMAIL_PREFIX}{_hash_email(email)}"
+
+        # Check both keys in parallel
+        ip_data = await self._redis.hgetall(ip_key)
+        email_data = await self._redis.hgetall(email_key)
+
+        now = time.time()
+
+        # Check IP lockout
+        ip_locked_until = float(ip_data.get(b"locked_until", 0))
+        if ip_locked_until > now:
+            remaining = int(ip_locked_until - now)
+            logger.warning("rate_limit_locked", key_type="ip", ip=ip, retry_after=remaining)
+            return LockoutStatus(is_locked=True, retry_after=remaining,
+                                 failures=int(ip_data.get(b"failures", 0)))
+
+        # Check email lockout
+        email_locked_until = float(email_data.get(b"locked_until", 0))
+        if email_locked_until > now:
+            remaining = int(email_locked_until - now)
+            logger.warning("rate_limit_locked", key_type="email",
+                           email_hash=_hash_email(email), retry_after=remaining)
+            return LockoutStatus(is_locked=True, retry_after=remaining,
+                                 failures=int(email_data.get(b"failures", 0)))
+
+        # Not locked — return current failure count
+        max_failures = max(
+            int(ip_data.get(b"failures", 0)),
+            int(email_data.get(b"failures", 0)),
+        )
+        return LockoutStatus(is_locked=False, failures=max_failures)
+
+    async def record_failure(self, ip: str, email: str) -> LockoutStatus:
+        """Record a failed login attempt for both IP and email.
+
+        Increments failure counters and applies lockout if threshold reached.
+        If already locked, extends the lockout window.
+        """
+        ip_key = f"{_IP_PREFIX}{ip}"
+        email_key = f"{_EMAIL_PREFIX}{_hash_email(email)}"
+        now = time.time()
+
+        for key in (ip_key, email_key):
+            # Increment failure count atomically
+            failures = await self._redis.hincrby(key, "failures", 1)
+            # Set TTL for auto-cleanup (24h + buffer)
+            await self._redis.expire(key, settings.RATE_LIMIT_WINDOW_SECONDS + 3600)
+
+            # Check if we should lock
+            lockout_seconds = _get_lockout_seconds(failures)
+            if lockout_seconds > 0:
+                # If already locked, extend from current locked_until
+                current_locked = float(await self._redis.hget(key, "locked_until") or 0)
+                base_time = max(now, current_locked)
+                new_locked_until = base_time + lockout_seconds
+
+                await self._redis.hset(key, "locked_until", str(new_locked_until))
+                logger.warning(
+                    "rate_limit_lockout_applied",
+                    key=key.split(":")[1],  # "ip" or "email"
+                    failures=failures,
+                    lockout_seconds=lockout_seconds,
+                    locked_until=new_locked_until,
+                )
+
+        # Return the combined status
+        return await self.check(ip, email)
+
+    async def record_success(self, ip: str, email: str) -> None:
+        """Reset failure counters after successful login.
+
+        Clears both IP and email failure tracking.
+        """
+        ip_key = f"{_IP_PREFIX}{ip}"
+        email_key = f"{_EMAIL_PREFIX}{_hash_email(email)}"
+
+        await self._redis.delete(ip_key)
+        await self._redis.delete(email_key)
+
+        logger.info("rate_limit_reset", ip=ip, email_hash=_hash_email(email))

--- a/app/modules/auth/router.py
+++ b/app/modules/auth/router.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Cookie, HTTPException, Request, Response
+from fastapi import APIRouter, Cookie, Depends, HTTPException, Request, Response
 from jwt import InvalidTokenError
 
 from app.core.config import settings
 from app.core.exceptions import AppError
+from app.core.logging import get_logger
+from app.core.rate_limit import RateLimiter
 from app.core.security import decode_access_token
 from app.dependencies import DBDep, RedisDep, CurrentUserDep
 from app.modules.auth.schemas import (
@@ -14,10 +16,25 @@ from app.modules.auth.schemas import (
 )
 from app.modules.auth import service
 
+logger = get_logger(__name__)
 
 REFRESH_COOKIE_NAME = "refresh_token"
 
 router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+def _get_client_ip(request: Request) -> str:
+    """Extract client IP, respecting X-Forwarded-For behind trusted proxies."""
+    if settings.TRUSTED_PROXIES and request.client:
+        forwarded = request.headers.get("x-forwarded-for")
+        if forwarded and request.client.host in settings.TRUSTED_PROXIES:
+            return forwarded.split(",")[0].strip()
+    return request.client.host if request.client else "unknown"
+
+
+async def _get_rate_limiter(redis: RedisDep) -> RateLimiter:
+    """Dependency: return a RateLimiter instance."""
+    return RateLimiter(redis)
 
 
 def _set_refresh_cookie(response: Response, token: str) -> None:
@@ -46,19 +63,53 @@ async def login(
     response: Response,
     db: DBDep,
     redis: RedisDep,
+    rate_limiter: RateLimiter = Depends(_get_rate_limiter),
 ) -> TokenResponse:
+    ip = _get_client_ip(request)
+
+    # Check rate limit before attempting login
+    # Returns 401 (not 429) to maintain enumeration resistance —
+    # attacker can't distinguish between wrong password, unknown user, and rate limit.
+    # Fail-open: if Redis is down, skip rate limiting and let auth proceed.
+    if settings.RATE_LIMIT_ENABLED:
+        try:
+            status = await rate_limiter.check(ip, body.email)
+            if status.is_locked:
+                logger.warning("login_rate_limited", ip=ip, email=body.email[:3] + "***")
+                raise HTTPException(
+                    status_code=401,
+                    detail="Credenciales incorrectas",
+                )
+        except HTTPException:
+            raise
+        except Exception:
+            logger.warning("rate_limit_check_failed", reason="redis_error", ip=ip)
+
     try:
         user_agent = request.headers.get("user-agent")
         token_response, refresh_token = await service.login(
             email=body.email,
             password=body.password,
-            request_ip=request.client.host if request.client else None,
+            request_ip=ip,
             user_agent=user_agent,
             db=db,
             redis=redis,
         )
     except AppError as exc:
+        # Record failure on auth error (wrong password, user not found, etc.)
+        if settings.RATE_LIMIT_ENABLED:
+            try:
+                await rate_limiter.record_failure(ip, body.email)
+            except Exception:
+                logger.warning("rate_limit_record_failed", reason="redis_error", ip=ip)
         raise HTTPException(status_code=exc.status_code, detail=exc.detail)
+
+    # Success — reset failure counters
+    if settings.RATE_LIMIT_ENABLED:
+        try:
+            await rate_limiter.record_success(ip, body.email)
+        except Exception:
+            logger.warning("rate_limit_reset_failed", reason="redis_error", ip=ip)
 
     _set_refresh_cookie(response, refresh_token)
     return token_response
@@ -70,10 +121,29 @@ async def refresh(
     response: Response,
     db: DBDep,
     redis: RedisDep,
+    rate_limiter: RateLimiter = Depends(_get_rate_limiter),
     refresh_token: str | None = Cookie(default=None, alias=REFRESH_COOKIE_NAME),
 ) -> TokenResponse:
     if not refresh_token:
         raise HTTPException(status_code=401, detail="Refresh token ausente")
+
+    ip = _get_client_ip(request)
+
+    # Check rate limit by IP only (no email available in refresh requests)
+    # Fail-open: if Redis is down, skip rate limiting.
+    if settings.RATE_LIMIT_ENABLED:
+        try:
+            status = await rate_limiter.check(ip, f"refresh:{ip}")
+            if status.is_locked:
+                logger.warning("refresh_rate_limited", ip=ip)
+                raise HTTPException(
+                    status_code=429,
+                    detail="Demasiados intentos. Intenta más tarde.",
+                )
+        except HTTPException:
+            raise
+        except Exception:
+            logger.warning("rate_limit_check_failed", reason="redis_error", ip=ip)
 
     # Extraer JTI viejo del access token si existe (no es requerido)
     old_jti = None
@@ -92,10 +162,23 @@ async def refresh(
             old_jti=old_jti,
             db=db,
             redis=redis,
-            request_ip=request.client.host if request.client else None,
+            request_ip=ip,
         )
     except AppError as exc:
+        # Record failure on refresh error
+        if settings.RATE_LIMIT_ENABLED:
+            try:
+                await rate_limiter.record_failure(ip, f"refresh:{ip}")
+            except Exception:
+                logger.warning("rate_limit_record_failed", reason="redis_error", ip=ip)
         raise HTTPException(status_code=exc.status_code, detail=exc.detail)
+
+    # Success — reset failure counters
+    if settings.RATE_LIMIT_ENABLED:
+        try:
+            await rate_limiter.record_success(ip, f"refresh:{ip}")
+        except Exception:
+            logger.warning("rate_limit_reset_failed", reason="redis_error", ip=ip)
 
     _set_refresh_cookie(response, new_refresh)
     return token_response
@@ -103,12 +186,31 @@ async def refresh(
 
 @router.post("/logout", status_code=200)
 async def logout(
+    request: Request,
     response: Response,
     db: DBDep,
     redis: RedisDep,
     current_user: CurrentUserDep,
+    rate_limiter: RateLimiter = Depends(_get_rate_limiter),
     refresh_token: str | None = Cookie(default=None, alias=REFRESH_COOKIE_NAME),
 ) -> dict:
+    ip = _get_client_ip(request)
+
+    # Check rate limit — fail-open if Redis is down
+    if settings.RATE_LIMIT_ENABLED:
+        try:
+            status = await rate_limiter.check(ip, f"logout:{current_user.id}")
+            if status.is_locked:
+                logger.warning("logout_rate_limited", ip=ip, user_id=str(current_user.id))
+                raise HTTPException(
+                    status_code=429,
+                    detail="Demasiados intentos. Intenta más tarde.",
+                )
+        except HTTPException:
+            raise
+        except Exception:
+            logger.warning("rate_limit_check_failed", reason="redis_error", ip=ip)
+
     try:
         await service.logout(
             jti=current_user.current_jti,  # type: ignore[attr-defined]
@@ -119,6 +221,11 @@ async def logout(
             redis=redis,
         )
     except AppError as exc:
+        if settings.RATE_LIMIT_ENABLED:
+            try:
+                await rate_limiter.record_failure(ip, f"logout:{current_user.id}")
+            except Exception:
+                logger.warning("rate_limit_record_failed", reason="redis_error", ip=ip)
         raise HTTPException(status_code=exc.status_code, detail=exc.detail)
 
     _clear_refresh_cookie(response)
@@ -128,11 +235,30 @@ async def logout(
 @router.post("/change-password", status_code=200)
 async def change_password(
     body: ChangePasswordRequest,
+    request: Request,
     response: Response,
     db: DBDep,
     redis: RedisDep,
     current_user: CurrentUserDep,
+    rate_limiter: RateLimiter = Depends(_get_rate_limiter),
 ) -> dict:
+    ip = _get_client_ip(request)
+
+    # Check rate limit — fail-open if Redis is down
+    if settings.RATE_LIMIT_ENABLED:
+        try:
+            status = await rate_limiter.check(ip, f"change-password:{current_user.id}")
+            if status.is_locked:
+                logger.warning("change_password_rate_limited", ip=ip, user_id=str(current_user.id))
+                raise HTTPException(
+                    status_code=429,
+                    detail="Demasiados intentos. Intenta más tarde.",
+                )
+        except HTTPException:
+            raise
+        except Exception:
+            logger.warning("rate_limit_check_failed", reason="redis_error", ip=ip)
+
     try:
         await service.change_password(
             user_id=current_user.id,
@@ -143,6 +269,11 @@ async def change_password(
             redis=redis,
         )
     except AppError as exc:
+        if settings.RATE_LIMIT_ENABLED:
+            try:
+                await rate_limiter.record_failure(ip, f"change-password:{current_user.id}")
+            except Exception:
+                logger.warning("rate_limit_record_failed", reason="redis_error", ip=ip)
         raise HTTPException(status_code=exc.status_code, detail=exc.detail)
 
     _clear_refresh_cookie(response)

--- a/tests/integration/test_auth_integration.py
+++ b/tests/integration/test_auth_integration.py
@@ -14,6 +14,10 @@ async def _clear_login_attempts_before_auth_test(client: AsyncClient):
         keys = await redis.keys("login_attempts:*")
         if keys:
             await redis.delete(*keys)
+        # Also clear new rate limit keys
+        rl_keys = await redis.keys("ratelimit:*")
+        if rl_keys:
+            await redis.delete(*rl_keys)
         break
 
 

--- a/tests/integration/test_event_bus_e2e.py
+++ b/tests/integration/test_event_bus_e2e.py
@@ -55,8 +55,15 @@ async def redis_client() -> Redis:
     if not await _redis_is_available():
         pytest.skip("Redis not available — E2E tests require a running Redis instance")
     client = Redis.from_url(settings.REDIS_URL, decode_responses=False)
+    # Cleanup BEFORE test to ensure clean state
+    try:
+        keys = await client.keys("events:*")
+        if keys:
+            await client.delete(*keys)
+    except Exception:
+        pass
     yield client
-    # Cleanup: flush test keys
+    # Cleanup AFTER test
     try:
         keys = await client.keys("events:*")
         if keys:
@@ -95,6 +102,17 @@ def sample_event() -> AuthLoginEvent:
 @pytest.mark.integration
 class TestEventBusE2E:
     """End-to-end event bus tests with real Redis."""
+
+    @pytest_asyncio.fixture(autouse=True)
+    async def _cleanup_streams(self, redis_client: Redis):
+        """Ensure clean Redis streams before each test."""
+        keys = await redis_client.keys("events:*")
+        if keys:
+            await redis_client.delete(*keys)
+        yield
+        keys = await redis_client.keys("events:*")
+        if keys:
+            await redis_client.delete(*keys)
 
     async def test_publish_and_consume(
         self, event_bus: EventBus, redis_client: Redis, sample_event: AuthLoginEvent

--- a/tests/integration/test_event_bus_e2e.py
+++ b/tests/integration/test_event_bus_e2e.py
@@ -1,0 +1,308 @@
+"""End-to-end tests for event bus with real Redis.
+
+Tests the full event bus lifecycle with a real Redis instance:
+- Publish → Consume → Ack
+- Consumer group behavior
+- Pending message recovery
+- DLQ (Dead Letter Queue) on handler failure
+
+These tests require a running Redis instance (provided by CI services).
+They are SKIPPED when Redis is not available (local dev without Redis).
+"""
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+import pytest_asyncio
+from redis.asyncio import Redis
+
+from app.core.config import settings
+from app.event_bus import EventBus, EventConsumer
+from app.event_schemas import AuthLoginEvent
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _redis_is_available() -> bool:
+    """Check if Redis is reachable."""
+    try:
+        client = Redis.from_url(settings.REDIS_URL, decode_responses=False)
+        await client.ping()
+        await client.aclose()
+        return True
+    except Exception:
+        return False
+
+
+# Skip all tests in this module if Redis is not available
+pytestmark = pytest.mark.integration
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def redis_client() -> Redis:
+    """Provide a real Redis client for E2E tests."""
+    if not await _redis_is_available():
+        pytest.skip("Redis not available — E2E tests require a running Redis instance")
+    client = Redis.from_url(settings.REDIS_URL, decode_responses=False)
+    yield client
+    # Cleanup: flush test keys
+    try:
+        keys = await client.keys("events:*")
+        if keys:
+            await client.delete(*keys)
+    except Exception:
+        pass
+    await client.aclose()
+
+
+@pytest_asyncio.fixture
+async def event_bus(redis_client: Redis) -> EventBus:
+    """Provide an EventBus backed by real Redis."""
+    return EventBus(redis_client)
+
+
+@pytest_asyncio.fixture
+def sample_event() -> AuthLoginEvent:
+    """Create a sample auth.login event."""
+    return AuthLoginEvent(
+        event_id=uuid.uuid4(),
+        event_type="auth.login",
+        tenant_id=uuid.uuid4(),
+        user_id=str(uuid.uuid4()),
+        email_hash="a" * 64,
+        ip_prefix="192.0.2.0/24",
+        user_agent="E2ETest/1.0",
+        timestamp=datetime.now(timezone.utc),
+    )
+
+
+# ---------------------------------------------------------------------------
+# E2E Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestEventBusE2E:
+    """End-to-end event bus tests with real Redis."""
+
+    async def test_publish_and_consume(
+        self, event_bus: EventBus, redis_client: Redis, sample_event: AuthLoginEvent
+    ):
+        """Publish an event and consume it via consumer group."""
+        # Publish
+        msg_id = await event_bus.publish(sample_event)
+        assert isinstance(msg_id, bytes)
+
+        # Create consumer
+        consumer = EventConsumer(
+            redis_client=redis_client,
+            event_type="auth.login",
+            consumer_name="e2e-worker-1",
+            group_name="e2e-test-group",
+        )
+
+        # Read new messages
+        messages = await consumer.read_new(block=1000)
+        assert len(messages) >= 1
+
+        # Verify message data
+        msg = messages[0]
+        data = msg["data"]
+        assert data["event_type"] == "auth.login"
+        assert data["user_id"] == str(sample_event.user_id)
+        assert data["email_hash"] == sample_event.email_hash
+        assert data["ip_prefix"] == sample_event.ip_prefix
+
+        # Acknowledge
+        await consumer.ack(msg["message_id"])
+
+        # Verify no longer pending
+        pending = await consumer.read_pending()
+        assert len(pending) == 0
+
+    async def test_consumer_group_multiple_consumers(
+        self, event_bus: EventBus, redis_client: Redis
+    ):
+        """Multiple consumers in the same group should get different messages."""
+        # Publish 2 events
+        event1 = AuthLoginEvent(
+            event_id=uuid.uuid4(),
+            event_type="auth.login",
+            tenant_id=uuid.uuid4(),
+            user_id=str(uuid.uuid4()),
+            email_hash="b" * 64,
+            ip_prefix="10.0.0.0/24",
+            user_agent="MultiConsumer/1.0",
+            timestamp=datetime.now(timezone.utc),
+        )
+        event2 = AuthLoginEvent(
+            event_id=uuid.uuid4(),
+            event_type="auth.login",
+            tenant_id=uuid.uuid4(),
+            user_id=str(uuid.uuid4()),
+            email_hash="c" * 64,
+            ip_prefix="10.0.1.0/24",
+            user_agent="MultiConsumer/1.0",
+            timestamp=datetime.now(timezone.utc),
+        )
+
+        await event_bus.publish(event1)
+        await event_bus.publish(event2)
+
+        # Consumer 1 reads
+        consumer1 = EventConsumer(
+            redis_client=redis_client,
+            event_type="auth.login",
+            consumer_name="e2e-worker-a",
+            group_name="e2e-multi-group",
+        )
+        messages1 = await consumer1.read_new(block=1000)
+        assert len(messages1) >= 1
+
+        # Consumer 2 reads (should get remaining messages)
+        consumer2 = EventConsumer(
+            redis_client=redis_client,
+            event_type="auth.login",
+            consumer_name="e2e-worker-b",
+            group_name="e2e-multi-group",
+        )
+        messages2 = await consumer2.read_new(block=1000)
+
+        # Both consumers should have received messages
+        total_messages = len(messages1) + len(messages2)
+        assert total_messages >= 2
+
+        # Cleanup
+        for msg in messages1:
+            await consumer1.ack(msg["message_id"])
+        for msg in messages2:
+            await consumer2.ack(msg["message_id"])
+
+    async def test_pending_message_recovery(
+        self, event_bus: EventBus, redis_client: Redis, sample_event: AuthLoginEvent
+    ):
+        """Unacknowledged messages should be recoverable via read_pending."""
+        # Publish
+        await event_bus.publish(sample_event)
+
+        consumer = EventConsumer(
+            redis_client=redis_client,
+            event_type="auth.login",
+            consumer_name="e2e-recovery-worker",
+            group_name="e2e-recovery-group",
+        )
+
+        # Read but DON'T ack (simulates crash)
+        messages = await consumer.read_new(block=1000)
+        assert len(messages) >= 1
+
+        # Create new consumer instance (simulates restart)
+        consumer2 = EventConsumer(
+            redis_client=redis_client,
+            event_type="auth.login",
+            consumer_name="e2e-recovery-worker",
+            group_name="e2e-recovery-group",
+        )
+
+        # Should recover pending messages
+        pending = await consumer2.read_pending()
+        assert len(pending) >= 1
+
+        # Verify recovered message data
+        msg = pending[0]
+        assert msg["data"]["event_type"] == "auth.login"
+
+        # Ack to cleanup
+        await consumer2.ack(msg["message_id"])
+
+    async def test_stream_maxlen_respected(
+        self, event_bus: EventBus, redis_client: Redis
+    ):
+        """Stream should respect EVENT_STREAM_MAXLEN setting."""
+        # Publish several events
+        for i in range(5):
+            event = AuthLoginEvent(
+                event_id=uuid.uuid4(),
+                event_type="auth.login",
+                tenant_id=uuid.uuid4(),
+                user_id=str(uuid.uuid4()),
+                email_hash=f"{'d' * 60}{i:04d}",
+                ip_prefix="10.0.0.0/24",
+                user_agent="MaxLenTest/1.0",
+                timestamp=datetime.now(timezone.utc),
+            )
+            await event_bus.publish(event)
+
+        # Verify stream exists and has messages
+        stream_key = f"{settings.EVENT_STREAM_PREFIX}:auth.login"
+        length = await redis_client.xlen(stream_key)
+        assert length >= 5
+
+    async def test_event_dispatch_handler(
+        self, event_bus: EventBus, redis_client: Redis, sample_event: AuthLoginEvent
+    ):
+        """EventBus._dispatch_event should handle auth.login events."""
+        # Publish
+        msg_id = await event_bus.publish(sample_event)
+
+        # Read the message
+        consumer = EventConsumer(
+            redis_client=redis_client,
+            event_type="auth.login",
+            consumer_name="e2e-dispatch-worker",
+            group_name="e2e-dispatch-group",
+        )
+        messages = await consumer.read_new(block=1000)
+        assert len(messages) >= 1
+
+        msg = messages[0]
+        msg_id_str = msg["message_id"].decode() if isinstance(msg["message_id"], bytes) else msg["message_id"]
+
+        # Dispatch the event (should not raise)
+        result = await EventBus._dispatch_event(
+            "auth.login",
+            msg["data"],
+            redis_client,
+            message_id=msg_id_str,
+        )
+        assert result is True
+
+        # Ack
+        await consumer.ack(msg["message_id"])
+
+    async def test_reconnect_and_resume(
+        self, event_bus: EventBus, redis_client: Redis, sample_event: AuthLoginEvent
+    ):
+        """reconnect_and_resume should recover pending messages."""
+        # Publish
+        await event_bus.publish(sample_event)
+
+        consumer = EventConsumer(
+            redis_client=redis_client,
+            event_type="auth.login",
+            consumer_name="e2e-reconnect-worker",
+            group_name="e2e-reconnect-group",
+        )
+
+        # Read but don't ack
+        messages = await consumer.read_new(block=1000)
+        assert len(messages) >= 1
+
+        # Reconnect (simulates reconnection)
+        pending = await consumer.reconnect_and_resume()
+        assert len(pending) >= 1
+
+        # Ack to cleanup
+        for msg in pending:
+            await consumer.ack(msg["message_id"])

--- a/tests/integration/test_rate_limiting.py
+++ b/tests/integration/test_rate_limiting.py
@@ -1,0 +1,311 @@
+"""Integration tests for progressive lockout rate limiting.
+
+Tests the dual-key (IP + email) progressive lockout mechanism with
+escalating timeouts: 3min → 15min → 1h → 4h → 24h.
+"""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from fakeredis.aioredis import FakeRedis
+
+from app.core.redis import get_redis
+from app.core.rate_limit import RateLimiter, _get_lockout_seconds, _hash_email
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for lockout escalation logic
+# ---------------------------------------------------------------------------
+
+
+class TestLockoutEscalation:
+    """Test the lockout threshold → duration mapping."""
+
+    def test_no_lockout_below_threshold(self):
+        """No lockout when failures are below the first threshold."""
+        assert _get_lockout_seconds(0) == 0
+        assert _get_lockout_seconds(1) == 0
+        assert _get_lockout_seconds(4) == 0
+
+    def test_lockout_at_threshold(self):
+        """Lockout starts when failures EXCEED the threshold (not at it)."""
+        # At threshold: no lockout yet (allows one more attempt)
+        assert _get_lockout_seconds(5) == 0
+        # Exceeding threshold: lockout applies
+        assert _get_lockout_seconds(6) == 3 * 60  # 3 min
+
+    def test_escalation_table(self):
+        """Verify all escalation levels."""
+        # Below 5: no lockout
+        assert _get_lockout_seconds(4) == 0
+        
+        # 5-10: 3 min (after exceeding 5)
+        assert _get_lockout_seconds(6) == 3 * 60
+        assert _get_lockout_seconds(10) == 3 * 60
+        
+        # 10-15: 15 min (after exceeding 10)
+        assert _get_lockout_seconds(11) == 15 * 60
+        assert _get_lockout_seconds(15) == 15 * 60
+        
+        # 15-20: 1 hour (after exceeding 15)
+        assert _get_lockout_seconds(16) == 60 * 60
+        assert _get_lockout_seconds(20) == 60 * 60
+        
+        # 20-25: 4 hours (after exceeding 20)
+        assert _get_lockout_seconds(21) == 4 * 60 * 60
+        assert _get_lockout_seconds(25) == 4 * 60 * 60
+        
+        # 25+: 24 hours (after exceeding 25)
+        assert _get_lockout_seconds(26) == 24 * 60 * 60
+        assert _get_lockout_seconds(100) == 24 * 60 * 60
+
+
+class TestEmailHashing:
+    """Test that emails are properly hashed for Redis keys."""
+
+    def test_hash_is_deterministic(self):
+        """Same email always produces the same hash."""
+        h1 = _hash_email("user@example.com")
+        h2 = _hash_email("user@example.com")
+        assert h1 == h2
+
+    def test_hash_is_case_insensitive(self):
+        """Email hashing normalizes case."""
+        assert _hash_email("User@Example.COM") == _hash_email("user@example.com")
+
+    def test_hash_strips_whitespace(self):
+        """Email hashing strips whitespace."""
+        assert _hash_email("  user@example.com  ") == _hash_email("user@example.com")
+
+    def test_hash_length(self):
+        """Hash is truncated to 16 chars for readability."""
+        assert len(_hash_email("any@email.com")) == 16
+
+    def test_different_emails_different_hashes(self):
+        """Different emails produce different hashes."""
+        assert _hash_email("user1@example.com") != _hash_email("user2@example.com")
+
+
+# ---------------------------------------------------------------------------
+# Integration tests with FakeRedis
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestRateLimiterIntegration:
+    """Test RateLimiter with FakeRedis."""
+
+    @pytest_asyncio.fixture(autouse=True)
+    async def _cleanup_redis(self):
+        """Clean up rate limit keys after each test."""
+        self.redis = FakeRedis()
+        yield
+        await self.redis.flushall()
+        await self.redis.aclose()
+
+    @pytest_asyncio.fixture
+    async def limiter(self) -> RateLimiter:
+        return RateLimiter(self.redis)
+
+    async def test_check_returns_not_locked_initially(self, limiter: RateLimiter):
+        """Fresh IP+email should not be locked."""
+        status = await limiter.check("10.0.0.1", "new@test.com")
+        assert status.is_locked is False
+        assert status.failures == 0
+
+    async def test_record_failure_increments_counter(self, limiter: RateLimiter):
+        """Recording failures increments the failure count."""
+        await limiter.record_failure("10.0.0.1", "user@test.com")
+        status = await limiter.check("10.0.0.1", "user@test.com")
+        assert status.failures == 1
+
+    async def test_lockout_after_exceeding_threshold(self, limiter: RateLimiter):
+        """Lockout applies after exceeding the first threshold (5 failures)."""
+        # 5 failures: at threshold, no lockout yet
+        for _ in range(5):
+            await limiter.record_failure("10.0.0.1", "user@test.com")
+        
+        status = await limiter.check("10.0.0.1", "user@test.com")
+        assert status.is_locked is False, "At threshold: no lockout yet"
+
+        # 6th failure: exceeds threshold, lockout applies
+        await limiter.record_failure("10.0.0.1", "user@test.com")
+        status = await limiter.check("10.0.0.1", "user@test.com")
+        assert status.is_locked is True
+        assert status.retry_after is not None
+        assert status.retry_after > 0
+
+    async def test_success_resets_counters(self, limiter: RateLimiter):
+        """Successful login resets both IP and email failure counters."""
+        # Build up some failures
+        for _ in range(3):
+            await limiter.record_failure("10.0.0.1", "user@test.com")
+        
+        # Verify failures are tracked
+        status = await limiter.check("10.0.0.1", "user@test.com")
+        assert status.failures == 3
+
+        # Success resets
+        await limiter.record_success("10.0.0.1", "user@test.com")
+        status = await limiter.check("10.0.0.1", "user@test.com")
+        assert status.is_locked is False
+        assert status.failures == 0
+
+    async def test_dual_key_ip_and_email(self, limiter: RateLimiter):
+        """Lockout triggers on EITHER IP or email being locked."""
+        # Lock the IP by failing with different emails
+        for i in range(6):
+            await limiter.record_failure("10.0.0.1", f"user{i}@test.com")
+        
+        # IP should be locked even though each email has only 1 failure
+        status = await limiter.check("10.0.0.1", "any@test.com")
+        assert status.is_locked is True
+
+    async def test_dual_key_email_locked_from_different_ips(self, limiter: RateLimiter):
+        """Email lockout persists even from different IPs."""
+        # Lock the email from multiple IPs
+        for i in range(6):
+            await limiter.record_failure(f"10.0.0.{i}", "victim@test.com")
+        
+        # Email should be locked from any IP
+        status = await limiter.check("10.99.99.99", "victim@test.com")
+        assert status.is_locked is True
+
+    async def test_lockout_extends_on_repeated_failures(self, limiter: RateLimiter):
+        """If already locked, repeated failures extend the lockout window."""
+        # Trigger initial lockout
+        for _ in range(6):
+            await limiter.record_failure("10.0.0.1", "user@test.com")
+        
+        status1 = await limiter.check("10.0.0.1", "user@test.com")
+        assert status1.is_locked is True
+        initial_retry = status1.retry_after
+
+        # Another failure should extend the lockout
+        await limiter.record_failure("10.0.0.1", "user@test.com")
+        status2 = await limiter.check("10.0.0.1", "user@test.com")
+        assert status2.is_locked is True
+        # The lockout should be extended (or at least not shorter)
+        assert status2.retry_after >= initial_retry - 1  # -1 for timing tolerance
+
+
+# ---------------------------------------------------------------------------
+# End-to-end tests with HTTP client
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestRateLimitingE2E:
+    """Test rate limiting through the actual HTTP endpoints."""
+
+    @pytest_asyncio.fixture(autouse=True)
+    async def _cleanup_rate_limits(self, client: AsyncClient):
+        """Clean up rate limit keys after each test."""
+        yield
+        redis_override = client._transport.app.dependency_overrides[get_redis]
+        async for redis in redis_override():
+            keys = await redis.keys("ratelimit:*")
+            if keys:
+                await redis.delete(*keys)
+            break
+
+    async def test_login_locked_returns_401_generic(self, client: AsyncClient, seed_data):
+        """Rate-limited login returns 401 (not 429) for enumeration resistance."""
+        # Trigger lockout: 6 failed attempts (exceeds threshold of 5)
+        for i in range(6):
+            resp = await client.post(
+                "/api/v1/auth/login",
+                json={"email": "admin@alpha.test", "password": f"Wrong{i}!"},
+            )
+            assert resp.status_code == 401
+
+        # 7th attempt: rate-limited, returns 401 (not 429)
+        resp = await client.post(
+            "/api/v1/auth/login",
+            json={"email": "admin@alpha.test", "password": "WrongFinal!"},
+        )
+        assert resp.status_code == 401
+        # Message should be generic, not revealing rate limit
+        assert "rate" not in resp.json()["detail"].lower()
+        assert "429" not in resp.json()["detail"]
+
+    async def test_login_success_resets_rate_limit(self, client: AsyncClient, seed_data):
+        """Successful login resets the rate limit counter."""
+        # Build up failures (4, below threshold)
+        for i in range(4):
+            resp = await client.post(
+                "/api/v1/auth/login",
+                json={"email": "admin@alpha.test", "password": f"Wrong{i}!"},
+            )
+            assert resp.status_code == 401
+
+        # Successful login
+        resp = await client.post(
+            "/api/v1/auth/login",
+            json={"email": "admin@alpha.test", "password": "AdminAlpha123!"},
+        )
+        assert resp.status_code == 200
+
+        # Should be able to fail 5 more times before lockout
+        for i in range(5):
+            resp = await client.post(
+                "/api/v1/auth/login",
+                json={"email": "admin@alpha.test", "password": f"Wrong{i}!"},
+            )
+            assert resp.status_code == 401
+
+        # 6th failure: now locked
+        resp = await client.post(
+            "/api/v1/auth/login",
+            json={"email": "admin@alpha.test", "password": "WrongFinal!"},
+        )
+        assert resp.status_code == 401  # locked
+
+    async def test_different_emails_independent_rate_limits(self, client: AsyncClient, seed_data):
+        """Rate limits are per-email AND per-IP (dual key).
+        
+        Note: In tests, all requests come from 127.0.0.1, so the IP gets locked
+        after 6 total failures regardless of email. In production with different
+        IPs, emails would be independent.
+        """
+        # Lock admin@alpha.test (6 failures from same IP)
+        for i in range(6):
+            await client.post(
+                "/api/v1/auth/login",
+                json={"email": "admin@alpha.test", "password": f"Wrong{i}!"},
+            )
+
+        # IP is now locked, so analyst@alpha.test also gets blocked
+        resp = await client.post(
+            "/api/v1/auth/login",
+            json={"email": "analyst@alpha.test", "password": "AnalystAlpha123!"},
+        )
+        # IP lockout affects all emails from that IP
+        assert resp.status_code == 401
+
+    async def test_rate_limit_message_matches_enum_resistance(self, client: AsyncClient, seed_data):
+        """Rate-limited response is indistinguishable from wrong password."""
+        # Wrong password (no lockout)
+        resp_wrong = await client.post(
+            "/api/v1/auth/login",
+            json={"email": "viewer@alpha.test", "password": "Wrong!"},
+        )
+        assert resp_wrong.status_code == 401
+
+        # Trigger lockout
+        for i in range(5):
+            await client.post(
+                "/api/v1/auth/login",
+                json={"email": "viewer@alpha.test", "password": f"Wrong{i}!"},
+            )
+
+        # Rate-limited
+        resp_limited = await client.post(
+            "/api/v1/auth/login",
+            json={"email": "viewer@alpha.test", "password": "WrongFinal!"},
+        )
+        assert resp_limited.status_code == 401
+
+        # Messages should be identical
+        assert resp_wrong.json()["detail"] == resp_limited.json()["detail"]

--- a/tests/integration/test_security_headers_integration.py
+++ b/tests/integration/test_security_headers_integration.py
@@ -31,3 +31,44 @@ class TestSecurityHeadersIntegration:
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             resp = await client.get("/api/docs")
         assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_middleware_stack_order_security_headers_applied(self):
+        """All security headers should be present on any endpoint."""
+        app = create_app()
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get("/health")
+        
+        # All security headers should be present
+        assert resp.headers.get("x-content-type-options") == "nosniff"
+        assert resp.headers.get("x-frame-options") == "DENY"
+        assert resp.headers.get("content-security-policy") == "default-src 'self'"
+        
+        # CORS headers should be present (from CORSMiddleware)
+        # Note: CORS headers only appear on cross-origin requests or preflight
+
+    @pytest.mark.asyncio
+    async def test_security_headers_on_auth_endpoints(self):
+        """Security headers should be present on auth endpoints too."""
+        app = create_app()
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                "/api/v1/auth/login",
+                json={"email": "test@test.com", "password": "wrong"},
+            )
+        
+        # Security headers should be present even on 401 responses
+        assert resp.headers.get("x-content-type-options") == "nosniff"
+        assert resp.headers.get("x-frame-options") == "DENY"
+        assert resp.headers.get("content-security-policy") == "default-src 'self'"
+
+    @pytest.mark.asyncio
+    async def test_security_headers_on_404(self):
+        """Security headers should be present on 404 responses."""
+        app = create_app()
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get("/nonexistent")
+        
+        assert resp.status_code == 404
+        assert resp.headers.get("x-content-type-options") == "nosniff"
+        assert resp.headers.get("x-frame-options") == "DENY"

--- a/tests/integration/test_seed_script.py
+++ b/tests/integration/test_seed_script.py
@@ -1,0 +1,190 @@
+"""Tests for scripts/seed_db.py — seed script validation and idempotency.
+
+Tests the seed script components without actually running the full script
+against a database (which would be slow and require specific env vars).
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+
+# Default env vars needed to import seed_db without SystemExit
+_DEFAULT_SEED_ENV = {
+    "SEED_SUPERADMIN_PASSWORD": "TestSuper123!",
+    "SEED_ADMIN_PASSWORD": "TestAdmin123!",
+    "SEED_ANALYST_PASSWORD": "TestAnalyst123!",
+    "SEED_VIEWER_PASSWORD": "TestViewer123!",
+}
+
+
+class TestSeedPasswordValidation:
+    """Test _validate_seed_passwords() function."""
+
+    def test_validates_all_required_env_vars(self):
+        """Should raise SystemExit when required env vars are missing."""
+        # We need to import the function without triggering module-level code
+        # Use importlib with patched env vars to get the module loaded first
+        with patch.dict(os.environ, _DEFAULT_SEED_ENV, clear=False):
+            import scripts.seed_db as seed_mod
+            func = seed_mod._validate_seed_passwords
+        
+        # Now test with missing vars
+        env_vars = [
+            "SEED_SUPERADMIN_PASSWORD",
+            "SEED_ADMIN_PASSWORD",
+            "SEED_ANALYST_PASSWORD",
+            "SEED_VIEWER_PASSWORD",
+        ]
+        with patch.dict(os.environ, {k: "" for k in env_vars}, clear=False):
+            for var in env_vars:
+                os.environ.pop(var, None)
+            
+            with pytest.raises(SystemExit) as exc_info:
+                func()
+            assert exc_info.value.code == 1
+
+    def test_passes_when_all_env_vars_set(self):
+        """Should not raise when all required env vars are set."""
+        with patch.dict(os.environ, _DEFAULT_SEED_ENV, clear=False):
+            import scripts.seed_db as seed_mod
+            func = seed_mod._validate_seed_passwords
+        
+        # Should not raise with all vars set
+        with patch.dict(os.environ, _DEFAULT_SEED_ENV, clear=False):
+            func()
+
+
+class TestSeedDataBuilder:
+    """Test _build_seed_data() function."""
+
+    def test_returns_tenant_superadmin_and_users(self):
+        """Should return tenant, superadmin, and list of tenant users."""
+        with patch.dict(os.environ, _DEFAULT_SEED_ENV, clear=False):
+            import scripts.seed_db as seed_mod
+            tenant, superadmin, users = seed_mod._build_seed_data()
+        
+        # Tenant
+        assert tenant["slug"] == "acme-corp"
+        assert tenant["is_active"] is True
+        
+        # Superadmin
+        assert superadmin["email"] == "superadmin@soc360.local"
+        assert superadmin["role"] == "superadmin"
+        assert superadmin["is_superadmin"] is True
+        assert superadmin["tenant_id"] is None
+        
+        # Tenant users
+        assert len(users) == 3
+        roles = {u["role"] for u in users}
+        assert roles == {"admin", "analyst", "viewer"}
+
+    def test_passwords_are_hashed(self):
+        """Passwords should be bcrypt hashed, not plaintext."""
+        with patch.dict(os.environ, _DEFAULT_SEED_ENV, clear=False):
+            import scripts.seed_db as seed_mod
+            tenant, superadmin, users = seed_mod._build_seed_data()
+        
+        # Superadmin password should be hashed (starts with $2b$)
+        assert superadmin["hashed_password"].startswith("$2b$")
+        assert superadmin["hashed_password"] != "SuperAdmin123!"
+        
+        # All user passwords should be hashed
+        for user in users:
+            assert user["hashed_password"].startswith("$2b$")
+
+    def test_uuids_are_deterministic(self):
+        """Seed UUIDs should be fixed for test reproducibility."""
+        with patch.dict(os.environ, _DEFAULT_SEED_ENV, clear=False):
+            import scripts.seed_db as seed_mod
+        
+        # Should be valid UUIDs
+        assert isinstance(seed_mod.SEED_TENANT_ID, uuid.UUID)
+        assert isinstance(seed_mod.SEED_SUPERADMIN_ID, uuid.UUID)
+        assert isinstance(seed_mod.SEED_ADMIN_ID, uuid.UUID)
+        assert isinstance(seed_mod.SEED_ANALYST_ID, uuid.UUID)
+        assert isinstance(seed_mod.SEED_VIEWER_ID, uuid.UUID)
+        
+        # Should be deterministic (same value every run)
+        assert str(seed_mod.SEED_TENANT_ID) == "00000000-0000-0000-0000-000000000001"
+        assert str(seed_mod.SEED_SUPERADMIN_ID) == "00000000-0000-0000-0000-000000000010"
+
+
+class TestSeedStats:
+    """Test SeedStats dataclass."""
+
+    def test_initial_state(self):
+        """Should start with zero counts."""
+        with patch.dict(os.environ, _DEFAULT_SEED_ENV, clear=False):
+            import scripts.seed_db as seed_mod
+        
+        stats = seed_mod.SeedStats()
+        assert stats.created == 0
+        assert stats.skipped == 0
+        assert stats.errors == 0
+        assert stats.details == []
+
+    def test_record_created(self):
+        """Should increment created count and add detail."""
+        with patch.dict(os.environ, _DEFAULT_SEED_ENV, clear=False):
+            import scripts.seed_db as seed_mod
+        
+        stats = seed_mod.SeedStats()
+        stats.record_created("Tenant 'acme'")
+        
+        assert stats.created == 1
+        assert stats.skipped == 0
+        assert stats.errors == 0
+        assert len(stats.details) == 1
+        assert "acme" in stats.details[0]
+
+    def test_record_skipped(self):
+        """Should increment skipped count."""
+        with patch.dict(os.environ, _DEFAULT_SEED_ENV, clear=False):
+            import scripts.seed_db as seed_mod
+        
+        stats = seed_mod.SeedStats()
+        stats.record_skipped("User 'admin@test.com'")
+        
+        assert stats.created == 0
+        assert stats.skipped == 1
+        assert len(stats.details) == 1
+
+    def test_record_error(self):
+        """Should increment error count and include reason."""
+        with patch.dict(os.environ, _DEFAULT_SEED_ENV, clear=False):
+            import scripts.seed_db as seed_mod
+        
+        stats = seed_mod.SeedStats()
+        stats.record_error("User 'bad@test.com'", "duplicate key")
+        
+        assert stats.created == 0
+        assert stats.skipped == 0
+        assert stats.errors == 1
+        assert "duplicate key" in stats.details[0]
+
+
+class TestEnvironmentGuard:
+    """Test that seed script blocks execution outside development."""
+
+    def test_blocks_in_production(self):
+        """Should raise SystemExit when ENVIRONMENT=production."""
+        with patch.dict(os.environ, _DEFAULT_SEED_ENV, clear=False):
+            import scripts.seed_db as seed_mod
+        
+        # The module-level guard checks settings.ENVIRONMENT
+        # We can test the logic by checking the allowed environments
+        assert "development" in seed_mod._ALLOWED_SEED_ENVIRONMENTS
+        assert "production" not in seed_mod._ALLOWED_SEED_ENVIRONMENTS
+        assert "staging" not in seed_mod._ALLOWED_SEED_ENVIRONMENTS
+
+    def test_allows_in_development(self):
+        """Should allow execution when ENVIRONMENT=development."""
+        with patch.dict(os.environ, _DEFAULT_SEED_ENV, clear=False):
+            import scripts.seed_db as seed_mod
+        
+        assert "development" in seed_mod._ALLOWED_SEED_ENVIRONMENTS


### PR DESCRIPTION
## Summary

Implements progressive lockout rate limiting for auth endpoints to prevent brute force attacks.

### Changes:
- **Rate limiting**: Dual-key (IP + email) with escalating timeouts (3min → 15min → 1h → 4h → 24h)
- **Enumeration resistance**: Login returns 401 (not 429) when rate-limited
- **Redis fail-open**: If Redis is down, auth works without rate limiting (availability over security)
- **Middleware stack tests**: Security headers on all endpoints
- **Seed script tests**: Validation, data builder, stats
- **Event bus E2E tests**: With real Redis (skipped locally, runs in CI)

### Files:
-  — RateLimiter service
-  — RATE_LIMIT_ENABLED, RATE_LIMIT_WINDOW_SECONDS settings
-  — Integrated rate limiting into login, refresh, logout, change-password
-  — 19 tests
-  — 5 tests
-  — 11 tests
-  — 6 tests (skip if no Redis)

### Test results:
- 58 passed, 6 skipped (Redis not available locally)
- All existing auth tests pass

Closes #178