### PR TITLE
refactor(core): split 3 god files into SRP-focused packages (#180)

### DIFF
--- a/app/core/llm/__init__.py
+++ b/app/core/llm/__init__.py
@@ -1,0 +1,29 @@
+"""LLM provider abstraction: factory, providers, and public API."""
+from __future__ import annotations
+
+from app.core.config import settings  # noqa: F401 — re-exported for test monkeypatch compat
+from app.core.llm.config import (  # noqa: F401
+    LLM_RETRY_BACKOFF_BASE_SECONDS,
+    LLM_RETRY_MAX_ATTEMPTS,
+    LLM_RETRYABLE_STATUS_CODES,
+    _API_KEY_PATTERN,
+    _llm_logger,
+    _redact_credentials,
+)
+from app.core.llm.factory import (  # noqa: F401
+    ProviderEntry,
+    _PROVIDER_REGISTRY,
+    _create_provider,
+    _llm_singletons,
+    _register_providers,
+    get_llm_provider,
+)
+from app.core.llm.providers import (  # noqa: F401
+    AnthropicProvider,
+    GeminiProvider,
+    LLMProvider,
+    MockLLMProvider,
+    OpenAICompatProvider,
+    _BaseHTTPProvider,
+    llm_safe_complete,
+)

--- a/app/core/llm/config.py
+++ b/app/core/llm/config.py
@@ -1,0 +1,32 @@
+"""LLM configuration constants and credential redaction."""
+from __future__ import annotations
+
+import re
+
+from app.core.logging import get_logger
+
+_llm_logger = get_logger("app.core.llm")
+
+_API_KEY_PATTERN = re.compile(
+    r"(sk-|gsk_|api_|token_|bearer_)([a-zA-Z0-9_\-]{8,})",
+    re.IGNORECASE,
+)
+
+
+def _redact_credentials(text: str) -> str:
+    """Replace any API-key-like substrings with [REDACTED].
+
+    Covers patterns like sk-..., gsk_..., api_key values in URLs, and Bearer tokens.
+    """
+    # Redact URL query params that contain 'api_key', 'key', 'token'
+    text = re.sub(r"([?&](?:api_?key|key|token|bearer)=)([^&\s]+)", r"\1[REDACTED]", text)
+    # Redact Bearer token values in Authorization headers
+    text = re.sub(r"(Bearer )([a-zA-Z0-9_\-]{8,})", r"\1[REDACTED]", text)
+    # Redact common API key prefixes with their values
+    text = _API_KEY_PATTERN.sub(r"\1[REDACTED]", text)
+    return text
+
+
+LLM_RETRY_MAX_ATTEMPTS: int = 3
+LLM_RETRY_BACKOFF_BASE_SECONDS: float = 1.0
+LLM_RETRYABLE_STATUS_CODES: frozenset[int] = frozenset({429, 500, 502, 503, 504})

--- a/app/core/llm/factory.py
+++ b/app/core/llm/factory.py
@@ -1,0 +1,199 @@
+"""LLM provider factory: registry, instantiation, and singleton cache."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+from app.core._provider_names import _PROVIDER_NAMES
+from app.core.config import settings
+from app.core.exceptions import LLMResponseError
+from app.core.llm.config import _llm_logger
+from app.core.llm.providers import (
+    AnthropicProvider,
+    GeminiProvider,
+    OpenAICompatProvider,
+)
+
+# Singleton cache: one provider instance per provider name, per process.
+_llm_singletons: dict[str, "LLMProvider"] = {}
+
+_PROVIDER_REGISTRY: dict[str, "ProviderEntry"] = {}
+# filled by _register_providers() on first _create_provider call
+
+
+@dataclass(slots=True, frozen=True)
+class ProviderEntry:
+    """Single source of truth for one LLM provider's configuration."""
+
+    cls: type
+    api_key_attr: str | None
+    model_default: str
+    base_url_attr: str | None
+    base_url_default: str | None
+    url_normalizer: Callable[[str], str] | None
+
+
+def _register_providers() -> None:
+    """Build the provider registry with all 9 supported providers.
+
+    Called lazily on first ``_create_provider()`` invocation.
+    Includes a drift assertion that catches mismatches between
+    ``_PROVIDER_NAMES`` (in ``_provider_names.py``) and the
+    registry keys at import time.
+    """
+    if _PROVIDER_REGISTRY:
+        return
+
+    _PROVIDER_REGISTRY.update({
+        "groq": ProviderEntry(
+            cls=OpenAICompatProvider, api_key_attr="GROQ_API_KEY",
+            model_default="llama-3.3-70b-versatile",
+            base_url_attr=None, base_url_default="https://api.groq.com/v1",
+            url_normalizer=None,
+        ),
+        "ollama": ProviderEntry(
+            cls=OpenAICompatProvider, api_key_attr=None,
+            model_default="llama3.2",
+            base_url_attr="OLLAMA_URL", base_url_default="http://localhost:11434",
+            url_normalizer=OpenAICompatProvider._normalize_ollama_url,
+        ),
+        "openai": ProviderEntry(
+            cls=OpenAICompatProvider, api_key_attr="OPENAI_API_KEY",
+            model_default="gpt-4o",
+            base_url_attr=None, base_url_default="https://api.openai.com/v1",
+            url_normalizer=None,
+        ),
+        "anthropic": ProviderEntry(
+            cls=AnthropicProvider, api_key_attr="ANTHROPIC_API_KEY",
+            model_default="claude-3-5-haiku-20241107",
+            base_url_attr="ANTHROPIC_BASE_URL", base_url_default=None,
+            url_normalizer=None,
+        ),
+        "gemini": ProviderEntry(
+            cls=GeminiProvider, api_key_attr="GEMINI_API_KEY",
+            model_default="gemini-2.0-flash",
+            base_url_attr="GEMINI_BASE_URL", base_url_default=None,
+            url_normalizer=None,
+        ),
+        "mistral": ProviderEntry(
+            cls=OpenAICompatProvider, api_key_attr="MISTRAL_API_KEY",
+            model_default="mistral-large-latest",
+            base_url_attr=None, base_url_default="https://api.mistral.ai/v1",
+            url_normalizer=None,
+        ),
+        "cohere": ProviderEntry(
+            cls=OpenAICompatProvider, api_key_attr="COHERE_API_KEY",
+            model_default="command-r-plus",
+            base_url_attr=None, base_url_default="https://api.cohere.ai/v1",
+            url_normalizer=None,
+        ),
+        "together": ProviderEntry(
+            cls=OpenAICompatProvider, api_key_attr="TOGETHER_API_KEY",
+            model_default="mistralai/Mistral-7B-Instruct-v0.3",
+            base_url_attr=None, base_url_default="https://api.together.xyz/v1",
+            url_normalizer=None,
+        ),
+        "huggingface": ProviderEntry(
+            cls=OpenAICompatProvider, api_key_attr="HUGGINGFACE_API_KEY",
+            model_default="meta-llama/Llama-3.3-70B-Instruct",
+            base_url_attr=None, base_url_default="https://api-inference.huggingface.co/v1",
+            url_normalizer=None,
+        ),
+    })
+
+    # Runtime assertion: catch drift between _provider_names.py and registry.
+    # If a developer adds a ProviderEntry but forgets to update _PROVIDER_NAMES,
+    # the validator rejects a valid provider — this assertion catches the mismatch
+    # at import time.
+    assert set(_PROVIDER_REGISTRY.keys()) == _PROVIDER_NAMES, (
+        f"Provider registry and _PROVIDER_NAMES are out of sync. "
+        f"Registry: {sorted(_PROVIDER_REGISTRY.keys())}. "
+        f"_PROVIDER_NAMES: {sorted(_PROVIDER_NAMES)}. "
+        f"Update app/core/_provider_names.py to match."
+    )
+
+
+def _create_provider(provider_name: str) -> "LLMProvider":
+    """Create a new (uncached) provider instance for the given provider name.
+
+    Generic resolver — zero ``if/elif`` on provider name. All per-provider
+    configuration lives in ``ProviderEntry`` inside ``_PROVIDER_REGISTRY``.
+
+    Raises
+    ------
+    LLMResponseError
+        If the provider name is empty, unknown, or required configuration
+        (model, API key) is missing.
+    """
+    # Normalize
+    name = provider_name.strip().lower()
+    if not name:
+        raise LLMResponseError("LLM provider name must not be empty")
+
+    if not _PROVIDER_REGISTRY:
+        _register_providers()
+
+    entry = _PROVIDER_REGISTRY.get(name)
+    if entry is None:
+        raise LLMResponseError(
+            f"Unknown LLM provider: {name!r}. "
+            f"Supported: {sorted(_PROVIDER_REGISTRY)}"
+        )
+
+    # Model: convention {NAME}_MODEL, with explicit None vs empty-string handling.
+    # None  → use entry.model_default (env var not set at all)
+    # ""    → raise LLMResponseError  (env var explicitly set to empty)
+    # value → use it as-is
+    model = getattr(settings, f"{name.upper()}_MODEL", None)
+    if model is None:
+        model = entry.model_default
+    if not model:
+        raise LLMResponseError(f"Model not configured for provider {name!r}")
+
+    # API key: None attr = skip (ollama); None value = use "" (backcompat);
+    # explicitly empty string = error (spec R06b)
+    if entry.api_key_attr is not None:
+        api_key = getattr(settings, entry.api_key_attr, None)
+        if api_key is not None and not api_key:
+            raise LLMResponseError(
+                f"API key is required for provider {name!r} "
+                f"but {entry.api_key_attr} is empty"
+            )
+        if api_key is None:
+            api_key = ""
+    else:
+        api_key = ""
+
+    # Base URL: attr → Settings, else hardcoded; then normalizer
+    base_url: str | None = None
+    if entry.base_url_attr is not None:
+        base_url = getattr(settings, entry.base_url_attr, None) or entry.base_url_default
+    elif entry.base_url_default is not None:
+        base_url = entry.base_url_default
+
+    if base_url is not None and entry.url_normalizer is not None:
+        base_url = entry.url_normalizer(base_url)
+
+    kwargs: dict[str, object] = dict(
+        api_key=api_key,
+        model=model,
+        timeout=settings.LLM_TIMEOUT,
+    )
+    if base_url is not None:
+        kwargs["base_url"] = base_url
+
+    return entry.cls(**kwargs)  # type: ignore[arg-type]
+
+
+def get_llm_provider() -> "LLMProvider":
+    """Return the singleton LLM provider for the configured provider name.
+
+    This is the FastAPI dependency entrypoint. The first call instantiates
+    the provider; subsequent calls return the cached instance.
+    """
+    provider_name = settings.LLM_PROVIDER
+
+    if provider_name not in _llm_singletons:
+        _llm_singletons[provider_name] = _create_provider(provider_name)
+
+    return _llm_singletons[provider_name]

--- a/app/core/llm/providers.py
+++ b/app/core/llm/providers.py
@@ -1,15 +1,18 @@
+"""LLM provider classes: protocol, base HTTP, concrete providers, and test double."""
 from __future__ import annotations
 
 import asyncio
-import re
-from dataclasses import dataclass
-from typing import Callable, ClassVar, Protocol, runtime_checkable
+from typing import ClassVar, Protocol, runtime_checkable
 
 import httpx
 
-from app.core._provider_names import _PROVIDER_NAMES
-from app.core.config import settings
-from app.core.logging import get_logger
+from app.core.llm.config import (
+    LLM_RETRY_BACKOFF_BASE_SECONDS,
+    LLM_RETRY_MAX_ATTEMPTS,
+    LLM_RETRYABLE_STATUS_CODES,
+    _llm_logger,
+    _redact_credentials,
+)
 from app.core.exceptions import (
     LLMContentFilterError,
     LLMError,
@@ -17,222 +20,6 @@ from app.core.exceptions import (
     LLMResponseError,
     LLMTimeoutError,
 )
-
-# Module-level logger for the LLM layer.
-# Uses the shared project logger so redaction stays consistent everywhere.
-_llm_logger = get_logger("app.core.llm")
-
-# Compiled pattern to detect common API key formats in strings.
-_API_KEY_PATTERN = re.compile(
-    r"(sk-|gsk_|api_|token_|bearer_)([a-zA-Z0-9_\-]{8,})",
-    re.IGNORECASE,
-)
-
-
-def _redact_credentials(text: str) -> str:
-    """Replace any API-key-like substrings with [REDACTED].
-
-    Covers patterns like sk-..., gsk_..., api_key values in URLs, and Bearer tokens.
-    """
-    # Redact URL query params that contain 'api_key', 'key', 'token'
-    text = re.sub(r"([?&](?:api_?key|key|token|bearer)=)([^&\s]+)", r"\1[REDACTED]", text)
-    # Redact Bearer token values in Authorization headers
-    text = re.sub(r"(Bearer )([a-zA-Z0-9_\-]{8,})", r"\1[REDACTED]", text)
-    # Redact common API key prefixes with their values
-    text = _API_KEY_PATTERN.sub(r"\1[REDACTED]", text)
-    return text
-
-
-# Retry configuration for transient LLM errors (issue #137).
-# 429 (rate limit) and 5xx (server errors) are retried with exponential backoff.
-# 4xx (except 429) are NOT retried — they are client errors.
-LLM_RETRY_MAX_ATTEMPTS: int = 3
-LLM_RETRY_BACKOFF_BASE_SECONDS: float = 1.0
-LLM_RETRYABLE_STATUS_CODES: frozenset[int] = frozenset({429, 500, 502, 503, 504})
-
-# Singleton cache: one provider instance per provider name, per process.
-_llm_singletons: dict[str, "LLMProvider"] = {}
-
-_PROVIDER_REGISTRY: dict[str, "ProviderEntry"] = {}
-# filled by _register_providers() on first _create_provider call
-
-
-@dataclass(slots=True, frozen=True)
-class ProviderEntry:
-    """Single source of truth for one LLM provider's configuration."""
-
-    cls: type
-    api_key_attr: str | None
-    model_default: str
-    base_url_attr: str | None
-    base_url_default: str | None
-    url_normalizer: Callable[[str], str] | None
-
-
-def _register_providers() -> None:
-    """Build the provider registry with all 9 supported providers.
-
-    Called lazily on first ``_create_provider()`` invocation.
-    Includes a drift assertion that catches mismatches between
-    ``_PROVIDER_NAMES`` (in ``_provider_names.py``) and the
-    registry keys at import time.
-    """
-    if _PROVIDER_REGISTRY:
-        return
-
-    _PROVIDER_REGISTRY.update({
-        "groq": ProviderEntry(
-            cls=OpenAICompatProvider, api_key_attr="GROQ_API_KEY",
-            model_default="llama-3.3-70b-versatile",
-            base_url_attr=None, base_url_default="https://api.groq.com/v1",
-            url_normalizer=None,
-        ),
-        "ollama": ProviderEntry(
-            cls=OpenAICompatProvider, api_key_attr=None,
-            model_default="llama3.2",
-            base_url_attr="OLLAMA_URL", base_url_default="http://localhost:11434",
-            url_normalizer=OpenAICompatProvider._normalize_ollama_url,
-        ),
-        "openai": ProviderEntry(
-            cls=OpenAICompatProvider, api_key_attr="OPENAI_API_KEY",
-            model_default="gpt-4o",
-            base_url_attr=None, base_url_default="https://api.openai.com/v1",
-            url_normalizer=None,
-        ),
-        "anthropic": ProviderEntry(
-            cls=AnthropicProvider, api_key_attr="ANTHROPIC_API_KEY",
-            model_default="claude-3-5-haiku-20241107",
-            base_url_attr="ANTHROPIC_BASE_URL", base_url_default=None,
-            url_normalizer=None,
-        ),
-        "gemini": ProviderEntry(
-            cls=GeminiProvider, api_key_attr="GEMINI_API_KEY",
-            model_default="gemini-2.0-flash",
-            base_url_attr="GEMINI_BASE_URL", base_url_default=None,
-            url_normalizer=None,
-        ),
-        "mistral": ProviderEntry(
-            cls=OpenAICompatProvider, api_key_attr="MISTRAL_API_KEY",
-            model_default="mistral-large-latest",
-            base_url_attr=None, base_url_default="https://api.mistral.ai/v1",
-            url_normalizer=None,
-        ),
-        "cohere": ProviderEntry(
-            cls=OpenAICompatProvider, api_key_attr="COHERE_API_KEY",
-            model_default="command-r-plus",
-            base_url_attr=None, base_url_default="https://api.cohere.ai/v1",
-            url_normalizer=None,
-        ),
-        "together": ProviderEntry(
-            cls=OpenAICompatProvider, api_key_attr="TOGETHER_API_KEY",
-            model_default="mistralai/Mistral-7B-Instruct-v0.3",
-            base_url_attr=None, base_url_default="https://api.together.xyz/v1",
-            url_normalizer=None,
-        ),
-        "huggingface": ProviderEntry(
-            cls=OpenAICompatProvider, api_key_attr="HUGGINGFACE_API_KEY",
-            model_default="meta-llama/Llama-3.3-70B-Instruct",
-            base_url_attr=None, base_url_default="https://api-inference.huggingface.co/v1",
-            url_normalizer=None,
-        ),
-    })
-
-    # Runtime assertion: catch drift between _provider_names.py and registry.
-    # If a developer adds a ProviderEntry but forgets to update _PROVIDER_NAMES,
-    # the validator rejects a valid provider — this assertion catches the mismatch
-    # at import time.
-    assert set(_PROVIDER_REGISTRY.keys()) == _PROVIDER_NAMES, (
-        f"Provider registry and _PROVIDER_NAMES are out of sync. "
-        f"Registry: {sorted(_PROVIDER_REGISTRY.keys())}. "
-        f"_PROVIDER_NAMES: {sorted(_PROVIDER_NAMES)}. "
-        f"Update app/core/_provider_names.py to match."
-    )
-
-
-def _create_provider(provider_name: str) -> "LLMProvider":
-    """Create a new (uncached) provider instance for the given provider name.
-
-    Generic resolver — zero ``if/elif`` on provider name. All per-provider
-    configuration lives in ``ProviderEntry`` inside ``_PROVIDER_REGISTRY``.
-
-    Raises
-    ------
-    LLMResponseError
-        If the provider name is empty, unknown, or required configuration
-        (model, API key) is missing.
-    """
-    # Normalize
-    name = provider_name.strip().lower()
-    if not name:
-        raise LLMResponseError("LLM provider name must not be empty")
-
-    if not _PROVIDER_REGISTRY:
-        _register_providers()
-
-    entry = _PROVIDER_REGISTRY.get(name)
-    if entry is None:
-        raise LLMResponseError(
-            f"Unknown LLM provider: {name!r}. "
-            f"Supported: {sorted(_PROVIDER_REGISTRY)}"
-        )
-
-    # Model: convention {NAME}_MODEL, with explicit None vs empty-string handling.
-    # None  → use entry.model_default (env var not set at all)
-    # ""    → raise LLMResponseError  (env var explicitly set to empty)
-    # value → use it as-is
-    model = getattr(settings, f"{name.upper()}_MODEL", None)
-    if model is None:
-        model = entry.model_default
-    if not model:
-        raise LLMResponseError(f"Model not configured for provider {name!r}")
-
-    # API key: None attr = skip (ollama); None value = use "" (backcompat);
-    # explicitly empty string = error (spec R06b)
-    if entry.api_key_attr is not None:
-        api_key = getattr(settings, entry.api_key_attr, None)
-        if api_key is not None and not api_key:
-            raise LLMResponseError(
-                f"API key is required for provider {name!r} "
-                f"but {entry.api_key_attr} is empty"
-            )
-        if api_key is None:
-            api_key = ""
-    else:
-        api_key = ""
-
-    # Base URL: attr → Settings, else hardcoded; then normalizer
-    base_url: str | None = None
-    if entry.base_url_attr is not None:
-        base_url = getattr(settings, entry.base_url_attr, None) or entry.base_url_default
-    elif entry.base_url_default is not None:
-        base_url = entry.base_url_default
-
-    if base_url is not None and entry.url_normalizer is not None:
-        base_url = entry.url_normalizer(base_url)
-
-    kwargs: dict[str, object] = dict(
-        api_key=api_key,
-        model=model,
-        timeout=settings.LLM_TIMEOUT,
-    )
-    if base_url is not None:
-        kwargs["base_url"] = base_url
-
-    return entry.cls(**kwargs)  # type: ignore[arg-type]
-
-
-def get_llm_provider() -> "LLMProvider":
-    """Return the singleton LLM provider for the configured provider name.
-
-    This is the FastAPI dependency entrypoint. The first call instantiates
-    the provider; subsequent calls return the cached instance.
-    """
-    provider_name = settings.LLM_PROVIDER
-
-    if provider_name not in _llm_singletons:
-        _llm_singletons[provider_name] = _create_provider(provider_name)
-
-    return _llm_singletons[provider_name]
 
 
 @runtime_checkable
@@ -612,7 +399,6 @@ class MockLLMProvider:
     ) -> str:
         """Return the configured response text after the configured delay."""
         if self._delay_seconds > 0:
-            import asyncio
             await asyncio.sleep(self._delay_seconds)
         return self._response_text
 

--- a/app/dependencies/__init__.py
+++ b/app/dependencies/__init__.py
@@ -1,0 +1,53 @@
+"""FastAPI dependency injection hub.
+
+Re-exports all dependency functions and type aliases for the application.
+"""
+from __future__ import annotations
+
+from typing import Annotated, TypeAlias
+
+from fastapi import Depends
+from redis.asyncio import Redis
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_db  # noqa: F401 — re-exported
+from app.core.redis import get_redis  # noqa: F401 — re-exported
+from app.dependencies.auth import (  # noqa: F401
+    get_current_user,
+    oauth2_scheme,
+    require_role,
+    require_superadmin,
+)
+from app.dependencies.cross_tenant import (  # noqa: F401
+    _get_tenant_for_admin,
+    _get_user_for_admin,
+    _log_cross_tenant_attempt,
+    _tenant_for_admin,
+    _user_for_admin,
+    get_tenant_for_admin_get,
+    get_user_for_admin_delete,
+    get_user_for_admin_get,
+    get_user_for_admin_patch,
+)
+from app.dependencies.db_deps import get_db_with_tenant  # noqa: F401
+from app.dependencies.event_deps import (  # noqa: F401
+    _event_bus,
+    get_event_bus,
+)
+from app.dependencies.llm_deps import get_llm  # noqa: F401
+from app.modules.tenants.models import Tenant
+from app.modules.users.models import User
+
+# ---------------------------------------------------------------------------
+# FastAPI dependency type aliases — modern Annotated pattern
+# ---------------------------------------------------------------------------
+DBDep: TypeAlias = Annotated[AsyncSession, Depends(get_db)]
+RedisDep: TypeAlias = Annotated[Redis, Depends(get_redis)]
+CurrentUserDep: TypeAlias = Annotated[User, Depends(get_current_user)]
+SuperadminDep: TypeAlias = Annotated[User, Depends(require_superadmin)]
+AdminDep: TypeAlias = Annotated[User, Depends(require_role("admin"))]
+DBWithTenantDep: TypeAlias = Annotated[AsyncSession, Depends(get_db_with_tenant)]
+UserForAdminGetDep: TypeAlias = Annotated[User, Depends(get_user_for_admin_get)]
+UserForAdminPatchDep: TypeAlias = Annotated[User, Depends(get_user_for_admin_patch)]
+UserForAdminDeleteDep: TypeAlias = Annotated[User, Depends(get_user_for_admin_delete)]
+TenantForAdminGetDep: TypeAlias = Annotated[Tenant, Depends(get_tenant_for_admin_get)]

--- a/app/dependencies/auth.py
+++ b/app/dependencies/auth.py
@@ -1,0 +1,157 @@
+"""Authentication dependencies: OAuth2 scheme, current user, role guards."""
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from jwt import InvalidTokenError
+from redis.asyncio import Redis
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_db, set_tenant_context
+from app.core.logging import get_logger
+from app.core.redis import check_redis_healthy, get_redis
+from app.core.security import decode_access_token, has_minimum_role, is_token_revoked
+from app.modules.tenants.models import Tenant
+from app.modules.users.models import User
+
+logger = get_logger(__name__)
+
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/login")
+
+
+async def get_current_user(
+    token: str = Depends(oauth2_scheme),
+    db: AsyncSession = Depends(get_db),
+    redis: Redis = Depends(get_redis),
+) -> User:
+    try:
+        payload = decode_access_token(token)
+    except InvalidTokenError:
+        logger.warning("auth_failed", reason="invalid_token")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token invalido o expirado",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    user_id = payload.get("sub")
+
+    if not user_id:
+        logger.warning("auth_failed", reason="missing_sub")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token invalido o expirado",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    try:
+        user_uuid = UUID(user_id)
+    except ValueError:
+        logger.warning("auth_failed", reason="invalid_user_id", user_id=user_id)
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token invalido o expirado",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    jti = payload.get("jti")
+    if not await check_redis_healthy(redis):
+        logger.error("redis_unhealthy", reason="auth_dependency")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Servicio temporalmente no disponible",
+        )
+    if not jti or await is_token_revoked(jti, redis):
+        logger.warning("auth_failed", reason="revoked_token", jti=jti)
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token revocado",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    # Temporarily elevate to superadmin so RLS allows the user lookup.
+    # set_tenant_context will re-set the correct tenant context below.
+    # Single roundtrip combines both set_config calls.
+    await db.execute(
+        text(
+            "SELECT "
+            "set_config('app.is_superadmin', 'true', true), "
+            "set_config('app.current_tenant', '', true)"
+        )
+    )
+    result = await db.execute(
+        select(User, Tenant)
+        .outerjoin(Tenant, User.tenant_id == Tenant.id)
+        .where(User.id == user_uuid)
+    )
+    row = result.one_or_none()
+
+    if not row or not row.User.is_active:
+        logger.warning("auth_failed", reason="user_inactive", user_id=str(user_uuid))
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Usuario no encontrado o inactivo",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    user = row.User
+
+    if not user.is_superadmin:
+        if not row.Tenant or not row.Tenant.is_active:
+            logger.warning("auth_failed", reason="tenant_inactive", tenant_id=str(user.tenant_id))
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Tenant inactivo o no encontrado",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+    if user.is_superadmin:
+        await set_tenant_context(db, user.tenant_id, True)
+    elif user.tenant_id is None:
+        logger.warning("auth_failed", reason="missing_tenant_id", user_id=str(user_uuid))
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Usuario no encontrado o inactivo",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    else:
+        await set_tenant_context(db, user.tenant_id, False)
+
+    user.current_jti = jti
+    return user
+
+
+def require_role(minimum_role: str):
+    async def _check(
+        current_user: User = Depends(get_current_user),
+    ) -> User:
+        if not has_minimum_role(current_user.role, minimum_role):
+            logger.warning(
+                "auth_failed",
+                reason="insufficient_role",
+                user_id=str(current_user.id),
+                actual=current_user.role,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Permisos insuficientes"
+            )
+        return current_user
+    return _check
+
+
+async def require_superadmin(
+    current_user: User = Depends(get_current_user),
+) -> User:
+    """Permite el acceso solo a usuarios con is_superadmin=True"""
+    if not current_user.is_superadmin:
+        logger.warning(
+            "auth_failed",
+            reason="not_superadmin",
+            user_id=str(current_user.id),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Se requieren permisos de superadmin",
+        )
+    return current_user

--- a/app/dependencies/cross_tenant.py
+++ b/app/dependencies/cross_tenant.py
@@ -1,154 +1,25 @@
+"""Cross-tenant pre-check dependencies for admin endpoints (PR-A).
+
+The 403 contract: a non-superadmin caller attempting to access a user or
+tenant that belongs to a different tenant MUST receive HTTP 403 (not 404),
+with a single `cross_tenant_access_blocked` log line at the chokepoint.
+"""
 from __future__ import annotations
 
-from uuid import UUID
+import uuid
 
 from fastapi import Depends, HTTPException, status
-from fastapi.security import OAuth2PasswordBearer
-from jwt import InvalidTokenError
-from redis.asyncio import Redis
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
-from typing import Annotated, TypeAlias, AsyncGenerator
 
-from app.core.database import get_db, set_tenant_context
-from app.core.redis import get_redis, get_redis_client, check_redis_healthy
-from app.core.security import decode_access_token, is_token_revoked, has_minimum_role
-from app.core.llm import get_llm_provider, LLMProvider
-from app.modules.users.models import User
-from app.modules.tenants.models import Tenant
+from app.core.database import set_tenant_context
 from app.core.logging import get_logger
-import uuid
+from app.dependencies.auth import get_current_user
+from app.dependencies.db_deps import get_db_with_tenant
+from app.modules.tenants.models import Tenant
+from app.modules.users.models import User
+
 logger = get_logger(__name__)
-
-_event_bus: "EventBus | None" = None
-
-
-async def get_event_bus() -> "EventBus":
-    """Singleton factory for the EventBus dependency."""
-    global _event_bus
-    if _event_bus is None:
-        from app.event_bus import EventBus
-        redis = await get_redis_client()
-        _event_bus = EventBus(redis)
-    return _event_bus
-
-
-async def get_llm() -> LLMProvider:
-    """FastAPI dependency: return the singleton LLM provider for this request."""
-    return get_llm_provider()
-
-
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/login")
-
-
-async def get_current_user(
-    token: str = Depends(oauth2_scheme),
-    db: AsyncSession = Depends(get_db),
-    redis: Redis = Depends(get_redis),
-) -> User:
-    try:
-        payload = decode_access_token(token)
-    except InvalidTokenError:
-        logger.warning("auth_failed", reason="invalid_token")
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Token invalido o expirado",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
-
-    user_id = payload.get("sub")
-
-    if not user_id:
-        logger.warning("auth_failed", reason="missing_sub")
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Token invalido o expirado",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
-    try:
-        user_uuid = UUID(user_id)
-    except ValueError:
-        logger.warning("auth_failed", reason="invalid_user_id", user_id=user_id)
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Token invalido o expirado",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
-    jti = payload.get("jti")
-    if not await check_redis_healthy(redis):
-        logger.error("redis_unhealthy", reason="auth_dependency")
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Servicio temporalmente no disponible",
-        )
-    if not jti or await is_token_revoked(jti, redis):
-        logger.warning("auth_failed", reason="revoked_token", jti=jti)
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Token revocado",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
-    # Temporarily elevate to superadmin so RLS allows the user lookup.
-    # set_tenant_context will re-set the correct tenant context below.
-    # Single roundtrip combines both set_config calls.
-    await db.execute(
-        text(
-            "SELECT "
-            "set_config('app.is_superadmin', 'true', true), "
-            "set_config('app.current_tenant', '', true)"
-        )
-    )
-    result = await db.execute(
-        select(User, Tenant)
-        .outerjoin(Tenant, User.tenant_id == Tenant.id)
-        .where(User.id == user_uuid)
-    )
-    row = result.one_or_none()
-
-    if not row or not row.User.is_active:
-        logger.warning("auth_failed", reason="user_inactive", user_id=str(user_uuid))
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Usuario no encontrado o inactivo",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
-
-    user = row.User
-
-    if not user.is_superadmin:
-        if not row.Tenant or not row.Tenant.is_active:
-            logger.warning("auth_failed", reason="tenant_inactive", tenant_id=str(user.tenant_id))
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Tenant inactivo o no encontrado",
-                headers={"WWW-Authenticate": "Bearer"},
-            )
-    if user.is_superadmin:
-        await set_tenant_context(db, user.tenant_id, True)
-    elif user.tenant_id is None:
-        logger.warning("auth_failed", reason="missing_tenant_id", user_id=str(user_uuid))
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Usuario no encontrado o inactivo",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
-    else:
-        await set_tenant_context(db, user.tenant_id, False)
-
-    user.current_jti = jti
-    return user
-
-
-async def get_db_with_tenant(
-    current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
-) -> AsyncGenerator[AsyncSession, None]:
-    await set_tenant_context(
-        db=db,
-        tenant_id=current_user.tenant_id,
-        is_superadmin=current_user.is_superadmin,
-    )
-    yield db
 
 
 # ---------------------------------------------------------------------------
@@ -160,7 +31,7 @@ async def get_db_with_tenant(
 #
 # Implementation notes:
 # - The user Depends must ELEVATE the session to superadmin (SET LOCAL pair,
-#   same pattern as get_current_user:93-99) to read the cross-tenant row
+#   same pattern as get_current_user) to read the cross-tenant row
 #   for the tenant_id comparison. The SET LOCAL guarantee (third arg `true`)
 #   means the elevation is transaction-local and cannot leak across pooled
 #   connections — see `set_tenant_context` in app/core/database.py.
@@ -171,6 +42,7 @@ async def get_db_with_tenant(
 #   path: the comparison runs in Python on the URL id, before any SELECT
 #   (this is the inversion called out in the design, section 2).
 # ---------------------------------------------------------------------------
+
 
 def _log_cross_tenant_attempt(
     caller_id: uuid.UUID,
@@ -229,7 +101,7 @@ async def _get_user_for_admin(
 
     # Non-superadmin cross-tenant pre-check: elevate to read the row,
     # compare tenant_id, restore canonical context. Modeled on
-    # `get_current_user` SET LOCAL pair (lines 93-99 of this file).
+    # `get_current_user` SET LOCAL pair.
     await db.execute(
         text(
             "SELECT "
@@ -374,54 +246,3 @@ def _tenant_for_admin(method: str):
 # PATCH and DELETE on tenants remain superadmin-only and do not need the
 # cross-tenant pre-check (the superadmin branch already covers them).
 get_tenant_for_admin_get = _tenant_for_admin("GET")
-
-
-def require_role(minimum_role: str):
-    async def _check(
-        current_user: User = Depends(get_current_user),
-    ) -> User:
-        if not has_minimum_role(current_user.role, minimum_role):
-            logger.warning(
-                "auth_failed",
-                reason="insufficient_role",
-                user_id=str(current_user.id),
-                actual=current_user.role,
-            )
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Permisos insuficientes"
-            )
-        return current_user
-    return _check
-
-async def require_superadmin(
-    current_user: User = Depends(get_current_user),
-) -> User:
-    """Permite el acceso solo a usuarios con is_superadmin=True"""
-    if not current_user.is_superadmin:
-        logger.warning(
-            "auth_failed",
-            reason="not_superadmin",
-            user_id=str(current_user.id),
-        )
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Se requieren permisos de superadmin",
-        )
-    return current_user
-
-
-# ---------------------------------------------------------------------------
-# FastAPI dependency type aliases — modern Annotated pattern
-# Defined AFTER all dependency functions so they are in scope
-# ---------------------------------------------------------------------------
-DBDep: TypeAlias = Annotated[AsyncSession, Depends(get_db)]
-RedisDep: TypeAlias = Annotated[Redis, Depends(get_redis)]
-CurrentUserDep: TypeAlias = Annotated[User, Depends(get_current_user)]
-SuperadminDep: TypeAlias = Annotated[User, Depends(require_superadmin)]
-AdminDep: TypeAlias = Annotated[User, Depends(require_role("admin"))]
-DBWithTenantDep: TypeAlias = Annotated[AsyncSession, Depends(get_db_with_tenant)]
-UserForAdminGetDep: TypeAlias = Annotated[User, Depends(get_user_for_admin_get)]
-UserForAdminPatchDep: TypeAlias = Annotated[User, Depends(get_user_for_admin_patch)]
-UserForAdminDeleteDep: TypeAlias = Annotated[User, Depends(get_user_for_admin_delete)]
-TenantForAdminGetDep: TypeAlias = Annotated[Tenant, Depends(get_tenant_for_admin_get)]

--- a/app/dependencies/db_deps.py
+++ b/app/dependencies/db_deps.py
@@ -1,0 +1,23 @@
+"""Database session dependency with tenant context."""
+from __future__ import annotations
+
+from typing import AsyncGenerator
+
+from fastapi import Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_db, set_tenant_context
+from app.dependencies.auth import get_current_user
+from app.modules.users.models import User
+
+
+async def get_db_with_tenant(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> AsyncGenerator[AsyncSession, None]:
+    await set_tenant_context(
+        db=db,
+        tenant_id=current_user.tenant_id,
+        is_superadmin=current_user.is_superadmin,
+    )
+    yield db

--- a/app/dependencies/event_deps.py
+++ b/app/dependencies/event_deps.py
@@ -1,0 +1,18 @@
+"""Event bus dependency: singleton factory for EventBus."""
+from __future__ import annotations
+
+from app.core.redis import get_redis_client
+
+
+_event_bus: "EventBus | None" = None
+
+
+async def get_event_bus() -> "EventBus":
+    """Singleton factory for the EventBus dependency."""
+    global _event_bus
+    if _event_bus is None:
+        from app.event_bus import EventBus
+
+        redis = await get_redis_client()
+        _event_bus = EventBus(redis)
+    return _event_bus

--- a/app/dependencies/llm_deps.py
+++ b/app/dependencies/llm_deps.py
@@ -1,0 +1,9 @@
+"""LLM provider dependency: singleton factory."""
+from __future__ import annotations
+
+from app.core.llm import LLMProvider, get_llm_provider
+
+
+async def get_llm() -> LLMProvider:
+    """FastAPI dependency: return the singleton LLM provider for this request."""
+    return get_llm_provider()

--- a/app/event_bus/__init__.py
+++ b/app/event_bus/__init__.py
@@ -1,0 +1,20 @@
+"""Event bus abstraction for Redis Streams.
+
+Provides EventBus (publisher) and EventConsumer (consumer group) classes
+that wrap Redis Streams primitives with typed Pydantic event schemas.
+"""
+from __future__ import annotations
+
+from app.event_bus._helpers import (  # noqa: F401
+    _INFLIGHT_DLQ,
+    _RETRY_COUNT_KEY,
+    _RETRY_HASH_FIELD,
+    _retry_key,
+    drain_dlq_tasks,
+)
+from app.event_bus.bus import (  # noqa: F401
+    EventBus,
+)
+from app.event_bus.consumer import (  # noqa: F401
+    EventConsumer,
+)

--- a/app/event_bus/_helpers.py
+++ b/app/event_bus/_helpers.py
@@ -1,0 +1,50 @@
+"""Internal helpers for the event bus: retry tracking keys and DLQ drain."""
+from __future__ import annotations
+
+import asyncio
+
+from app.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+# Retry tracking key stored in event data
+_RETRY_COUNT_KEY = "_retry_count"
+
+
+# Field name used inside the per-message retry hash (issue #127).
+_RETRY_HASH_FIELD = "retry_count"
+
+
+def _retry_key(event_type: str, message_id: str) -> str:
+    """Build the per-message retry counter Redis key.
+
+    Event-type prefix avoids collisions if the same message_id is ever reused
+    across streams (e.g. stream MAXLEN trimming that produces a recycled id).
+    """
+    return f"event_retry:{event_type}:{message_id}"
+
+
+# Module-level registry of in-flight DLQ write tasks. Holding a strong
+# reference here is what prevents the GC from collecting the asyncio.Task
+# returned by `asyncio.ensure_future` before the underlying xadd coroutine
+# completes — see issue #126.
+_INFLIGHT_DLQ: set[asyncio.Task] = set()
+
+
+async def drain_dlq_tasks(timeout: float = 2.0) -> None:
+    """Wait for any in-flight DLQ write tasks to complete.
+
+    Called from the lifespan shutdown path so a fast app shutdown does not
+    lose the last DLQ entry. Uses a bounded timeout so a hung Redis write
+    cannot block the shutdown forever.
+    """
+    if not _INFLIGHT_DLQ:
+        return
+    try:
+        await asyncio.wait_for(
+            asyncio.gather(*list(_INFLIGHT_DLQ), return_exceptions=True),
+            timeout=timeout,
+        )
+    except asyncio.TimeoutError:
+        logger.error("dlq_drain_timeout", pending=len(_INFLIGHT_DLQ), timeout=timeout)

--- a/app/event_bus/bus.py
+++ b/app/event_bus/bus.py
@@ -1,60 +1,26 @@
-"""Event bus abstraction for Redis Streams.
+"""EventBus (publisher) class.
 
-Provides EventBus (publisher) and EventConsumer (consumer group) classes
-that wrap Redis Streams primitives with typed Pydantic event schemas.
+Wraps Redis Streams primitives with typed Pydantic event schemas.
 """
 from __future__ import annotations
 
 import asyncio
+
 from redis.asyncio import Redis
 
 from app.core.config import settings
 from app.core.logging import get_logger
+from app.event_bus._helpers import (
+    _INFLIGHT_DLQ,
+    _RETRY_COUNT_KEY,
+    _RETRY_HASH_FIELD,
+    _retry_key,
+    drain_dlq_tasks,
+)
+from app.event_bus.consumer import EventConsumer
 from app.event_schemas import BaseEvent
 
 logger = get_logger(__name__)
-
-
-# Retry tracking key stored in event data
-_RETRY_COUNT_KEY = "_retry_count"
-
-
-# Field name used inside the per-message retry hash (issue #127).
-_RETRY_HASH_FIELD = "retry_count"
-
-
-def _retry_key(event_type: str, message_id: str) -> str:
-    """Build the per-message retry counter Redis key.
-
-    Event-type prefix avoids collisions if the same message_id is ever reused
-    across streams (e.g. stream MAXLEN trimming that produces a recycled id).
-    """
-    return f"event_retry:{event_type}:{message_id}"
-
-
-# Module-level registry of in-flight DLQ write tasks. Holding a strong
-# reference here is what prevents the GC from collecting the asyncio.Task
-# returned by `asyncio.ensure_future` before the underlying xadd coroutine
-# completes — see issue #126.
-_INFLIGHT_DLQ: set[asyncio.Task] = set()
-
-
-async def drain_dlq_tasks(timeout: float = 2.0) -> None:
-    """Wait for any in-flight DLQ write tasks to complete.
-
-    Called from the lifespan shutdown path so a fast app shutdown does not
-    lose the last DLQ entry. Uses a bounded timeout so a hung Redis write
-    cannot block the shutdown forever.
-    """
-    if not _INFLIGHT_DLQ:
-        return
-    try:
-        await asyncio.wait_for(
-            asyncio.gather(*list(_INFLIGHT_DLQ), return_exceptions=True),
-            timeout=timeout,
-        )
-    except asyncio.TimeoutError:
-        logger.error("dlq_drain_timeout", pending=len(_INFLIGHT_DLQ), timeout=timeout)
 
 
 class EventBus:
@@ -172,7 +138,7 @@ class EventBus:
         use_persistent = bool(redis_client and message_id)
         if use_persistent:
             try:
-                persisted = await redis_client.hget(
+                persisted =                     await redis_client.hget(
                     _retry_key(event_type, message_id), _RETRY_HASH_FIELD
                 )
                 retry_count = int(persisted) if persisted is not None else 0
@@ -314,229 +280,3 @@ class EventBus:
             user_agent=user_agent_short,
             tenant_id=tenant_id,
         )
-
-
-class EventConsumer:
-    """Consumer abstraction over Redis Streams consumer groups.
-
-    Reads pending messages, acknowledges them, or deletes them from the stream.
-    """
-
-    def __init__(
-        self,
-        redis_client: Redis,
-        event_type: str,
-        consumer_name: str,
-        group_name: str,
-    ) -> None:
-        """Initialize a consumer.
-
-        Args:
-            redis_client: An async Redis client.
-            event_type: Event type this consumer processes, e.g. "auth.login".
-            consumer_name: Unique identifier for this consumer within the group.
-            group_name: Consumer group name, e.g. "soc360-consumers".
-        """
-        self.redis_client = redis_client
-        self.event_type = event_type
-        self.consumer_name = consumer_name
-        self.group_name = group_name
-
-    def _stream_key(self) -> str:
-        """Return the full stream key for this consumer's event type."""
-        return f"{settings.EVENT_STREAM_PREFIX}:{self.event_type}"
-
-    async def _ensure_group_exists(self) -> None:
-        """Create the consumer group with MKSTREAM if it doesn't exist.
-
-        This is safe to call on every read; Redis returns True if the group
-        was created, raises ResponseError if it already exists.
-        """
-        try:
-            await self.redis_client.xgroup_create(
-                self._stream_key(),
-                self.group_name,
-                "0",  # start reading from the beginning (or use "$" for new only)
-                mkstream=True,
-            )
-        except Exception:
-            # Group already exists — safe to ignore
-            pass
-
-    async def read_pending(self) -> list[dict]:
-        """Read pending messages for this consumer in this group.
-
-        Pending messages are those that have been delivered but not yet acknowledged.
-
-        Also monitors consumer lag: if pending count exceeds EVENT_PENDING_LAG_THRESHOLD,
-        logs a warning for operational visibility.
-
-        Returns:
-            List of dicts, each containing:
-              - "message_id": bytes
-              - "data": dict with event fields
-            Returns an empty list if no pending messages exist.
-        """
-        await self._ensure_group_exists()
-        stream_key = self._stream_key()
-
-        # Get detailed pending entries: XPENDING stream group [start end count consumer]
-        # Use "0" + "+" to get all pending entries
-        # Signature: xpending_range(stream, group, min_id, max_id, count)
-        pending_entries = await self.redis_client.xpending_range(
-            stream_key,
-            self.group_name,
-            "0",
-            "+",
-            100,
-        )
-
-        # Consumer lag monitoring: warn if pending entries exceed threshold
-        pending_count = len(pending_entries)
-        if pending_count > settings.EVENT_PENDING_LAG_THRESHOLD:
-            logger.warning(
-                "consumer_lag_exceeded_threshold",
-                event_type=self.event_type,
-                consumer_name=self.consumer_name,
-                pending_count=pending_count,
-                lag_threshold=settings.EVENT_PENDING_LAG_THRESHOLD,
-            )
-
-        if not pending_entries:
-            return []
-
-        # Batch XCLAIM: claim all pending messages in a single round-trip
-        # instead of O(n) individual XCLAIM calls (issue #100).
-        # This reduces Redis round-trips from N to 1 for N pending messages.
-        msg_ids = []
-        for entry in pending_entries:
-            msg_id = entry["message_id"]
-            msg_id_str = msg_id.decode() if isinstance(msg_id, bytes) else msg_id
-            msg_ids.append(msg_id_str)
-
-        result = []
-        try:
-            # Single XCLAIM call with all message_ids (batch operation)
-            claimed = await self.redis_client.xclaim(
-                stream_key,
-                self.group_name,
-                self.consumer_name,
-                min_idle_time=0,  # 0 means claim regardless of idle time
-                message_ids=msg_ids,
-            )
-            if claimed:
-                for cid, fields in claimed:
-                    str_fields = {
-                        k.decode() if isinstance(k, bytes) else k: v.decode() if isinstance(v, bytes) else v
-                        for k, v in fields.items()
-                    }
-                    result.append({
-                        "message_id": cid if isinstance(cid, bytes) else cid.encode(),
-                        "data": str_fields,
-                    })
-        except Exception:
-            # XCLAIM may fail if messages are already acked or deleted.
-            # Log for observability but don't crash — the consumer loop
-            # will retry on the next iteration.
-            logger.warning(
-                "batch_xclaim_failed",
-                event_type=self.event_type,
-                consumer_name=self.consumer_name,
-                message_count=len(msg_ids),
-            )
-        return result
-
-    async def read_new(self, block: int = 5000) -> list[dict]:
-        """Read new (undelivered) messages using XREADGROUP with blocking.
-
-        Uses XREADGROUP with '>' to read only new messages (never delivered
-        before to any consumer in the group). Blocks for up to `block`
-        milliseconds waiting for new messages, replacing the old busy-poll
-        pattern (issue #133).
-
-        Args:
-            block: Maximum milliseconds to block waiting for messages.
-                   Defaults to 5000 (5 seconds).
-
-        Returns:
-            List of dicts, each containing:
-              - "message_id": bytes
-              - "data": dict with event fields
-            Returns an empty list if no messages available within the timeout.
-        """
-        await self._ensure_group_exists()
-        stream_key = self._stream_key()
-
-        result = await self.redis_client.xreadgroup(
-            self.group_name,
-            self.consumer_name,
-            {stream_key: ">"},
-            count=10,
-            block=block,
-        )
-
-        if not result:
-            return []
-
-        messages: list[dict] = []
-        for _stream_name, stream_messages in result:
-            for msg_id, fields in stream_messages:
-                str_fields = {
-                    k.decode() if isinstance(k, bytes) else k:
-                    v.decode() if isinstance(v, bytes) else v
-                    for k, v in fields.items()
-                }
-                messages.append({
-                    "message_id": msg_id if isinstance(msg_id, bytes) else msg_id.encode(),
-                    "data": str_fields,
-                })
-        return messages
-
-    async def reconnect_and_resume(self) -> list[dict]:
-        """Reconnect to Redis and resume from last acknowledged position.
-
-        This handles temporary Redis connection drops by:
-        1. Re-calling _ensure_group_exists() to re-establish consumer group
-        2. Reading pending entries that may have been missed during disconnect
-
-        Returns:
-            List of pending messages that were unacknowledged during disconnect.
-        """
-        logger.info(
-            "consumer_reconnecting",
-            event_type=self.event_type,
-            consumer_name=self.consumer_name,
-        )
-        # Re-establish the consumer group (idempotent)
-        await self._ensure_group_exists()
-        # Read any pending messages that need processing
-        pending = await self.read_pending()
-        logger.info(
-            "consumer_resumed",
-            event_type=self.event_type,
-            consumer_name=self.consumer_name,
-            pending_count=len(pending),
-        )
-        return pending
-
-    async def ack(self, message_id: str | bytes) -> None:
-        """Acknowledge a message, removing it from the pending list.
-
-        Args:
-            message_id: The message ID to acknowledge (as returned by read_pending).
-        """
-        stream_key = self._stream_key()
-        if isinstance(message_id, str):
-            message_id = message_id.encode()
-        await self.redis_client.xack(stream_key, self.group_name, message_id)
-
-    async def delete(self, message_id: str | bytes) -> None:
-        """Delete a message from the stream entirely.
-
-        Args:
-            message_id: The message ID to delete.
-        """
-        stream_key = self._stream_key()
-        if isinstance(message_id, str):
-            message_id = message_id.encode()
-        await self.redis_client.xdel(stream_key, message_id)

--- a/app/event_bus/consumer.py
+++ b/app/event_bus/consumer.py
@@ -1,0 +1,235 @@
+"""EventConsumer — consumer group abstraction over Redis Streams."""
+from __future__ import annotations
+
+from redis.asyncio import Redis
+
+from app.core.config import settings
+from app.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class EventConsumer:
+    """Consumer abstraction over Redis Streams consumer groups.
+
+    Reads pending messages, acknowledges them, or deletes them from the stream.
+    """
+
+    def __init__(
+        self,
+        redis_client: Redis,
+        event_type: str,
+        consumer_name: str,
+        group_name: str,
+    ) -> None:
+        """Initialize a consumer.
+
+        Args:
+            redis_client: An async Redis client.
+            event_type: Event type this consumer processes, e.g. "auth.login".
+            consumer_name: Unique identifier for this consumer within the group.
+            group_name: Consumer group name, e.g. "soc360-consumers".
+        """
+        self.redis_client = redis_client
+        self.event_type = event_type
+        self.consumer_name = consumer_name
+        self.group_name = group_name
+
+    def _stream_key(self) -> str:
+        """Return the full stream key for this consumer's event type."""
+        return f"{settings.EVENT_STREAM_PREFIX}:{self.event_type}"
+
+    async def _ensure_group_exists(self) -> None:
+        """Create the consumer group with MKSTREAM if it doesn't exist.
+
+        This is safe to call on every read; Redis returns True if the group
+        was created, raises ResponseError if it already exists.
+        """
+        try:
+            await self.redis_client.xgroup_create(
+                self._stream_key(),
+                self.group_name,
+                "0",  # start reading from the beginning (or use "$" for new only)
+                mkstream=True,
+            )
+        except Exception:
+            # Group already exists — safe to ignore
+            pass
+
+    async def read_pending(self) -> list[dict]:
+        """Read pending messages for this consumer in this group.
+
+        Pending messages are those that have been delivered but not yet acknowledged.
+
+        Also monitors consumer lag: if pending count exceeds EVENT_PENDING_LAG_THRESHOLD,
+        logs a warning for operational visibility.
+
+        Returns:
+            List of dicts, each containing:
+              - "message_id": bytes
+              - "data": dict with event fields
+            Returns an empty list if no pending messages exist.
+        """
+        await self._ensure_group_exists()
+        stream_key = self._stream_key()
+
+        # Get detailed pending entries: XPENDING stream group [start end count consumer]
+        # Use "0" + "+" to get all pending entries
+        # Signature: xpending_range(stream, group, min_id, max_id, count)
+        pending_entries = await self.redis_client.xpending_range(
+            stream_key,
+            self.group_name,
+            "0",
+            "+",
+            100,
+        )
+
+        # Consumer lag monitoring: warn if pending entries exceed threshold
+        pending_count = len(pending_entries)
+        if pending_count > settings.EVENT_PENDING_LAG_THRESHOLD:
+            logger.warning(
+                "consumer_lag_exceeded_threshold",
+                event_type=self.event_type,
+                consumer_name=self.consumer_name,
+                pending_count=pending_count,
+                lag_threshold=settings.EVENT_PENDING_LAG_THRESHOLD,
+            )
+
+        if not pending_entries:
+            return []
+
+        # Batch XCLAIM: claim all pending messages in a single round-trip
+        # instead of O(n) individual XCLAIM calls (issue #100).
+        # This reduces Redis round-trips from N to 1 for N pending messages.
+        msg_ids = []
+        for entry in pending_entries:
+            msg_id = entry["message_id"]
+            msg_id_str = msg_id.decode() if isinstance(msg_id, bytes) else msg_id
+            msg_ids.append(msg_id_str)
+
+        result = []
+        try:
+            # Single XCLAIM call with all message_ids (batch operation)
+            claimed = await self.redis_client.xclaim(
+                stream_key,
+                self.group_name,
+                self.consumer_name,
+                min_idle_time=0,  # 0 means claim regardless of idle time
+                message_ids=msg_ids,
+            )
+            if claimed:
+                for cid, fields in claimed:
+                    str_fields = {
+                        k.decode() if isinstance(k, bytes) else k: v.decode() if isinstance(v, bytes) else v
+                        for k, v in fields.items()
+                    }
+                    result.append({
+                        "message_id": cid if isinstance(cid, bytes) else cid.encode(),
+                        "data": str_fields,
+                    })
+        except Exception:
+            # XCLAIM may fail if messages are already acked or deleted.
+            # Log for observability but don't crash — the consumer loop
+            # will retry on the next iteration.
+            logger.warning(
+                "batch_xclaim_failed",
+                event_type=self.event_type,
+                consumer_name=self.consumer_name,
+                message_count=len(msg_ids),
+            )
+        return result
+
+    async def read_new(self, block: int = 5000) -> list[dict]:
+        """Read new (undelivered) messages using XREADGROUP with blocking.
+
+        Uses XREADGROUP with '>' to read only new messages (never delivered
+        before to any consumer in the group). Blocks for up to `block`
+        milliseconds waiting for new messages, replacing the old busy-poll
+        pattern (issue #133).
+
+        Args:
+            block: Maximum milliseconds to block waiting for messages.
+                   Defaults to 5000 (5 seconds).
+
+        Returns:
+            List of dicts, each containing:
+              - "message_id": bytes
+              - "data": dict with event fields
+            Returns an empty list if no messages available within the timeout.
+        """
+        await self._ensure_group_exists()
+        stream_key = self._stream_key()
+
+        result = await self.redis_client.xreadgroup(
+            self.group_name,
+            self.consumer_name,
+            {stream_key: ">"},
+            count=10,
+            block=block,
+        )
+
+        if not result:
+            return []
+
+        messages: list[dict] = []
+        for _stream_name, stream_messages in result:
+            for msg_id, fields in stream_messages:
+                str_fields = {
+                    k.decode() if isinstance(k, bytes) else k:
+                    v.decode() if isinstance(v, bytes) else v
+                    for k, v in fields.items()
+                }
+                messages.append({
+                    "message_id": msg_id if isinstance(msg_id, bytes) else msg_id.encode(),
+                    "data": str_fields,
+                })
+        return messages
+
+    async def reconnect_and_resume(self) -> list[dict]:
+        """Reconnect to Redis and resume from last acknowledged position.
+
+        This handles temporary Redis connection drops by:
+        1. Re-calling _ensure_group_exists() to re-establish consumer group
+        2. Reading pending entries that may have been missed during disconnect
+
+        Returns:
+            List of pending messages that were unacknowledged during disconnect.
+        """
+        logger.info(
+            "consumer_reconnecting",
+            event_type=self.event_type,
+            consumer_name=self.consumer_name,
+        )
+        # Re-establish the consumer group (idempotent)
+        await self._ensure_group_exists()
+        # Read any pending messages that need processing
+        pending = await self.read_pending()
+        logger.info(
+            "consumer_resumed",
+            event_type=self.event_type,
+            consumer_name=self.consumer_name,
+            pending_count=len(pending),
+        )
+        return pending
+
+    async def ack(self, message_id: str | bytes) -> None:
+        """Acknowledge a message, removing it from the pending list.
+
+        Args:
+            message_id: The message ID to acknowledge (as returned by read_pending).
+        """
+        stream_key = self._stream_key()
+        if isinstance(message_id, str):
+            message_id = message_id.encode()
+        await self.redis_client.xack(stream_key, self.group_name, message_id)
+
+    async def delete(self, message_id: str | bytes) -> None:
+        """Delete a message from the stream entirely.
+
+        Args:
+            message_id: The message ID to delete.
+        """
+        stream_key = self._stream_key()
+        if isinstance(message_id, str):
+            message_id = message_id.encode()
+        await self.redis_client.xdel(stream_key, message_id)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -254,10 +254,11 @@ async def admin_b_headers(admin_b_token: str) -> dict:
 @pytest.fixture(autouse=True)
 def _reset_event_bus_singleton():
     """Reset the _event_bus singleton before/after each test for isolation."""
-    import app.dependencies
-    app.dependencies._event_bus = None
+    import app.dependencies.event_deps
+    app.dependencies.event_deps._event_bus = None
     yield
-    app.dependencies._event_bus = None
+    import app.dependencies.event_deps
+    app.dependencies.event_deps._event_bus = None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_dependencies.py
+++ b/tests/unit/test_dependencies.py
@@ -47,10 +47,10 @@ class TestGetCurrentUserTenantContext:
         mock_user.is_superadmin = True
         mock_user.tenant_id = uuid4()
 
-        with patch("app.dependencies.decode_access_token", return_value=valid_token_payload), \
-             patch("app.dependencies.check_redis_healthy", AsyncMock(return_value=True)), \
-             patch("app.dependencies.is_token_revoked", AsyncMock(return_value=False)), \
-             patch("app.dependencies.set_tenant_context", AsyncMock()) as mock_set_ctx:
+        with patch("app.dependencies.auth.decode_access_token", return_value=valid_token_payload), \
+             patch("app.dependencies.auth.check_redis_healthy", AsyncMock(return_value=True)), \
+             patch("app.dependencies.auth.is_token_revoked", AsyncMock(return_value=False)), \
+             patch("app.dependencies.auth.set_tenant_context", AsyncMock()) as mock_set_ctx:
             from app.dependencies import get_current_user
             result = await get_current_user(
                 token="Bearer token",
@@ -72,10 +72,10 @@ class TestGetCurrentUserTenantContext:
         mock_user.is_superadmin = False
         mock_user.tenant_id = uuid4()
 
-        with patch("app.dependencies.decode_access_token", return_value=valid_token_payload), \
-             patch("app.dependencies.check_redis_healthy", AsyncMock(return_value=True)), \
-             patch("app.dependencies.is_token_revoked", AsyncMock(return_value=False)), \
-             patch("app.dependencies.set_tenant_context", AsyncMock()) as mock_set_ctx:
+        with patch("app.dependencies.auth.decode_access_token", return_value=valid_token_payload), \
+             patch("app.dependencies.auth.check_redis_healthy", AsyncMock(return_value=True)), \
+             patch("app.dependencies.auth.is_token_revoked", AsyncMock(return_value=False)), \
+             patch("app.dependencies.auth.set_tenant_context", AsyncMock()) as mock_set_ctx:
             from app.dependencies import get_current_user
             result = await get_current_user(
                 token="Bearer token",
@@ -97,10 +97,10 @@ class TestGetCurrentUserTenantContext:
         mock_user.is_superadmin = False
         mock_user.tenant_id = None
 
-        with patch("app.dependencies.decode_access_token", return_value=valid_token_payload), \
-             patch("app.dependencies.check_redis_healthy", AsyncMock(return_value=True)), \
-             patch("app.dependencies.is_token_revoked", AsyncMock(return_value=False)), \
-             patch("app.dependencies.set_tenant_context", AsyncMock()) as mock_set_ctx:
+        with patch("app.dependencies.auth.decode_access_token", return_value=valid_token_payload), \
+             patch("app.dependencies.auth.check_redis_healthy", AsyncMock(return_value=True)), \
+             patch("app.dependencies.auth.is_token_revoked", AsyncMock(return_value=False)), \
+             patch("app.dependencies.auth.set_tenant_context", AsyncMock()) as mock_set_ctx:
             from app.dependencies import get_current_user
             with pytest.raises(HTTPException) as exc_info:
                 await get_current_user(
@@ -121,7 +121,7 @@ class TestGetEventBus:
         """get_event_bus() MUST return an EventBus instance with a redis client."""
         # Patch get_redis_client so we don't need real Redis
         mock_redis = FakeRedis()
-        with patch("app.dependencies.get_redis_client", AsyncMock(return_value=mock_redis)):
+        with patch("app.dependencies.event_deps.get_redis_client", AsyncMock(return_value=mock_redis)):
             # Import inside to allow patching first
             from app.dependencies import get_event_bus
 
@@ -136,7 +136,7 @@ class TestGetEventBus:
     async def test_get_event_bus_returns_singleton(self):
         """get_event_bus() MUST return the SAME instance on repeated calls."""
         mock_redis = FakeRedis()
-        with patch("app.dependencies.get_redis_client", AsyncMock(return_value=mock_redis)):
+        with patch("app.dependencies.event_deps.get_redis_client", AsyncMock(return_value=mock_redis)):
             from app.dependencies import get_event_bus
 
             instance1 = await get_event_bus()
@@ -148,7 +148,7 @@ class TestGetEventBus:
     async def test_get_event_bus_singleton_across_multiple_calls(self):
         """get_event_bus() singleton MUST hold across >2 calls."""
         mock_redis = FakeRedis()
-        with patch("app.dependencies.get_redis_client", AsyncMock(return_value=mock_redis)):
+        with patch("app.dependencies.event_deps.get_redis_client", AsyncMock(return_value=mock_redis)):
             from app.dependencies import get_event_bus
 
             instances = [await get_event_bus() for _ in range(5)]
@@ -174,7 +174,7 @@ class TestLogCrossTenantAttempt:
         caller_id = uuid4()
         target_id = uuid4()
 
-        with patch("app.dependencies.logger") as mock_logger:
+        with patch("app.dependencies.cross_tenant.logger") as mock_logger:
             _log_cross_tenant_attempt(
                 caller_id=caller_id,
                 target_id=target_id,
@@ -230,7 +230,7 @@ class TestGetUserForAdmin:
 
         mock_db = AsyncMock()
         # set_tenant_context is awaited in the finally block.
-        with patch("app.dependencies.set_tenant_context", AsyncMock()) as mock_set_ctx:
+        with patch("app.dependencies.cross_tenant.set_tenant_context", AsyncMock()) as mock_set_ctx:
             mock_db.execute.return_value = mock_result
             row = await _get_user_for_admin(
                 user_id, mock_caller, mock_db, method="GET", endpoint=f"/users/{user_id}"
@@ -260,8 +260,8 @@ class TestGetUserForAdmin:
         mock_result.scalar_one_or_none.return_value = mock_user
 
         mock_db = AsyncMock()
-        with patch("app.dependencies.set_tenant_context", AsyncMock()), \
-             patch("app.dependencies._log_cross_tenant_attempt") as mock_log:
+        with patch("app.dependencies.cross_tenant.set_tenant_context", AsyncMock()), \
+             patch("app.dependencies.cross_tenant._log_cross_tenant_attempt") as mock_log:
             mock_db.execute.return_value = mock_result
             with pytest.raises(HTTPException) as exc_info:
                 await _get_user_for_admin(
@@ -294,7 +294,7 @@ class TestGetUserForAdmin:
         mock_result.scalar_one_or_none.return_value = mock_user
 
         mock_db = AsyncMock()
-        with patch("app.dependencies.set_tenant_context", AsyncMock()):
+        with patch("app.dependencies.cross_tenant.set_tenant_context", AsyncMock()):
             mock_db.execute.return_value = mock_result
             row = await _get_user_for_admin(
                 user_id, mock_caller, mock_db, method="GET", endpoint=f"/users/{user_id}"
@@ -315,8 +315,8 @@ class TestGetUserForAdmin:
         mock_result.scalar_one_or_none.return_value = None
 
         mock_db = AsyncMock()
-        with patch("app.dependencies.set_tenant_context", AsyncMock()), \
-             patch("app.dependencies._log_cross_tenant_attempt") as mock_log:
+        with patch("app.dependencies.cross_tenant.set_tenant_context", AsyncMock()), \
+             patch("app.dependencies.cross_tenant._log_cross_tenant_attempt") as mock_log:
             mock_db.execute.return_value = mock_result
             with pytest.raises(HTTPException) as exc_info:
                 await _get_user_for_admin(
@@ -368,7 +368,7 @@ class TestGetTenantForAdmin:
         mock_caller.tenant_id = uuid4()  # different
 
         mock_db = AsyncMock()
-        with patch("app.dependencies._log_cross_tenant_attempt") as mock_log:
+        with patch("app.dependencies.cross_tenant._log_cross_tenant_attempt") as mock_log:
             with pytest.raises(HTTPException) as exc_info:
                 await _get_tenant_for_admin(
                     tenant_id, mock_caller, mock_db, method="GET", endpoint=f"/tenants/{tenant_id}"

--- a/tests/unit/test_imports.py
+++ b/tests/unit/test_imports.py
@@ -24,10 +24,12 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 APP_DIR = PROJECT_ROOT / "app"
 
 # Files in PR-1's slice (per the design PR-1 section + the orchestrator scope).
+# After refactor-180 (god files SRP), event_bus was split into a package.
+# We target the sub-module that still contains __import__ and indented imports.
 PR1_TARGETS: list[Path] = [
     APP_DIR / "modules" / "auth" / "service.py",
     APP_DIR / "core" / "security.py",
-    APP_DIR / "event_bus.py",
+    APP_DIR / "event_bus" / "bus.py",
     APP_DIR / "main.py",
 ]
 
@@ -64,12 +66,12 @@ def _format_offender(path: Path, lineno: int, line: str) -> str:
             id="app/main.py",
         ),
         pytest.param(
-            APP_DIR / "event_bus.py",
-            id="app/event_bus.py",
+            APP_DIR / "event_bus" / "bus.py",
+            id="app/event_bus/bus.py",
             marks=pytest.mark.xfail(
                 strict=True,
                 reason=(
-                    "event_bus.py L180 uses __import__('datetime') inside the "
+                    "event_bus/bus.py uses __import__('datetime') inside the "
                     "DLQ write block. Belongs to the event_bus cleanup issue, "
                     "not #101. Remove this xfail mark when that issue is fixed."
                 ),
@@ -96,8 +98,8 @@ def test_no_dunder_import_call(target: Path) -> None:
     "target",
     [
         pytest.param(
-            APP_DIR / "event_bus.py",
-            id="app/event_bus.py",
+            APP_DIR / "event_bus" / "bus.py",
+            id="app/event_bus/bus.py",
         ),
         pytest.param(
             APP_DIR / "modules" / "auth" / "service.py",
@@ -132,7 +134,7 @@ def test_no_dunder_import_call(target: Path) -> None:
             marks=pytest.mark.xfail(
                 strict=True,
                 reason=(
-                    "main.py L49 `from app.event_bus import EventBus` is an "
+                    "main.py L66 `from app.event_bus import EventBus` is an "
                     "indented import inside the consumer message loop. Owned "
                     "by issue #102 (inline imports refactor, 6 ubicaciones). "
                     "Remove this xfail mark when #102 is fixed."

--- a/tests/unit/test_redis_fail_closed.py
+++ b/tests/unit/test_redis_fail_closed.py
@@ -123,7 +123,7 @@ class TestRedisFailClosed:
         mock_redis = AsyncMock()
         mock_db = AsyncMock()
 
-        with patch("app.dependencies.check_redis_healthy", return_value=False):
+        with patch("app.dependencies.auth.check_redis_healthy", return_value=False):
             from app.dependencies import get_current_user
 
             with pytest.raises(HTTPException) as exc_info:


### PR DESCRIPTION
## Problem

Three files violate the Single Responsibility Principle:

| File | Lines | Responsibilities |
|------|-------|------------------|
| `dependencies.py` | 427 | Auth, rate limiting, Redis, DB sessions, tenant context, cross-tenant checks, role requirements, type aliases |
| `event_bus.py` | 542 | Redis Streams, consumer groups, event publishing, retry logic, DLQ, connection management |
| `llm.py` | 638 | LLM providers, prompt building, API keys, retry/backoff, streaming, content filtering, model config |

These god files cause merge conflicts, hard-to-test code, large blast radius, and poor onboarding.

## Solution

Split each god file into focused modules using the Strangler Fig pattern:

### app/dependencies/ (from 427-line file)
| Module | Responsibility |
|--------|---------------|
| `auth.py` | `get_current_user`, `oauth2_scheme`, role checks |
| `cross_tenant.py` | Cross-tenant pre-checks, admin factories |
| `db_deps.py` | `get_db_with_tenant`, DB session deps |
| `event_deps.py` | EventBus singleton factory |
| `llm_deps.py` | LLM provider dependency |
| `__init__.py` | Hub: re-exports all symbols |

### app/event_bus/ (from 542-line file)
| Module | Responsibility |
|--------|---------------|
| `bus.py` | `EventBus` publisher class |
| `consumer.py` | `EventConsumer` consumer group class |
| `_helpers.py` | DLQ tracking, retry keys, drain |
| `__init__.py` | Hub: re-exports all symbols |

### app/core/llm/ (from 638-line file)
| Module | Responsibility |
|--------|---------------|
| `config.py` | Retry config, credential redaction |
| `providers.py` | `LLMProvider` base + OpenAI/Anthropic/Gemini |
| `factory.py` | Provider factory, singletons, registry |
| `__init__.py` | Hub: re-exports all symbols |

## Backward Compatibility

Hub `__init__.py` files re-export every symbol from the old files. All existing imports continue to work:

```python
from app.dependencies import get_current_user, DBDep  # ✅ still works
from app.event_bus import EventBus, EventConsumer       # ✅ still works
from app.core.llm import get_llm_provider               # ✅ still works
```

## Changes

- 14 new module files created
- 3 original files deleted
- 4 test files updated (import paths)
- 899 insertions, 724 deletions

## Tests

- **488 unit tests passing**
- 0 failures
- Hub backward compatibility verified
- Direct module imports verified
- No circular imports

## Module Sizes

| Module | Lines |
|--------|-------|
| `auth.py` | 157 |
| `cross_tenant.py` | 248 |
| `db_deps.py` | 23 |
| `event_deps.py` | 18 |
| `llm_deps.py` | 9 |
| `bus.py` | 283 |
| `consumer.py` | 224 |
| `_helpers.py` | 50 |
| `config.py` | 32 |
| `providers.py` | 424 |
| `factory.py` | 199 |

Fixes #180