### PR TITLE
fix(auth): prevent silent drop of superadmin login audit events

### DIFF
--- a/app/event_bus/bus.py
+++ b/app/event_bus/bus.py
@@ -68,6 +68,7 @@ class EventBus:
         payload = {
             k: str(v) if hasattr(v, "__str__") else v
             for k, v in raw.items()
+            if v is not None
         }
         # XADD with bounded stream length (approximate)
         msg_id = await self._redis.xadd(
@@ -166,7 +167,7 @@ class EventBus:
                 )
 
         try:
-            if event_type == "auth.login":
+            if event_type in ("auth.login", "system.auth.login"):
                 EventBus._handle_auth_login(data)
             else:
                 logger.debug("no_handler_for_event_type", event_type=event_type)

--- a/app/event_schemas.py
+++ b/app/event_schemas.py
@@ -74,3 +74,43 @@ class AuthLoginEvent(BaseEvent):
     email_hash: Annotated[str, Field(min_length=1, description="SHA256[:32] of user email")]
     ip_prefix: Annotated[str | None, Field(default=None, description="Masked IP /24 prefix, e.g. 192.168.1.0/24")]
     user_agent: Annotated[str | None, Field(default=None, description="Client User-Agent if available")]
+
+
+class TenantlessEvent(BaseEvent):
+    """Event base for system-level events without a tenant scope.
+
+    Allows `tenant_id` to be absent or `None` for system-level audit events.
+    `BaseEvent` remains unchanged — existing tenant-scoped events continue
+    to require a UUID tenant id.
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        str_strip_whitespace=True,
+    )
+
+    tenant_id: Annotated[
+        uuid.UUID | None,
+        Field(default=None, description="Tenant that owns this event (None for system events)"),
+    ]
+
+
+class AuthSuperadminLoginEvent(TenantlessEvent):
+    """system.auth.login event emitted after a superadmin login.
+
+    Tenantless — superadmins operate outside any tenant scope.
+    `is_superadmin=True` is explicit so consumers don't need to parse
+    stream names to infer event semantics.
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        str_strip_whitespace=True,
+    )
+
+    event_type: Annotated[str, Field(default="system.auth.login", description="Event type discriminator")]
+    user_id: Annotated[str, Field(min_length=1, description="Authenticated user ID")]
+    email_hash: Annotated[str, Field(min_length=1, description="SHA256[:32] of user email")]
+    ip_prefix: Annotated[str | None, Field(default=None, description="Masked IP /24 prefix, e.g. 192.168.1.0/24")]
+    user_agent: Annotated[str | None, Field(default=None, description="Client User-Agent if available")]
+    is_superadmin: Annotated[bool, Field(default=True, description="Flag indicating superadmin authentication")]

--- a/app/modules/auth/service.py
+++ b/app/modules/auth/service.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 from uuid import UUID, uuid4
 
 from redis.asyncio import Redis
+from redis.exceptions import RedisError
 from sqlalchemy import select, update, func, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -384,20 +385,32 @@ async def login(
     await track_jti(str(user.id), jti, redis)
     refresh_token = await _create_refresh_token(user.id, db, created_from_ip=request_ip)
 
-    # Publish auth.login event (non-blocking on failure)
+    # Publish login event (non-blocking on failure)
     try:
         event_bus = await get_event_bus()
-        from app.event_schemas import AuthLoginEvent
-        await event_bus.publish(AuthLoginEvent(
-            event_id=uuid4(),
-            tenant_id=user.tenant_id,
-            user_id=str(user.id),
-            email_hash=hash_email(user.email),
-            ip_prefix=mask_ip(request_ip),
-            user_agent=user_agent,
-        ))
+        if user.is_superadmin:
+            from app.event_schemas import AuthSuperadminLoginEvent
+            await event_bus.publish(AuthSuperadminLoginEvent(
+                event_id=uuid4(),
+                user_id=str(user.id),
+                email_hash=hash_email(user.email),
+                ip_prefix=mask_ip(request_ip),
+                user_agent=user_agent,
+            ))
+        else:
+            from app.event_schemas import AuthLoginEvent
+            await event_bus.publish(AuthLoginEvent(
+                event_id=uuid4(),
+                tenant_id=user.tenant_id,
+                user_id=str(user.id),
+                email_hash=hash_email(user.email),
+                ip_prefix=mask_ip(request_ip),
+                user_agent=user_agent,
+            ))
+    except RedisError:
+        logger.warning("event_publish_failed", event_type="auth.login", reason="redis_error")
     except Exception:
-        logger.warning("event_publish_failed", event_type="auth.login")
+        logger.critical("event_publish_programming_error", event_type="auth.login")
 
     return TokenResponse(
         access_token=access_token,

--- a/tests/integration/test_auth_login_event_flow.py
+++ b/tests/integration/test_auth_login_event_flow.py
@@ -240,3 +240,114 @@ async def test_login_succeeds_even_if_redis_unavailable_for_event():
     assert refresh_token == "refresh_token"
 
     await fake_redis.aclose()
+
+
+@pytest.mark.asyncio
+async def test_superadmin_login_publishes_system_event_in_separate_stream():
+    """Superadmin login MUST publish a system.auth.login event in the system stream.
+
+    Verifies:
+    1. Login succeeds for superadmin (no tenant)
+    2. System.auth.login event appears in events:system.auth.login stream
+    3. No tenant_id in Redis payload (filtered before XADD)
+    4. Regular stream events:auth.login is NOT written for superadmins
+    """
+    from app.modules.auth import service
+    from app.event_bus import EventBus
+
+    fake_redis = FakeRedis()
+
+    mock_user = MagicMock()
+    mock_user.id = uuid4()
+    mock_user.email = "sa-integration@test.com"
+    mock_user.hashed_password = "hashed_password"
+    mock_user.tenant_id = None  # superadmin
+    mock_user.role = "superadmin"
+    mock_user.is_superadmin = True
+    mock_user.is_active = True
+    mock_tenant = None  # superadmin
+
+    mock_db = AsyncMock()
+
+    with patch.object(service, "_check_account_lockout", return_value=None):
+        with patch.object(service, "_get_active_user", return_value=(mock_user, mock_tenant)):
+            with patch("app.modules.auth.service.verify_password_async", return_value=True):
+                with patch.object(service, "_check_tenant_active", return_value=None):
+                    with patch.object(service, "_clear_login_attempts", return_value=None):
+                        with patch(
+                            "app.modules.auth.service.create_access_token",
+                            return_value=("sa_access_token", "sa_jti"),
+                        ):
+                            with patch.object(
+                                service, "_create_refresh_token", return_value="sa_refresh_token"
+                            ):
+                                with patch(
+                                    "app.modules.auth.service.get_event_bus"
+                                ) as mock_get_bus:
+                                    event_bus = EventBus(fake_redis)
+                                    mock_get_bus.return_value = event_bus
+
+                                    result = await service.login(
+                                        email="sa-integration@test.com",
+                                        password="password",
+                                        db=mock_db,
+                                        redis=fake_redis,
+                                        request_ip="10.0.0.50",
+                                    )
+
+    # Login succeeded
+    token_response, refresh_token = result
+    assert token_response.access_token == "sa_access_token"
+    assert refresh_token == "sa_refresh_token"
+
+    # The system.auth.login stream MUST have the event
+    system_stream = "events:system.auth.login"
+    system_msgs = await fake_redis.xrange(system_stream)
+    assert len(system_msgs) >= 1, (
+        f"Expected system.auth.login event in {system_stream}, "
+        f"but stream is empty"
+    )
+
+    # Verify the event payload in the system stream
+    found_system_event = False
+    for _msg_id, fields in system_msgs:
+        field_dict = {
+            k.decode() if isinstance(k, bytes) else k: v.decode() if isinstance(v, bytes) else v
+            for k, v in fields.items()
+        }
+        if field_dict.get("event_type") == "system.auth.login":
+            found_system_event = True
+            # user_id must match
+            assert field_dict["user_id"] == str(mock_user.id)
+            # email_hash must be present
+            assert "email_hash" in field_dict
+            # raw email must NOT leak
+            assert "email" not in field_dict
+            # ip_prefix must be masked
+            assert field_dict.get("ip_prefix") == "10.0.0.0/24"
+            # tenant_id MUST be absent (filtered by publish())
+            assert "tenant_id" not in field_dict, (
+                f"tenant_id should be filtered when None, "
+                f"but found in payload: {field_dict}"
+            )
+            break
+
+    assert found_system_event, (
+        "system.auth.login event not found in events:system.auth.login stream"
+    )
+
+    # The auth.login stream MUST NOT have the superadmin event
+    regular_stream = "events:auth.login"
+    regular_msgs = await fake_redis.xrange(regular_stream)
+    for _msg_id, fields in regular_msgs:
+        field_dict = {
+            k.decode() if isinstance(k, bytes) else k: v.decode() if isinstance(v, bytes) else v
+            for k, v in fields.items()
+        }
+        if field_dict.get("user_id") == str(mock_user.id):
+            pytest.fail(
+                f"Superadmin event found in tenant-scoped stream {regular_stream}. "
+                f"Superadmin events MUST go to {system_stream}"
+            )
+
+    await fake_redis.aclose()

--- a/tests/unit/test_auth_service_event_publish.py
+++ b/tests/unit/test_auth_service_event_publish.py
@@ -156,6 +156,7 @@ class TestAuthLoginEventPublish:
         """Test login succeeds even if event publishing fails (non-blocking)."""
         from app.modules.auth import service
         from app.event_bus import EventBus
+        from redis.exceptions import RedisError
 
         mock_user = MagicMock()
         mock_user.id = uuid4()
@@ -172,8 +173,8 @@ class TestAuthLoginEventPublish:
         mock_redis = AsyncMock()
 
         mock_event_bus = AsyncMock(spec=EventBus)
-        # Simulate publish raising an exception
-        mock_event_bus.publish.side_effect = Exception("Redis connection failed")
+        # Simulate RedisError during publish (realistic failure scenario)
+        mock_event_bus.publish.side_effect = RedisError("Connection refused")
 
         with patch.object(service, "_check_account_lockout", return_value=None):
             with patch.object(service, "_get_active_user", return_value=(mock_user, mock_tenant)):
@@ -206,9 +207,10 @@ class TestAuthLoginEventPublish:
         assert token_response.access_token == "access_token"
         assert refresh_token == "refresh_token"
 
-        # Warning was logged about the publish failure
-        mock_warning.assert_called_once()
-        mock_warning.assert_called_with("event_publish_failed", event_type="auth.login")
+        # RedisError → warning was logged about the publish failure
+        mock_warning.assert_called_once_with(
+            "event_publish_failed", event_type="auth.login", reason="redis_error"
+        )
 
     @pytest.mark.asyncio
     async def test_login_blocked_if_credentials_invalid(self):
@@ -254,3 +256,301 @@ class TestAuthLoginEventPublish:
 
         # verify publish was never called
         mock_event_bus.publish.assert_not_called()
+
+
+class TestAuthSuperadminLoginEventPublish:
+    """Test that superadmin login publishes AuthSuperadminLoginEvent."""
+
+    @pytest.mark.asyncio
+    async def test_superadmin_login_publishes_system_auth_login_event(self):
+        """Superadmin login MUST publish AuthSuperadminLoginEvent."""
+        from app.modules.auth import service
+        from app.event_schemas import AuthSuperadminLoginEvent
+        from app.event_bus import EventBus
+
+        mock_user = MagicMock()
+        mock_user.id = uuid4()
+        mock_user.email = "sa@example.com"
+        mock_user.hashed_password = "hashed_password"
+        mock_user.tenant_id = None  # superadmins have no tenant
+        mock_user.role = "superadmin"
+        mock_user.is_superadmin = True
+        mock_user.is_active = True
+        mock_tenant = None  # superadmins have no tenant
+
+        mock_db = AsyncMock()
+        mock_redis = AsyncMock()
+
+        published_events: list = []
+
+        async def mock_publish(event) -> bytes:
+            published_events.append(event)
+            return b"1234567890123-0"
+
+        mock_event_bus = AsyncMock(spec=EventBus)
+        mock_event_bus.publish.side_effect = mock_publish
+
+        with patch.object(service, "_check_account_lockout", return_value=None):
+            with patch.object(service, "_get_active_user", return_value=(mock_user, mock_tenant)):
+                with patch("app.modules.auth.service.verify_password_async", return_value=True):
+                    with patch.object(service, "_check_tenant_active", return_value=None):
+                        with patch.object(service, "_clear_login_attempts", return_value=None):
+                            with patch(
+                                "app.modules.auth.service.create_access_token",
+                                return_value=("access_token", "jti-sa"),
+                            ):
+                                with patch.object(
+                                    service, "_create_refresh_token", return_value="refresh_token"
+                                ):
+                                    with patch(
+                                        "app.modules.auth.service.get_event_bus",
+                                        return_value=mock_event_bus,
+                                    ):
+                                        result = await service.login(
+                                            email="sa@example.com",
+                                            password="password",
+                                            db=mock_db,
+                                            redis=mock_redis,
+                                            request_ip="10.0.0.1",
+                                        )
+
+        # Login succeeded
+        token_response, refresh_token = result
+        assert token_response.access_token == "access_token"
+
+        # Exactly one event published
+        assert len(published_events) == 1
+        event = published_events[0]
+
+        # Must be an AuthSuperadminLoginEvent instance
+        assert isinstance(event, AuthSuperadminLoginEvent), (
+            f"Expected AuthSuperadminLoginEvent, got {type(event).__name__}"
+        )
+        # Must have system.auth.login event type
+        assert event.event_type == "system.auth.login"
+        # Must be tenantless
+        assert event.tenant_id is None
+        # Must have is_superadmin=True
+        assert event.is_superadmin is True
+        # Must have the user ID
+        assert event.user_id == str(mock_user.id)
+        # Must have email hash
+        assert event.email_hash is not None
+        assert len(event.email_hash) == 32
+
+    @pytest.mark.asyncio
+    async def test_regular_user_login_still_publishes_auth_login_event(self):
+        """Regular (non-superadmin) login MUST still publish AuthLoginEvent."""
+        from app.modules.auth import service
+        from app.event_schemas import AuthLoginEvent
+        from app.event_bus import EventBus
+
+        mock_user = MagicMock()
+        mock_user.id = uuid4()
+        mock_user.email = "regular@example.com"
+        mock_user.hashed_password = "hashed_password"
+        mock_user.tenant_id = uuid4()  # regular users have a tenant
+        mock_user.role = "admin"
+        mock_user.is_superadmin = False
+        mock_user.is_active = True
+        mock_tenant = MagicMock()
+        mock_tenant.is_active = True
+
+        mock_db = AsyncMock()
+        mock_redis = AsyncMock()
+
+        published_events: list = []
+
+        async def mock_publish(event) -> bytes:
+            published_events.append(event)
+            return b"1234567890123-0"
+
+        mock_event_bus = AsyncMock(spec=EventBus)
+        mock_event_bus.publish.side_effect = mock_publish
+
+        with patch.object(service, "_check_account_lockout", return_value=None):
+            with patch.object(service, "_get_active_user", return_value=(mock_user, mock_tenant)):
+                with patch("app.modules.auth.service.verify_password_async", return_value=True):
+                    with patch.object(service, "_check_tenant_active", return_value=None):
+                        with patch.object(service, "_clear_login_attempts", return_value=None):
+                            with patch(
+                                "app.modules.auth.service.create_access_token",
+                                return_value=("access_token", "jti-reg"),
+                            ):
+                                with patch.object(
+                                    service, "_create_refresh_token", return_value="refresh_token"
+                                ):
+                                    with patch(
+                                        "app.modules.auth.service.get_event_bus",
+                                        return_value=mock_event_bus,
+                                    ):
+                                        result = await service.login(
+                                            email="regular@example.com",
+                                            password="password",
+                                            db=mock_db,
+                                            redis=mock_redis,
+                                            request_ip="192.168.1.1",
+                                        )
+
+        # Login succeeded
+        token_response, refresh_token = result
+        assert token_response.access_token == "access_token"
+
+        # Exactly one event published
+        assert len(published_events) == 1
+        event = published_events[0]
+
+        # Must be an AuthLoginEvent instance (NOT AuthSuperadminLoginEvent)
+        assert isinstance(event, AuthLoginEvent), (
+            f"Expected AuthLoginEvent, got {type(event).__name__}"
+        )
+        assert type(event).__name__ == "AuthLoginEvent", (
+            f"Expected type AuthLoginEvent, got {type(event).__name__}"
+        )
+        # Must have auth.login event type
+        assert event.event_type == "auth.login"
+        # Must have a tenant_id (not None)
+        assert event.tenant_id is not None
+        assert event.tenant_id == mock_user.tenant_id
+
+
+class TestLoginEventErrorHandling:
+    """REQ-004: Differentiated exception handling in login event publishing.
+
+    Login MUST always succeed (availability-first).
+    RedisError → logger.warning (swallowed).
+    Programming errors → logger.critical (NOT re-raised).
+    """
+
+    @pytest.mark.asyncio
+    async def test_redis_error_during_publish_logs_warning(self):
+        """RedisError during publish → logger.warning, login still succeeds."""
+        from app.modules.auth import service
+        from redis.exceptions import RedisError
+
+        mock_user = MagicMock()
+        mock_user.id = uuid4()
+        mock_user.email = "redis-fail@test.com"
+        mock_user.hashed_password = "hashed_password"
+        mock_user.tenant_id = uuid4()
+        mock_user.role = "admin"
+        mock_user.is_superadmin = False
+        mock_user.is_active = True
+        mock_tenant = MagicMock()
+        mock_tenant.is_active = True
+
+        mock_db = AsyncMock()
+        mock_redis = AsyncMock()
+
+        mock_event_bus = AsyncMock()
+        mock_event_bus.publish.side_effect = RedisError("Connection refused")
+
+        with patch.object(service, "_check_account_lockout", return_value=None):
+            with patch.object(service, "_get_active_user", return_value=(mock_user, mock_tenant)):
+                with patch("app.modules.auth.service.verify_password_async", return_value=True):
+                    with patch.object(service, "_check_tenant_active", return_value=None):
+                        with patch.object(service, "_clear_login_attempts", return_value=None):
+                            with patch(
+                                "app.modules.auth.service.create_access_token",
+                                return_value=("access_token", "jti-redis"),
+                            ):
+                                with patch.object(
+                                    service, "_create_refresh_token", return_value="refresh_token"
+                                ):
+                                    with patch(
+                                        "app.modules.auth.service.get_event_bus",
+                                        return_value=mock_event_bus,
+                                    ):
+                                        with patch.object(service.logger, "warning") as mock_warning:
+                                            with patch.object(
+                                                service.logger, "critical"
+                                            ) as mock_critical:
+                                                result = await service.login(
+                                                    email="redis-fail@test.com",
+                                                    password="password",
+                                                    db=mock_db,
+                                                    redis=mock_redis,
+                                                    request_ip="10.0.0.1",
+                                                )
+
+        # Login MUST succeed (availability-first)
+        token_response, refresh_token = result
+        assert token_response.access_token == "access_token"
+        assert refresh_token == "refresh_token"
+
+        # RedisError → logger.warning
+        mock_warning.assert_called_once_with(
+            "event_publish_failed", event_type="auth.login", reason="redis_error"
+        )
+        # critical must NOT have been called
+        mock_critical.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_programming_error_during_publish_logs_critical(self):
+        """Non-Redis programming error during publish → logger.critical, login still succeeds."""
+        from app.modules.auth import service
+
+        mock_user = MagicMock()
+        mock_user.id = uuid4()
+        mock_user.email = "prog-error@test.com"
+        mock_user.hashed_password = "hashed_password"
+        mock_user.tenant_id = uuid4()
+        mock_user.role = "admin"
+        mock_user.is_superadmin = False
+        mock_user.is_active = True
+        mock_tenant = MagicMock()
+        mock_tenant.is_active = True
+
+        mock_db = AsyncMock()
+        mock_redis = AsyncMock()
+
+        mock_event_bus = AsyncMock()
+        # Non-Redis exception → programming error
+        mock_event_bus.publish.side_effect = ValueError("Unexpected schema mismatch")
+
+        with patch.object(service, "_check_account_lockout", return_value=None):
+            with patch.object(service, "_get_active_user", return_value=(mock_user, mock_tenant)):
+                with patch("app.modules.auth.service.verify_password_async", return_value=True):
+                    with patch.object(service, "_check_tenant_active", return_value=None):
+                        with patch.object(service, "_clear_login_attempts", return_value=None):
+                            with patch(
+                                "app.modules.auth.service.create_access_token",
+                                return_value=("access_token", "jti-prog"),
+                            ):
+                                with patch.object(
+                                    service, "_create_refresh_token", return_value="refresh_token"
+                                ):
+                                    with patch(
+                                        "app.modules.auth.service.get_event_bus",
+                                        return_value=mock_event_bus,
+                                    ):
+                                        with patch.object(service.logger, "warning") as mock_warning:
+                                            with patch.object(
+                                                service.logger, "critical"
+                                            ) as mock_critical:
+                                                result = await service.login(
+                                                    email="prog-error@test.com",
+                                                    password="password",
+                                                    db=mock_db,
+                                                    redis=mock_redis,
+                                                    request_ip="10.0.0.1",
+                                                )
+
+        # Login MUST succeed (availability-first)
+        token_response, refresh_token = result
+        assert token_response.access_token == "access_token"
+        assert refresh_token == "refresh_token"
+
+        # Programming error → logger.critical
+        mock_critical.assert_called_once_with(
+            "event_publish_programming_error", event_type="auth.login"
+        )
+        # warning must NOT have been called
+        mock_warning.assert_not_called()
+
+    def test_redis_error_importable(self):
+        """RedisError is importable from redis.exceptions."""
+        from redis.exceptions import RedisError
+
+        assert RedisError is not None
+        assert issubclass(RedisError, Exception)

--- a/tests/unit/test_event_bus.py
+++ b/tests/unit/test_event_bus.py
@@ -102,6 +102,88 @@ class TestEventBusPublish:
         assert b"-" in msg_id
 
 
+class TestEventBusPublishNoneFilter:
+    """Validate publish() filters None values before XADD (W1)."""
+
+    @pytest_asyncio.fixture
+    async def client(self) -> FakeRedis:
+        r = FakeRedis()
+        yield r
+        await r.aclose()
+
+    @pytest.mark.asyncio
+    async def test_publish_omits_none_tenant_id_from_redis(self, client: FakeRedis):
+        """publish() MUST omit tenant_id from Redis payload when it is None."""
+        from app.event_bus import EventBus
+        from app.event_schemas import AuthSuperadminLoginEvent
+
+        bus = EventBus(redis_client=client)
+
+        # Create a tenantless superadmin login event
+        event = AuthSuperadminLoginEvent(
+            event_id=uuid.uuid4(),
+            user_id="sa-user",
+            email_hash="a" * 32,
+        )
+        assert event.tenant_id is None  # precondition
+
+        msg_id = await bus.publish(event)
+        assert isinstance(msg_id, bytes)
+
+        # Read the raw message from Redis
+        stream = "events:system.auth.login"
+        messages = await client.xrange(stream)
+        assert len(messages) >= 1
+
+        _msg_id, fields = messages[0]
+        field_dict = {
+            k.decode() if isinstance(k, bytes) else k: v.decode() if isinstance(v, bytes) else v
+            for k, v in fields.items()
+        }
+        # tenant_id must NOT be in the XADD payload (None values filtered out)
+        assert "tenant_id" not in field_dict, (
+            f"tenant_id should be omitted from Redis when None, "
+            f"but found in payload keys: {list(field_dict.keys())}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_publish_keeps_non_none_tenant_id(self, client: FakeRedis):
+        """publish() MUST keep tenant_id in Redis payload when it is not None."""
+        from app.event_bus import EventBus
+        from app.event_schemas import AuthLoginEvent
+        from datetime import datetime, timezone
+
+        bus = EventBus(redis_client=client)
+        tenant_id = uuid.uuid4()
+
+        event = AuthLoginEvent(
+            event_id=uuid.uuid4(),
+            tenant_id=tenant_id,
+            user_id="user-123",
+            email_hash="b" * 32,
+            ip_prefix="192.168.1.0/24",
+            user_agent="Mozilla/5.0",
+            timestamp=datetime.now(timezone.utc),
+        )
+        assert event.tenant_id is not None  # precondition
+
+        msg_id = await bus.publish(event)
+        assert isinstance(msg_id, bytes)
+
+        # Read the raw message from Redis
+        messages = await client.xrange("events:auth.login")
+        assert len(messages) >= 1
+
+        _msg_id, fields = messages[0]
+        field_dict = {
+            k.decode() if isinstance(k, bytes) else k: v.decode() if isinstance(v, bytes) else v
+            for k, v in fields.items()
+        }
+        # tenant_id MUST be present when not None
+        assert "tenant_id" in field_dict
+        assert field_dict["tenant_id"] == str(tenant_id)
+
+
 class TestEventConsumerInit:
     """Validate EventConsumer initialization."""
 

--- a/tests/unit/test_event_bus_handler.py
+++ b/tests/unit/test_event_bus_handler.py
@@ -11,6 +11,7 @@ we assert on the formatted message content.
 from __future__ import annotations
 
 import re
+import uuid
 import pytest
 import logging
 
@@ -236,3 +237,87 @@ class TestConsumerHandlerIntegration:
         assert "email_hash=dddddddddddddddddddddddddddddddd" in msg, f"Expected email_hash in message, got: {msg}"
         assert "ip_prefix=8.8.8.0/24" in msg, f"Expected ip_prefix in message, got: {msg}"
         assert "user_id=" in msg, f"Expected user_id in message, got: {msg}"
+
+
+class TestSystemAuthLoginDispatch:
+    """Validate system.auth.login dispatch routing (W2)."""
+
+    @pytest.mark.asyncio
+    async def test_system_auth_login_routes_to_handle_auth_login(self, caplog):
+        """_dispatch_event MUST route system.auth.login to _handle_auth_login."""
+        from app.event_bus import EventBus
+
+        # Build a payload similar to what AuthSuperadminLoginEvent would produce
+        payload = {
+            "event_type": "system.auth.login",
+            "user_id": "sa-user-1",
+            "email_hash": "a" * 32,
+            "ip_prefix": "10.0.0.0/24",
+            "user_agent": "SuperadminAgent/1.0",
+            # Notice: no tenant_id — it was filtered out before XADD
+        }
+
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger="app.event_bus"):
+            await EventBus._dispatch_event("system.auth.login", payload)
+
+        # Must route to _handle_auth_login and log the event
+        assert any(
+            "auth.login_event_consumed" in (r.message or "")
+            for r in caplog.records
+        ), (
+            f"Expected auth.login_event_consumed for system.auth.login dispatch, "
+            f"got: {[(r.levelname, r.message) for r in caplog.records]}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_system_auth_login_handles_missing_tenant_id(self, caplog):
+        """_dispatch_event MUST handle system.auth.login without tenant_id gracefully."""
+        from app.event_bus import EventBus
+
+        # AuthSuperadminLoginEvent has no tenant_id after None-filtering
+        payload = {
+            "event_type": "system.auth.login",
+            "user_id": "sa-user-2",
+            "email_hash": "b" * 32,
+            "ip_prefix": "192.168.1.0/24",
+            # no tenant_id key at all
+        }
+
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger="app.event_bus"):
+            try:
+                await EventBus._dispatch_event("system.auth.login", payload)
+            except Exception as exc:
+                pytest.fail(
+                    f"_dispatch_event raised {exc} for system.auth.login "
+                    f"without tenant_id"
+                )
+
+        # Must have logged successfully
+        assert any(
+            "auth.login_event_consumed" in (r.message or "")
+            for r in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_auth_login_still_routes_correctly(self, caplog):
+        """_dispatch_event MUST still route auth.login (not just system.auth.login)."""
+        from app.event_bus import EventBus
+
+        payload = {
+            "event_type": "auth.login",
+            "user_id": "regular-user",
+            "email_hash": "c" * 32,
+            "ip_prefix": "10.0.0.0/24",
+            "tenant_id": str(uuid.uuid4()),
+        }
+
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger="app.event_bus"):
+            await EventBus._dispatch_event("auth.login", payload)
+
+        assert any(
+            "auth.login_event_consumed" in (r.message or "")
+            for r in caplog.records
+        ), f"auth.login should still route, got: {[(r.levelname, r.message) for r in caplog.records]}"

--- a/tests/unit/test_event_schemas.py
+++ b/tests/unit/test_event_schemas.py
@@ -255,3 +255,137 @@ class TestAuthLoginEventSerialization:
         assert restored.ip_prefix == original.ip_prefix
         assert restored.user_agent == original.user_agent
         assert restored.event_id == original.event_id
+
+
+class TestTenantlessEvent:
+    """Validate TenantlessEvent Pydantic model."""
+
+    def test_tenantless_event_accepts_no_tenant_id(self):
+        """TenantlessEvent MUST accept tenant_id=None."""
+        from app.event_schemas import TenantlessEvent
+
+        event = TenantlessEvent(
+            event_id=uuid.uuid4(),
+            event_type="system.auth.login",
+        )
+        assert event.tenant_id is None
+
+    def test_tenantless_event_tenant_id_defaults_to_none(self):
+        """TenantlessEvent tenant_id MUST default to None when not provided."""
+        from app.event_schemas import TenantlessEvent
+
+        event = TenantlessEvent(
+            event_id=uuid.uuid4(),
+            event_type="system.event",
+        )
+        assert event.tenant_id is None
+
+    def test_tenantless_event_is_base_event_subclass(self):
+        """TenantlessEvent MUST be a subclass of BaseEvent."""
+        from app.event_schemas import TenantlessEvent, BaseEvent
+
+        assert issubclass(TenantlessEvent, BaseEvent)
+
+    def test_tenantless_event_strips_whitespace(self):
+        """TenantlessEvent MUST strip whitespace from string fields."""
+        from app.event_schemas import TenantlessEvent
+
+        event = TenantlessEvent(
+            event_id=uuid.uuid4(),
+            event_type="  system.auth.login  ",
+        )
+        assert event.event_type == "system.auth.login"
+
+
+class TestAuthSuperadminLoginEvent:
+    """Validate AuthSuperadminLoginEvent Pydantic model."""
+
+    def test_superadmin_login_event_defaults(self):
+        """AuthSuperadminLoginEvent MUST have correct defaults."""
+        from app.event_schemas import AuthSuperadminLoginEvent
+
+        event = AuthSuperadminLoginEvent(
+            event_id=uuid.uuid4(),
+            user_id="sa-user",
+            email_hash="d" * 32,
+        )
+        assert event.event_type == "system.auth.login"
+        assert event.is_superadmin is True
+        assert event.tenant_id is None
+
+    def test_superadmin_login_event_inherits_from_tenantless(self):
+        """AuthSuperadminLoginEvent MUST inherit from TenantlessEvent."""
+        from app.event_schemas import AuthSuperadminLoginEvent, TenantlessEvent
+
+        assert issubclass(AuthSuperadminLoginEvent, TenantlessEvent)
+
+    def test_superadmin_login_event_accepts_full_data(self):
+        """AuthSuperadminLoginEvent MUST accept all fields with valid data."""
+        from app.event_schemas import AuthSuperadminLoginEvent
+
+        event = AuthSuperadminLoginEvent(
+            event_id=uuid.uuid4(),
+            user_id="sa-user-1",
+            email_hash="e" * 32,
+            ip_prefix="10.0.0.0/24",
+            user_agent="TestAgent/1.0",
+            is_superadmin=True,
+        )
+        assert event.user_id == "sa-user-1"
+        assert event.email_hash == "e" * 32
+        assert event.ip_prefix == "10.0.0.0/24"
+        assert event.user_agent == "TestAgent/1.0"
+        assert event.is_superadmin is True
+
+
+class TestAuthSuperadminLoginEventSerialization:
+    """Validate serialization of AuthSuperadminLoginEvent."""
+
+    def test_model_dump_omits_tenant_id_if_none(self):
+        """model_dump() MUST include tenant_id as None for TenantlessEvent."""
+        from app.event_schemas import AuthSuperadminLoginEvent
+
+        event = AuthSuperadminLoginEvent(
+            event_id=uuid.uuid4(),
+            user_id="sa-user",
+            email_hash="f" * 32,
+        )
+        data = event.model_dump()
+        assert data["tenant_id"] is None
+        assert data["event_type"] == "system.auth.login"
+        assert data["is_superadmin"] is True
+
+    def test_model_dump_json_includes_system_auth_login(self):
+        """model_dump_json() MUST contain system.auth.login type."""
+        from app.event_schemas import AuthSuperadminLoginEvent
+
+        event = AuthSuperadminLoginEvent(
+            event_id=uuid.uuid4(),
+            user_id="sa-user",
+            email_hash="g" * 32,
+        )
+        json_str = event.model_dump_json()
+        assert "system.auth.login" in json_str
+        assert "is_superadmin" in json_str
+
+    def test_model_validate_round_trip(self):
+        """model_validate() MUST reconstruct an identical superadmin event."""
+        from app.event_schemas import AuthSuperadminLoginEvent
+
+        original = AuthSuperadminLoginEvent(
+            event_id=uuid.uuid4(),
+            user_id="sa-user-2",
+            email_hash="h" * 32,
+            ip_prefix="192.168.1.0/24",
+            user_agent="RoundTrip/1.0",
+        )
+        data = original.model_dump()
+        restored = AuthSuperadminLoginEvent.model_validate(data)
+        assert restored.user_id == original.user_id
+        assert restored.email_hash == original.email_hash
+        assert restored.ip_prefix == original.ip_prefix
+        assert restored.user_agent == original.user_agent
+        assert restored.event_id == original.event_id
+        assert restored.tenant_id is None
+        assert restored.is_superadmin is True
+        assert restored.event_type == "system.auth.login"


### PR DESCRIPTION
Closes #173

## Summary
- Introduce `TenantlessEvent` base model for system events without `tenant_id`
- Superadmin logins now publish to `events:system.auth.login` stream (separate from tenant events)
- Differentiated exception handling: `RedisError` → warning, programming errors → critical
- 16 new regression tests (unit + integration)

## Changes

| File | Change |
|------|--------|
| `app/event_schemas.py` | Add `TenantlessEvent(BaseEvent)` + `AuthSuperadminLoginEvent(TenantlessEvent)` |
| `app/modules/auth/service.py` | Branch on `user.is_superadmin` for correct event class; split `RedisError` vs `Exception` handling |
| `app/event_bus/bus.py` | Filter `None` values before XADD; route `system.auth.login` to auth handler |
| `tests/unit/test_event_schemas.py` | 10 new tests for TenantlessEvent + AuthSuperadminLoginEvent |
| `tests/unit/test_event_bus.py` | 2 new tests for None filtering |
| `tests/unit/test_event_bus_handler.py` | 3 new tests for system.auth.login dispatch |
| `tests/unit/test_auth_service_event_publish.py` | 5 new tests for branching + error handling |
| `tests/integration/test_auth_login_event_flow.py` | 1 new test for superadmin flow |

## Test Plan
- [x] All 752 tests pass (`uv run pytest`)
- [x] 16 new tests cover: TenantlessEvent validation, AuthSuperadminLoginEvent defaults, None serialization, dispatch routing, login branching, RedisError handling, programming error handling
- [x] No regressions in existing test suite