### PR TITLE
fix(llm): reuse httpx.AsyncClient for connection pooling

### DIFF
--- a/app/core/llm/providers.py
+++ b/app/core/llm/providers.py
@@ -63,6 +63,7 @@ class _BaseHTTPProvider:
         self._api_key = api_key
         self._model = model
         self._timeout = timeout
+        self._client = httpx.AsyncClient(timeout=httpx.Timeout(timeout))
 
     def _build_request(
         self,
@@ -113,8 +114,7 @@ class _BaseHTTPProvider:
         last_error: Exception | None = None
         for attempt in range(1, LLM_RETRY_MAX_ATTEMPTS + 1):
             try:
-                async with httpx.AsyncClient(timeout=httpx.Timeout(self._timeout)) as client:
-                    response = await client.post(url, json=payload, headers=headers)
+                response = await self._client.post(url, json=payload, headers=headers)
             except httpx.TimeoutException:
                 _llm_logger.warning(
                     "LLM timeout: provider=%s timeout=%ss",
@@ -221,6 +221,10 @@ class _BaseHTTPProvider:
 
         # Unreachable — keeps type-checkers happy
         raise LLMError("Unexpected: retry loop exited without returning or raising")
+
+    async def close(self) -> None:
+        """Close the underlying HTTP client and release connection pool."""
+        await self._client.aclose()
 
 
 class OpenAICompatProvider(_BaseHTTPProvider):

--- a/app/main.py
+++ b/app/main.py
@@ -152,6 +152,12 @@ async def lifespan(app: FastAPI):
     # shutdown forever.
     await drain_dlq_tasks(timeout=2.0)
     await close_pool()
+    # Close the LLM provider's HTTP connection pool (issue #194).
+    from app.core.llm import get_llm_provider
+    from app.core.llm.providers import _BaseHTTPProvider
+    provider = get_llm_provider()
+    if isinstance(provider, _BaseHTTPProvider):
+        await provider.close()
     logger.info("soc360.shutdown")
 
 def create_app() -> FastAPI:


### PR DESCRIPTION
Closes #194

## Summary

Create `httpx.AsyncClient` once in `_BaseHTTPProvider.__init__` and reuse across calls/retries. Previously a new client was created per request (and per retry), destroying connection pooling and forcing redundant TCP/TLS handshakes.

## Changes

| File | Change |
|------|--------|
| `app/core/llm/providers.py` | Reuse `self._client` instead of `async with httpx.AsyncClient()`; add `close()` method |
| `app/main.py` | Add LLM provider `close()` call in lifespan shutdown |

## Test Plan

- [x] LLM tests pass
- [x] Connection pool reused across calls