### PR TITLE
refactor(llm): move MockLLMProvider from production code to test doubles

### DIFF
--- a/app/core/llm/__init__.py
+++ b/app/core/llm/__init__.py
@@ -22,7 +22,6 @@ from app.core.llm.providers import (  # noqa: F401
     AnthropicProvider,
     GeminiProvider,
     LLMProvider,
-    MockLLMProvider,
     OpenAICompatProvider,
     _BaseHTTPProvider,
     llm_safe_complete,

--- a/app/core/llm/providers.py
+++ b/app/core/llm/providers.py
@@ -374,35 +374,6 @@ class GeminiProvider(_BaseHTTPProvider):
         return data["candidates"][0]["content"]["parts"][0]["text"]
 
 
-class MockLLMProvider:
-    """
-    Async test double for LLM providers.
-
-    Returns a pre-configured response after an optional delay.
-    No network calls are made. Satisfies the LLMProvider protocol
-    at runtime so it can be substituted for any concrete provider.
-    """
-
-    def __init__(
-        self,
-        response_text: str = "mock response",
-        delay_seconds: float = 0.0,
-    ) -> None:
-        self._response_text = response_text
-        self._delay_seconds = delay_seconds
-
-    async def complete(
-        self,
-        prompt: str,
-        max_tokens: int,
-        temperature: float,
-    ) -> str:
-        """Return the configured response text after the configured delay."""
-        if self._delay_seconds > 0:
-            await asyncio.sleep(self._delay_seconds)
-        return self._response_text
-
-
 async def llm_safe_complete(
     provider: "LLMProvider",
     prompt: str,

--- a/tests/llm_test_doubles.py
+++ b/tests/llm_test_doubles.py
@@ -1,0 +1,32 @@
+"""LLM test doubles — mock providers for unit tests."""
+from __future__ import annotations
+
+import asyncio
+
+
+class MockLLMProvider:
+    """Async test double for LLM providers.
+
+    Returns a pre-configured response after an optional delay.
+    No network calls are made. Satisfies the LLMProvider protocol
+    at runtime so it can be substituted for any concrete provider.
+    """
+
+    def __init__(
+        self,
+        response_text: str = "mock response",
+        delay_seconds: float = 0.0,
+    ) -> None:
+        self._response_text = response_text
+        self._delay_seconds = delay_seconds
+
+    async def complete(
+        self,
+        prompt: str,
+        max_tokens: int,
+        temperature: float,
+    ) -> str:
+        """Return the configured response text after the configured delay."""
+        if self._delay_seconds > 0:
+            await asyncio.sleep(self._delay_seconds)
+        return self._response_text


### PR DESCRIPTION
Closes #193

## Summary

Move `MockLLMProvider` from production code (`app/core/llm/providers.py`) to `tests/llm_test_doubles.py`. The class is a test double that should not be shipped with the application.

## Changes

| File | Change |
|------|--------|
| `app/core/llm/providers.py` | Remove MockLLMProvider class |
| `app/core/llm/__init__.py` | Remove MockLLMProvider re-export |
| `tests/llm_test_doubles.py` | New — MockLLMProvider lives here |

## Test Plan

- [x] LLM tests pass
- [x] MockLLMProvider no longer in production imports