### PR TITLE
fix(users): remove manual rollback inside session.begin() context manager

### DIFF
--- a/app/modules/users/service.py
+++ b/app/modules/users/service.py
@@ -81,7 +81,9 @@ async def create_user(data: UserCreate | UserInternalCreate, db: AsyncSession) -
         await db.flush()
     except IntegrityError as exc:
         if getattr(exc.orig, "pgcode", None) == "23505":
-            await db.rollback()
+            # No manual rollback — session.begin() context manager handles it.
+            # Calling db.rollback() here leaves the session inactive (SQLA 2.0+)
+            # causing InvalidRequestError on subsequent operations.
             raise UserError(
                 "El email ya está registrado", status_code=409
             ) from exc

--- a/tests/unit/test_users.py
+++ b/tests/unit/test_users.py
@@ -213,7 +213,8 @@ class TestUserService:
         assert exc_info.value.status_code == 409
         assert "email" in exc_info.value.detail.lower()
         mock_db.flush.assert_awaited_once()
-        mock_db.rollback.assert_awaited_once()
+        # No manual rollback — session.begin() context manager handles it.
+        mock_db.rollback.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_create_user_propagates_non_unique_integrity_error(self):
@@ -259,12 +260,15 @@ class TestUserService:
 
     @pytest.mark.asyncio
     async def test_create_user_rolls_back_failed_session_for_subsequent_create(self):
-        """After a 409, the session must be usable for a fresh non-duplicate insert.
+        """After a 409, the session remains usable for a fresh non-duplicate insert.
 
-        Regression: if `create_user` raises 409 without rolling back, the next
-        call against the same session raises `PendingRollbackError` because the
-        failed flush left the transaction in a broken state. This test enforces
-        that rollback runs so the session stays usable.
+        Regression guard: the old code called db.rollback() manually inside the
+        IntegrityError handler. This caused InvalidRequestError under SQLAlchemy
+        2.0+ because session.begin() context manager owns the transaction lifecycle.
+
+        The fix removes the manual rollback — the session.begin() context manager
+        rolls back automatically when the UserError propagates. This test verifies
+        that subsequent calls against the same session do not fail.
         """
         from app.modules.users import service
         from app.core.exceptions import UserError
@@ -316,10 +320,11 @@ class TestUserService:
             await service.create_user(data=data_dup, db=mock_db)
         assert exc_info.value.status_code == 409
 
-        # Second call must not raise PendingRollbackError — rollback must have run.
+        # Second call must not raise — session is usable after 409.
         result = await service.create_user(data=data_ok, db=mock_db)
         assert result is not None
-        mock_db.rollback.assert_awaited_once()
+        # No manual rollback — session.begin() context manager handles it.
+        mock_db.rollback.assert_not_awaited()
         assert mock_db.flush.await_count == 2
     
     @pytest.mark.asyncio

--- a/tests/unit/test_users.py
+++ b/tests/unit/test_users.py
@@ -169,12 +169,12 @@ class TestUserService:
 
     @pytest.mark.asyncio
     async def test_create_user_translates_unique_violation_to_409(self):
-        """create_user must translate asyncpg pgcode '23505' to UserError(409) and roll back.
+        """create_user must translate asyncpg pgcode '23505' to UserError(409).
 
         Regression for PR-B: the pre-check (`_is_email_taken`) can race a concurrent
         INSERT. When the flush hits the unique constraint, the raw asyncpg
-        `UniqueViolationError` (SQLSTATE 23505) must be surfaced as 409, and the
-        session must be rolled back to avoid `PendingRollbackError` on the next call.
+        `UniqueViolationError` (SQLSTATE 23505) must be surfaced as 409.
+        No manual rollback — session.begin() context manager handles it.
         """
         from app.modules.users import service
         from app.core.exceptions import UserError


### PR DESCRIPTION
## Linked Issue

Closes #252

## Summary

- Remove manual `db.rollback()` from `create_user` IntegrityError handler that conflicted with SQLAlchemy 2.0+'s `session.begin()` context manager
- The context manager now handles rollback automatically when the UserError propagates, preserving the same 409 behavior without session state corruption
- Update 2 tests that were asserting the old rollback behavior

## Changes

| File | Change |
|------|--------|
| `app/modules/users/service.py` | Removed `await db.rollback()` from IntegrityError handler (lines 80-88) |
| `tests/unit/test_users.py` | Updated 2 test assertions to verify rollback is NOT called manually |

## Test Plan

- [x] All 20 unit tests pass: `pytest tests/unit/test_users.py`
- [x] No manual rollback — session.begin() context manager handles it
- [x] Same 409 behavior preserved for duplicate email

## Contributor Checklist

- [x] Linked an approved issue (#252)
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers