### PR TITLE
fix(tests): replace over-mocked test_login_success with real integration test (#183)

### DIFF
--- a/tests/integration/test_auth_integration.py
+++ b/tests/integration/test_auth_integration.py
@@ -4,6 +4,7 @@ import pytest_asyncio
 from httpx import AsyncClient
 from unittest.mock import patch
 
+from app.core.config import settings
 from app.core.redis import get_redis
 from app.event_bus import EventBus
 from fakeredis.aioredis import FakeRedis
@@ -268,7 +269,7 @@ async def test_regular_user_login_real_path_updates_state_publishes_event_and_ro
         assert user.last_login_at != previous_last_login_at, "last_login_at must change"
 
         # --- Assert auth.login event in Redis stream ---
-        stream_name = "events:auth.login"
+        stream_name = f"{settings.EVENT_STREAM_PREFIX}:auth.login"
         stream_length = await fake_redis.xlen(stream_name)
         assert stream_length >= 1, (
             f"Expected at least 1 message in {stream_name}, "


### PR DESCRIPTION
## Summary

Remove  (7 nested  decorators testing mock orchestration, not login logic). Replace with one real-path integration test through .

## What changed

| File | Action |
|------|--------|
|  | Deleted  (40 lines of brittle mocks) |
|  | Added  (81 lines) |

## New test asserts

- HTTP 200 with non-empty 
-  cookie set
-  updated in DB
-  event published to Redis stream (with , no raw email)
- Refresh token rotation (second token differs from first)

## Why

The deleted test patched every internal helper in  and only verified mocks were called. Real bugs (RLS bootstrap, event publish,  mutation) were never tested. The new integration test exercises the real code path.

## Verification

- Unit tests: 31/31 pass (deleted test confirmed gone)
- Integration test: collects correctly; requires PostgreSQL + Redis in CI to execute
- Changed lines: 121 (well under 400-line budget)

Closes #183