### PR TITLE
fix(security): add extra='forbid' to UserUpdate schema (#225)

### DIFF
--- a/app/modules/users/schemas.py
+++ b/app/modules/users/schemas.py
@@ -59,6 +59,8 @@ class UserInternalCreate(UserCreate):
 
 
 class UserUpdate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     email: EmailStr | None = Field(None, max_length=255)
     full_name: str | None = Field(None, min_length=1, max_length=255)
     role: RoleEnum | None = None

--- a/tests/unit/test_users.py
+++ b/tests/unit/test_users.py
@@ -74,6 +74,16 @@ class TestUserSchemas:
         valid = UserUpdate(full_name="New Name")
         assert valid.full_name == "New Name"
 
+    def test_user_update_rejects_extra_fields(self):
+        """Test UserUpdate rejects unknown fields (mass assignment prevention)."""
+        from app.modules.users.schemas import UserUpdate
+
+        with pytest.raises(ValueError, match="Extra inputs"):
+            UserUpdate(full_name="New Name", is_superadmin=True)
+
+        with pytest.raises(ValueError, match="Extra inputs"):
+            UserUpdate(full_name="New Name", tenant_id="should-not-pass")
+
 
 class TestUserApiValidation:
     """Test user API request validation without database dependencies."""


### PR DESCRIPTION
Closes #225

## What
UserUpdate was the only mutation schema without `extra='forbid'` in `model_config`, creating a mass assignment inconsistency with UserCreate, TenantCreate, and TenantUpdate.

## Fix
- Add `model_config = ConfigDict(extra='forbid')` to `UserUpdate`
- Add test verifying extra fields (`is_superadmin`, `tenant_id`) are rejected

## Verification
- 539 unit tests pass
- New test confirms extra fields raise `ValueError('Extra inputs')`