### PR TITLE
fix(scans): enforce tenant-scoped asset references

### DIFF
--- a/app/modules/scans/models.py
+++ b/app/modules/scans/models.py
@@ -3,7 +3,16 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import CheckConstraint, DateTime, ForeignKey, String, UniqueConstraint, func
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    ForeignKeyConstraint,
+    Index,
+    String,
+    UniqueConstraint,
+    func,
+)
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -24,9 +33,7 @@ class Scan(Base):
     )
     asset_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
-        ForeignKey("assets.id", ondelete="CASCADE"),
         nullable=False,
-        index=True,
     )
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     scan_type: Mapped[str] = mapped_column(String(50), nullable=False)
@@ -62,6 +69,13 @@ class Scan(Base):
             name="chk_scans_status",
         ),
         UniqueConstraint("id", "tenant_id", name="uq_scans_id_tenant_id"),
+        ForeignKeyConstraint(
+            ["asset_id", "tenant_id"],
+            ["assets.id", "assets.tenant_id"],
+            ondelete="CASCADE",
+            name="fk_scans_asset_tenant",
+        ),
+        Index("ix_scans_asset_tenant", "asset_id", "tenant_id"),
     )
 
     def __repr__(self) -> str:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
 services:
-  
   postgres:
     image: postgres:16-alpine
     container_name: soc360_postgres
@@ -21,7 +20,25 @@ services:
       timeout: 6s
       retries: 5
     restart: unless-stopped
-  
+
+  postgres-test:
+    image: postgres:16-alpine
+    container_name: soc360_postgres_test
+    profiles: [test]
+    # Only starts with: docker compose --profile test up -d
+    environment:
+      POSTGRES_USER: soc360_migration
+      POSTGRES_PASSWORD: MigSoc360Pass2005futureDev
+      POSTGRES_DB: soc360_test
+    ports:
+      - "5434:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U soc360_migration -d soc360_test"]
+      interval: 10s
+      timeout: 6s
+      retries: 5
+    restart: unless-stopped
+
   redis:
     image: redis:7-alpine
     container_name: soc360_redis

--- a/migrations/versions/20260710_1600_fix_scans_asset_tenant_fk_c1d2e3f4a5b6.py
+++ b/migrations/versions/20260710_1600_fix_scans_asset_tenant_fk_c1d2e3f4a5b6.py
@@ -1,0 +1,48 @@
+"""enforce tenant-scoped scan asset references
+
+Revision ID: c1d2e3f4a5b6
+Revises: bfca7016cbb7
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "c1d2e3f4a5b6"
+down_revision: Union[str, None] = "bfca7016cbb7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        DO $$
+        DECLARE mismatch_count bigint;
+        BEGIN
+            SELECT COUNT(*) INTO mismatch_count
+            FROM scans s JOIN assets a ON a.id = s.asset_id
+            WHERE s.tenant_id <> a.tenant_id;
+            IF mismatch_count > 0 THEN
+                RAISE EXCEPTION 'cross-tenant scan/asset rows detected: %', mismatch_count;
+            END IF;
+        END $$;
+    """)
+    op.create_index("ix_scans_asset_tenant", "scans", ["asset_id", "tenant_id"])
+    op.execute("""
+        ALTER TABLE scans ADD CONSTRAINT fk_scans_asset_tenant
+        FOREIGN KEY (asset_id, tenant_id) REFERENCES assets (id, tenant_id)
+        ON DELETE CASCADE NOT VALID
+    """)
+    op.execute("ALTER TABLE scans VALIDATE CONSTRAINT fk_scans_asset_tenant")
+    op.drop_constraint("scans_asset_id_fkey", "scans", type_="foreignkey")
+    op.drop_index("ix_scans_asset_id", table_name="scans")
+
+
+def downgrade() -> None:
+    op.drop_constraint("fk_scans_asset_tenant", "scans", type_="foreignkey")
+    op.drop_index("ix_scans_asset_tenant", table_name="scans")
+    op.create_index("ix_scans_asset_id", "scans", ["asset_id"], unique=False)
+    op.create_foreign_key(
+        "scans_asset_id_fkey", "scans", "assets", ["asset_id"], ["id"], ondelete="CASCADE"
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import bcrypt
 import pytest
 import pytest_asyncio
 from httpx import AsyncClient, ASGITransport
-from sqlalchemy import text
+from sqlalchemy import text, make_url
 from sqlalchemy.ext.asyncio import (
     AsyncSession,
     async_sessionmaker,
@@ -17,8 +17,14 @@ from sqlalchemy.pool import NullPool
 from fakeredis.aioredis import FakeRedis
 
 os.environ.setdefault("ENVIRONMENT", "development")
-os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://soc360_app:AppSoc360Pass2000futureDev@localhost:5433/soc360_test")
-os.environ.setdefault("DATABASE_URL_MIGRATION", "postgresql+asyncpg://soc360_migration:MigSoc360Pass2005futureDev@localhost:5433/soc360_test")
+os.environ.setdefault(
+    "DATABASE_URL",
+    "postgresql+asyncpg://soc360_app:AppSoc360Pass2000futureDev@localhost:5434/soc360_test",
+)
+os.environ.setdefault(
+    "DATABASE_URL_MIGRATION",
+    "postgresql+asyncpg://soc360_migration:MigSoc360Pass2005futureDev@localhost:5434/soc360_test",
+)
 os.environ.setdefault(
     "SECRET_KEY",
     "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz"
@@ -38,13 +44,13 @@ from app.dependencies import get_db, get_db_with_tenant
 from app.modules.users.models import User
 from app.modules.tenants.models import Tenant
 
-TENANT_A_ID  = "11111111-1111-1111-1111-111111111111"
-TENANT_B_ID  = "22222222-2222-2222-2222-222222222222"
+TENANT_A_ID = "11111111-1111-1111-1111-111111111111"
+TENANT_B_ID = "22222222-2222-2222-2222-222222222222"
 SUPERADMIN_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
-ADMIN_A_ID    = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
-ANALYST_A_ID  = "cccccccc-cccc-cccc-cccc-cccccccccccc"
-VIEWER_A_ID   = "dddddddd-dddd-dddd-dddd-dddddddddddd"
-ADMIN_B_ID    = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee"
+ADMIN_A_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+ANALYST_A_ID = "cccccccc-cccc-cccc-cccc-cccccccccccc"
+VIEWER_A_ID = "dddddddd-dddd-dddd-dddd-dddddddddddd"
+ADMIN_B_ID = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee"
 
 TEST_DATABASE_URL = os.environ["DATABASE_URL"]
 MIGRATION_DATABASE_URL = os.environ["DATABASE_URL_MIGRATION"]
@@ -65,19 +71,82 @@ def prepare_database():
     from app.modules.users.models import User  # noqa: F401
     from app.modules.vulnerabilities.models import Vulnerability  # noqa: F401
 
+    async def _ensure_app_role() -> None:
+        """Idempotently create the soc360_app login role for test GRANTs.
+
+        The role is created outside the schema transaction via a raw asyncpg
+        connection to avoid any transactional-DDL edge cases with CREATE ROLE.
+        Safe for repeated test runs (DO $$ IF NOT EXISTS).
+        """
+        import asyncpg
+
+        parsed = make_url(MIGRATION_DATABASE_URL)
+        if (
+            not parsed.username
+            or not parsed.password
+            or not parsed.host
+            or not parsed.port
+            or not parsed.database
+        ):
+            raise RuntimeError(
+                f"MIGRATION_DATABASE_URL is incomplete: missing one or more "
+                f"required URL components (user, password, host, port, database). "
+                f"Got: host={parsed.host}, port={parsed.port}, database={parsed.database}"
+            )
+        conn = await asyncpg.connect(
+            user=parsed.username,
+            password=parsed.password,
+            host=parsed.host,
+            port=parsed.port,
+            database=parsed.database,
+        )
+        try:
+            await conn.execute("""
+                DO $$
+                BEGIN
+                    IF NOT EXISTS (
+                        SELECT FROM pg_catalog.pg_roles
+                        WHERE rolname = 'soc360_app'
+                    ) THEN
+                        CREATE ROLE soc360_app
+                            WITH LOGIN PASSWORD 'AppSoc360Pass2000futureDev';
+                    END IF;
+                END
+                $$;
+            """)
+        finally:
+            await conn.close()
+
     async def _setup() -> None:
-        engine = create_async_engine(MIGRATION_DATABASE_URL, echo=False, poolclass=NullPool)
+        await _ensure_app_role()
+        engine = create_async_engine(
+            MIGRATION_DATABASE_URL, echo=False, poolclass=NullPool
+        )
         async with engine.begin() as conn:
             await conn.run_sync(Base.metadata.drop_all)
             await conn.run_sync(Base.metadata.create_all)
-            await conn.execute(text("GRANT ALL ON ALL TABLES IN SCHEMA public TO soc360_app"))
-            await conn.execute(text("GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO soc360_app"))
-            await conn.execute(text("ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO soc360_app"))
-            await conn.execute(text("ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO soc360_app"))
+            await conn.execute(
+                text("GRANT ALL ON ALL TABLES IN SCHEMA public TO soc360_app")
+            )
+            await conn.execute(
+                text("GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO soc360_app")
+            )
+            await conn.execute(
+                text(
+                    "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO soc360_app"
+                )
+            )
+            await conn.execute(
+                text(
+                    "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO soc360_app"
+                )
+            )
         await engine.dispose()
 
     async def _teardown() -> None:
-        engine = create_async_engine(MIGRATION_DATABASE_URL, echo=False, poolclass=NullPool)
+        engine = create_async_engine(
+            MIGRATION_DATABASE_URL, echo=False, poolclass=NullPool
+        )
         async with engine.begin() as conn:
             await conn.run_sync(Base.metadata.drop_all)
         await engine.dispose()
@@ -110,54 +179,101 @@ async def seed_data(db_session: AsyncSession):
     # Idempotent tenant inserts — concurrency tests may have already committed these
     await db_session.execute(text("SET LOCAL app.is_superadmin = 'true'"))
     await db_session.execute(
-        pg_insert(Tenant).values(
-            id=UUID(TENANT_A_ID), name="Empresa Alpha", slug="empresa-alpha",
-            plan="starter", is_active=True, max_assets=50,
-        ).on_conflict_do_nothing(index_elements=["id"])
+        pg_insert(Tenant)
+        .values(
+            id=UUID(TENANT_A_ID),
+            name="Empresa Alpha",
+            slug="empresa-alpha",
+            plan="starter",
+            is_active=True,
+            max_assets=50,
+        )
+        .on_conflict_do_nothing(index_elements=["id"])
     )
     await db_session.execute(
-        pg_insert(Tenant).values(
-            id=UUID(TENANT_B_ID), name="Empresa Beta", slug="empresa-beta",
-            plan="free", is_active=True, max_assets=10,
-        ).on_conflict_do_nothing(index_elements=["id"])
+        pg_insert(Tenant)
+        .values(
+            id=UUID(TENANT_B_ID),
+            name="Empresa Beta",
+            slug="empresa-beta",
+            plan="free",
+            is_active=True,
+            max_assets=10,
+        )
+        .on_conflict_do_nothing(index_elements=["id"])
     )
     await db_session.flush()
 
     # Idempotent user inserts
     await db_session.execute(
-        pg_insert(User).values(
-            id=UUID(SUPERADMIN_ID), tenant_id=None,
-            email="superadmin@soc360.test", hashed_password=_seed_password_hash("SuperAdmin123!"),
-            full_name="Super Admin", role="superadmin", is_active=True, is_superadmin=True,
-        ).on_conflict_do_nothing(index_elements=["id"])
+        pg_insert(User)
+        .values(
+            id=UUID(SUPERADMIN_ID),
+            tenant_id=None,
+            email="superadmin@soc360.test",
+            hashed_password=_seed_password_hash("SuperAdmin123!"),
+            full_name="Super Admin",
+            role="superadmin",
+            is_active=True,
+            is_superadmin=True,
+        )
+        .on_conflict_do_nothing(index_elements=["id"])
     )
     await db_session.execute(
-        pg_insert(User).values(
-            id=UUID(ADMIN_A_ID), tenant_id=UUID(TENANT_A_ID),
-            email="admin@alpha.test", hashed_password=_seed_password_hash("AdminAlpha123!"),
-            full_name="Admin Alpha", role="admin", is_active=True, is_superadmin=False,
-        ).on_conflict_do_nothing(index_elements=["id"])
+        pg_insert(User)
+        .values(
+            id=UUID(ADMIN_A_ID),
+            tenant_id=UUID(TENANT_A_ID),
+            email="admin@alpha.test",
+            hashed_password=_seed_password_hash("AdminAlpha123!"),
+            full_name="Admin Alpha",
+            role="admin",
+            is_active=True,
+            is_superadmin=False,
+        )
+        .on_conflict_do_nothing(index_elements=["id"])
     )
     await db_session.execute(
-        pg_insert(User).values(
-            id=UUID(ANALYST_A_ID), tenant_id=UUID(TENANT_A_ID),
-            email="analyst@alpha.test", hashed_password=_seed_password_hash("AnalystAlpha123!"),
-            full_name="Analyst Alpha", role="analyst", is_active=True, is_superadmin=False,
-        ).on_conflict_do_nothing(index_elements=["id"])
+        pg_insert(User)
+        .values(
+            id=UUID(ANALYST_A_ID),
+            tenant_id=UUID(TENANT_A_ID),
+            email="analyst@alpha.test",
+            hashed_password=_seed_password_hash("AnalystAlpha123!"),
+            full_name="Analyst Alpha",
+            role="analyst",
+            is_active=True,
+            is_superadmin=False,
+        )
+        .on_conflict_do_nothing(index_elements=["id"])
     )
     await db_session.execute(
-        pg_insert(User).values(
-            id=UUID(VIEWER_A_ID), tenant_id=UUID(TENANT_A_ID),
-            email="viewer@alpha.test", hashed_password=_seed_password_hash("ViewerAlpha123!"),
-            full_name="Viewer Alpha", role="viewer", is_active=True, is_superadmin=False,
-        ).on_conflict_do_nothing(index_elements=["id"])
+        pg_insert(User)
+        .values(
+            id=UUID(VIEWER_A_ID),
+            tenant_id=UUID(TENANT_A_ID),
+            email="viewer@alpha.test",
+            hashed_password=_seed_password_hash("ViewerAlpha123!"),
+            full_name="Viewer Alpha",
+            role="viewer",
+            is_active=True,
+            is_superadmin=False,
+        )
+        .on_conflict_do_nothing(index_elements=["id"])
     )
     await db_session.execute(
-        pg_insert(User).values(
-            id=UUID(ADMIN_B_ID), tenant_id=UUID(TENANT_B_ID),
-            email="admin@beta.test", hashed_password=_seed_password_hash("AdminBeta123!"),
-            full_name="Admin Beta", role="admin", is_active=True, is_superadmin=False,
-        ).on_conflict_do_nothing(index_elements=["id"])
+        pg_insert(User)
+        .values(
+            id=UUID(ADMIN_B_ID),
+            tenant_id=UUID(TENANT_B_ID),
+            email="admin@beta.test",
+            hashed_password=_seed_password_hash("AdminBeta123!"),
+            full_name="Admin Beta",
+            role="admin",
+            is_active=True,
+            is_superadmin=False,
+        )
+        .on_conflict_do_nothing(index_elements=["id"])
     )
     await db_session.flush()
 
@@ -171,9 +287,13 @@ async def seed_data(db_session: AsyncSession):
     admin_b = await db_session.get(User, UUID(ADMIN_B_ID))
 
     return {
-        "tenant_a": tenant_a, "tenant_b": tenant_b,
-        "superadmin": superadmin, "admin_a": admin_a,
-        "analyst_a": analyst_a, "viewer_a": viewer_a, "admin_b": admin_b,
+        "tenant_a": tenant_a,
+        "tenant_b": tenant_b,
+        "superadmin": superadmin,
+        "admin_a": admin_a,
+        "analyst_a": analyst_a,
+        "viewer_a": viewer_a,
+        "admin_b": admin_b,
     }
 
 
@@ -215,37 +335,46 @@ async def _get_token(client: AsyncClient, email: str, password: str) -> str:
 async def superadmin_token(client: AsyncClient, seed_data) -> str:
     return await _get_token(client, "superadmin@soc360.test", "SuperAdmin123!")
 
+
 @pytest_asyncio.fixture
 async def admin_a_token(client: AsyncClient, seed_data) -> str:
     return await _get_token(client, "admin@alpha.test", "AdminAlpha123!")
+
 
 @pytest_asyncio.fixture
 async def analyst_a_token(client: AsyncClient, seed_data) -> str:
     return await _get_token(client, "analyst@alpha.test", "AnalystAlpha123!")
 
+
 @pytest_asyncio.fixture
 async def viewer_a_token(client: AsyncClient, seed_data) -> str:
     return await _get_token(client, "viewer@alpha.test", "ViewerAlpha123!")
+
 
 @pytest_asyncio.fixture
 async def admin_b_token(client: AsyncClient, seed_data) -> str:
     return await _get_token(client, "admin@beta.test", "AdminBeta123!")
 
+
 @pytest_asyncio.fixture
 async def superadmin_headers(superadmin_token: str) -> dict:
     return {"Authorization": f"Bearer {superadmin_token}"}
+
 
 @pytest_asyncio.fixture
 async def admin_a_headers(admin_a_token: str) -> dict:
     return {"Authorization": f"Bearer {admin_a_token}"}
 
+
 @pytest_asyncio.fixture
 async def analyst_a_headers(analyst_a_token: str) -> dict:
     return {"Authorization": f"Bearer {analyst_a_token}"}
 
+
 @pytest_asyncio.fixture
 async def viewer_a_headers(viewer_a_token: str) -> dict:
     return {"Authorization": f"Bearer {viewer_a_token}"}
+
 
 @pytest_asyncio.fixture
 async def admin_b_headers(admin_b_token: str) -> dict:
@@ -256,19 +385,23 @@ async def admin_b_headers(admin_b_token: str) -> dict:
 # Singleton isolation — reset module-level singletons between tests
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture(autouse=True)
 def _reset_event_bus_singleton():
     """Reset the _event_bus singleton before/after each test for isolation."""
     import app.dependencies.event_deps
+
     app.dependencies.event_deps._event_bus = None
     yield
     import app.dependencies.event_deps
+
     app.dependencies.event_deps._event_bus = None
 
 
 # ---------------------------------------------------------------------------
 # Concurrency test infrastructure — real pooled connections for parallel tests
 # ---------------------------------------------------------------------------
+
 
 @pytest_asyncio.fixture(scope="function")
 async def pooled_engine():

--- a/tests/integration/test_f2_tenant_isolation.py
+++ b/tests/integration/test_f2_tenant_isolation.py
@@ -4,7 +4,7 @@ import uuid
 from uuid import UUID
 
 import pytest
-from sqlalchemy import text
+from sqlalchemy import select, text
 from sqlalchemy.exc import IntegrityError
 
 from app.modules.assets.models import Asset
@@ -88,3 +88,75 @@ async def test_report_rejects_cross_tenant_asset(
         await db_session.flush()
 
     await db_session.rollback()
+
+
+async def test_scan_rejects_cross_tenant_asset(db_session, seed_data):
+    """DB must reject a scan whose tenant does not match its asset's tenant."""
+    await _enable_superadmin(db_session)
+    tenant_a = UUID(TENANT_A_ID)
+    tenant_b = UUID(TENANT_B_ID)
+    asset_b = Asset(
+        id=uuid.uuid4(), tenant_id=tenant_b, name="asset-b", asset_type="host"
+    )
+    db_session.add(asset_b)
+    await db_session.flush()
+    db_session.add(
+        Scan(
+            id=uuid.uuid4(),
+            tenant_id=tenant_a,
+            asset_id=asset_b.id,
+            name="cross-tenant scan",
+            scan_type="vulnerability",
+        )
+    )
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+    await db_session.rollback()
+
+
+async def test_scan_rejects_cross_tenant_asset_reassignment(db_session, seed_data):
+    """DB must reject updating a scan's asset_id to another tenant's asset."""
+    await _enable_superadmin(db_session)
+    tenant_a = UUID(TENANT_A_ID)
+    tenant_b = UUID(TENANT_B_ID)
+    asset_a = Asset(
+        id=uuid.uuid4(), tenant_id=tenant_a, name="asset-a", asset_type="host"
+    )
+    asset_b = Asset(
+        id=uuid.uuid4(), tenant_id=tenant_b, name="asset-b", asset_type="host"
+    )
+    scan = Scan(
+        id=uuid.uuid4(),
+        tenant_id=tenant_a,
+        asset_id=asset_a.id,
+        name="reassign-scan",
+        scan_type="vulnerability",
+    )
+    db_session.add_all([asset_a, asset_b, scan])
+    await db_session.flush()
+    scan.asset_id = asset_b.id
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+    await db_session.rollback()
+
+
+async def test_scan_same_tenant_asset_and_cascade(db_session, seed_data):
+    """Same-tenant scans remain valid and cascade when their asset is deleted."""
+    await _enable_superadmin(db_session)
+    tenant_a = UUID(TENANT_A_ID)
+    asset = Asset(
+        id=uuid.uuid4(), tenant_id=tenant_a, name="asset-a", asset_type="host"
+    )
+    scan = Scan(
+        id=uuid.uuid4(),
+        tenant_id=tenant_a,
+        asset_id=asset.id,
+        name="same-tenant scan",
+        scan_type="vulnerability",
+    )
+    db_session.add_all([asset, scan])
+    await db_session.flush()
+    await db_session.delete(asset)
+    await db_session.flush()
+    remaining_scan = await db_session.scalar(select(Scan).where(Scan.id == scan.id))
+    assert remaining_scan is None

--- a/tests/sdd/test_uv_migration.py
+++ b/tests/sdd/test_uv_migration.py
@@ -90,7 +90,9 @@ def test_uv_lock_exists_and_is_tracked():
 
 
 def test_requirements_txt_is_removed_and_pins_moved_to_pyproject():
-    assert not (ROOT / "requirements.txt").exists(), "requirements.txt must be removed in PR-3"
+    assert not (
+        ROOT / "requirements.txt"
+    ).exists(), "requirements.txt must be removed in PR-3"
 
     with (ROOT / "pyproject.toml").open("rb") as f:
         deps = tomllib.load(f)["project"]["dependencies"]
@@ -117,7 +119,9 @@ def test_requirements_txt_is_removed_and_pins_moved_to_pyproject():
 
 
 def test_requirements_dev_is_removed_and_dev_pins_moved_to_pyproject():
-    assert not (ROOT / "requirements-dev.txt").exists(), "requirements-dev.txt must be removed in PR-3"
+    assert not (
+        ROOT / "requirements-dev.txt"
+    ).exists(), "requirements-dev.txt must be removed in PR-3"
 
     with (ROOT / "pyproject.toml").open("rb") as f:
         dev = tomllib.load(f)["project"]["optional-dependencies"]["dev"]
@@ -131,7 +135,9 @@ def test_requirements_dev_is_removed_and_dev_pins_moved_to_pyproject():
         "fakeredis==2.34.1",
     ]
     for pin in dev_pins:
-        assert pin in dev, f"{pin} must be preserved in pyproject.toml dev optional dependencies"
+        assert (
+            pin in dev
+        ), f"{pin} must be preserved in pyproject.toml dev optional dependencies"
 
 
 def test_ci_workflow_has_uv_job_only():
@@ -144,11 +150,20 @@ def test_ci_workflow_has_uv_job_only():
             continue
         if in_jobs and line and not line.startswith(" "):
             break
-        if in_jobs and line.startswith("  ") and not line.startswith("    ") and line.rstrip().endswith(":"):
+        if (
+            in_jobs
+            and line.startswith("  ")
+            and not line.startswith("    ")
+            and line.rstrip().endswith(":")
+        ):
             job_ids.append(line.split(":", 1)[0].strip())
 
-    assert job_ids == ["test"], f"CI must contain only the canonical uv test job, found: {job_ids}"
-    assert "pip install -r requirements-dev.txt" not in ci_text, "Legacy pip install step must be removed"
+    assert job_ids == [
+        "test"
+    ], f"CI must contain only the canonical uv test job, found: {job_ids}"
+    assert (
+        "pip install -r requirements-dev.txt" not in ci_text
+    ), "Legacy pip install step must be removed"
     assert "astral-sh/setup-uv@v4" in ci_text
     assert "uv lock --check" in ci_text, "CI must verify uv.lock is fresh"
     assert "uv sync --frozen --extra dev" in ci_text
@@ -170,7 +185,9 @@ def test_ci_uv_job_has_celery_help_step():
 
 def test_uv_run_celery_help_runs():
     if shutil.which("uv") is None:
-        pytest.skip("uv CLI is unavailable; this runtime smoke is covered by the test-uv CI job")
+        pytest.skip(
+            "uv CLI is unavailable; this runtime smoke is covered by the test-uv CI job"
+        )
 
     result = subprocess.run(
         ["uv", "run", "celery", "--help"],
@@ -180,7 +197,9 @@ def test_uv_run_celery_help_runs():
         check=False,
     )
     assert result.returncode == 0, f"uv run celery --help failed: {result.stderr}"
-    assert "Celery command entrypoint" in result.stdout, "Celery CLI usage must be printed"
+    assert (
+        "Celery command entrypoint" in result.stdout
+    ), "Celery CLI usage must be printed"
 
 
 def test_readme_has_uv_quickstart_block():
@@ -201,13 +220,19 @@ def test_no_dockerfile_and_compose_has_only_infrastructure_services():
     assert compose_path.exists()
     compose_text = compose_path.read_text()
     # PR-1 must not introduce any application image or build context.
-    assert "build:" not in compose_text, "docker-compose.yml must not contain a build context"
-    assert "Dockerfile" not in compose_text, "docker-compose.yml must not reference a Dockerfile"
+    assert (
+        "build:" not in compose_text
+    ), "docker-compose.yml must not contain a build context"
+    assert (
+        "Dockerfile" not in compose_text
+    ), "docker-compose.yml must not reference a Dockerfile"
     services = [
         line.split(":")[0].strip()
         for line in compose_text.splitlines()
-        if line.rstrip().endswith(":") and line.startswith("  ") and not line.startswith("    ")
+        if line.rstrip().endswith(":")
+        and line.startswith("  ")
+        and not line.startswith("    ")
     ]
-    assert sorted(services) == ["postgres", "redis"], (
-        f"docker-compose.yml should only define postgres and redis services, found: {services}"
-    )
+    assert (
+        sorted(services) == ["postgres", "postgres-test", "redis"]
+    ), f"docker-compose.yml should only define infrastructure services (postgres, postgres-test, redis), found: {services}"

--- a/tests/unit/test_f2_migration_constraints.py
+++ b/tests/unit/test_f2_migration_constraints.py
@@ -56,6 +56,48 @@ def migration_sql() -> str:
     return result.stdout.lower()
 
 
+@pytest.fixture(scope="module")
+def migration_downgrade_sql() -> str:
+    """Generate the offline SQL for downgrading the last revision (c1d2e3f4a5b6 → bfca7016cbb7).
+
+    This proves the downgrade restores the original simple FK and index.
+    """
+    project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    env = {
+        **os.environ,
+        "PYTHONPATH": project_root,
+    }
+
+    if "DATABASE_URL_MIGRATION" not in env:
+        env["DATABASE_URL_MIGRATION"] = str(
+            URL.create(
+                "postgresql+asyncpg",
+                username="test",
+                password="test",
+                host="localhost",
+                port=5433,
+                database="soc360_test",
+            )
+        )
+
+    result = subprocess.run(
+        [sys.executable, "-m", "alembic", "downgrade", "c1d2e3f4a5b6:bfca7016cbb7", "--sql"],
+        cwd=project_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"Alembic offline downgrade SQL generation failed (exit {result.returncode}):\n"
+            f"{result.stderr}"
+        )
+
+    return result.stdout.lower()
+
+
 class TestCompositeForeignKeyMigration:
     """DB-free checks that R2 migration declares composite tenant-scoped FKs."""
 
@@ -84,3 +126,17 @@ class TestCompositeForeignKeyMigration:
             r"foreign key\(asset_id, tenant_id\) references assets \(id, tenant_id\)",
             migration_sql,
         )
+
+    def test_scans_composite_fk_rollout_contract(self, migration_sql: str) -> None:
+        assert "fk_scans_asset_tenant" in migration_sql
+        assert "ix_scans_asset_tenant" in migration_sql
+        assert "not valid" in migration_sql
+        assert "validate constraint fk_scans_asset_tenant" in migration_sql
+        assert "scans_asset_id_fkey" in migration_sql
+        assert "cross-tenant scan/asset rows" in migration_sql
+
+    def test_scans_composite_fk_downgrade_contract(self, migration_downgrade_sql: str) -> None:
+        assert "drop constraint fk_scans_asset_tenant" in migration_downgrade_sql
+        assert "drop index ix_scans_asset_tenant" in migration_downgrade_sql
+        assert "create index ix_scans_asset_id" in migration_downgrade_sql
+        assert "scans_asset_id_fkey" in migration_downgrade_sql

--- a/tests/unit/test_f2_models.py
+++ b/tests/unit/test_f2_models.py
@@ -168,12 +168,29 @@ class TestScanModel:
 
     def test_fk_columns(self) -> None:
         """Verify foreign keys point to expected parent tables."""
-        fks = {
-            fk.column.table.name: fk.parent.name
+        pairs = {
+            (fk.column.table.name, fk.parent.name)
             for fk in Scan.__table__.foreign_keys
         }
-        assert fks["tenants"] == "tenant_id"
-        assert fks["assets"] == "asset_id"
+        assert ("tenants", "tenant_id") in pairs
+        assert ("assets", "asset_id") in pairs
+        assert ("assets", "tenant_id") in pairs
+
+    def test_composite_fk_constraint_exists(self) -> None:
+        constraint = next(
+            c for c in Scan.__table__.constraints
+            if isinstance(c, ForeignKeyConstraint)
+            and c.name == "fk_scans_asset_tenant"
+        )
+        assert [column.name for column in constraint.columns] == ["asset_id", "tenant_id"]
+        assert [element.target_fullname for element in constraint.elements] == [
+            "assets.id", "assets.tenant_id"
+        ]
+        assert constraint.ondelete == "CASCADE"
+
+    def test_composite_asset_index_exists(self) -> None:
+        index = next(i for i in Scan.__table__.indexes if i.name == "ix_scans_asset_tenant")
+        assert [column.name for column in index.columns] == ["asset_id", "tenant_id"]
 
     def test_repr_format(self) -> None:
         scan = Scan(


### PR DESCRIPTION
Closes #192

## Type

- [x] Bug fix

## Summary

- Enforce tenant-scoped Scan-to-Asset integrity with a composite foreign key.
- Add a safe Alembic migration with data validation and downgrade coverage.
- Isolate PostgreSQL-backed tests behind the explicit Docker Compose `test` profile.

## Changes

| File | Change |
|------|--------|
| `app/modules/scans/models.py` | Replace the simple asset foreign key with a tenant-scoped composite constraint. |
| `migrations/versions/20260710_1600_fix_scans_asset_tenant_fk_c1d2e3f4a5b6.py` | Validate existing data and migrate the Scan foreign key/index safely. |
| `docker-compose.yml` | Add the isolated `postgres-test` service on port 5434 under profile `test`. |
| `tests/conftest.py` | Point tests to the isolated database and create the application test role idempotently. |
| `tests/integration/test_f2_tenant_isolation.py` | Cover cross-tenant rejection, reassignment, same-tenant behavior, and cascade deletion. |
| `tests/unit/test_f2_models.py` | Assert the composite Scan foreign-key contract. |
| `tests/unit/test_f2_migration_constraints.py` | Verify upgrade and downgrade SQL contracts. |
| `tests/sdd/test_uv_migration.py` | Allow the additional infrastructure-only Compose service. |

## Test Plan

- [x] `docker compose --profile test config`
- [x] `uv run pytest tests/sdd/test_uv_migration.py -v` — 14 passed
- [x] `uv run pytest tests/test_tenants.py -v` — 35 passed
- [x] Repeated tenant suite — 35 passed; role setup is idempotent
- [x] Full unit suite from SDD verification — 548 passed, 1 skipped, 2 xfailed
- [x] PostgreSQL tenant-isolation integration scenarios — 5 passed

## Review Notes

- **Size exception:** 534 changed lines. The maintainer explicitly approved a single-PR `size:exception` instead of splitting the FK fix and its isolated test infrastructure.
- Test credentials are intentionally local/test-only. Do not expose port 5434 beyond the developer host.
- Automated startup/wait/cleanup for `postgres-test` is intentionally deferred to a separate follow-up.

## Contributor Checklist

- [x] Linked approved issue #192
- [x] Added exactly one `type:*` label: `type:bug`
- [x] Added maintainer-approved `size:exception`
- [x] Tests aligned with behavior changes
- [x] Conventional commit used
- [x] No AI attribution or `Co-Authored-By` trailers
