### PR TITLE
fix(database): restore FK/user indexes and enforce RLS isolation (#263)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,12 @@ jobs:
         image: postgres:16-alpine
         env:
           POSTGRES_DB: soc360_pymes_test
-          POSTGRES_USER: soc360_app
+          POSTGRES_USER: soc360_migration
           POSTGRES_PASSWORD: soc360_test_password
         ports:
           - 5432:5432
         options: >-
-          --health-cmd "pg_isready -U soc360_app -d soc360_pymes_test"
+          --health-cmd "pg_isready -U soc360_migration -d soc360_pymes_test"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
@@ -40,11 +40,11 @@ jobs:
 
     env:
       ENVIRONMENT: development
-      POSTGRES_USER: soc360_app
+      POSTGRES_USER: soc360_migration
       POSTGRES_PASSWORD: soc360_test_password
       POSTGRES_DB: soc360_pymes_test
       DATABASE_URL: postgresql+asyncpg://soc360_app:soc360_test_password@localhost:5432/soc360_pymes_test
-      DATABASE_URL_MIGRATION: postgresql+asyncpg://soc360_app:soc360_test_password@localhost:5432/soc360_pymes_test
+      DATABASE_URL_MIGRATION: postgresql+asyncpg://soc360_migration:soc360_test_password@localhost:5432/soc360_pymes_test
       REDIS_URL: redis://localhost:6379/0
       REDIS_PASSWORD: ""
       SECRET_KEY: abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwx
@@ -71,6 +71,25 @@ jobs:
 
       - name: Smoke test Celery CLI help
         run: uv run celery --help
+
+      - name: Setup app role
+        env:
+          PGPASSWORD: soc360_test_password
+        run: |
+          psql -U soc360_migration -d soc360_pymes_test -h localhost <<'SQL'
+          DO $$
+          BEGIN
+            IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname='soc360_app') THEN
+              CREATE ROLE soc360_app WITH LOGIN PASSWORD 'soc360_test_password' NOSUPERUSER NOBYPASSRLS;
+            END IF;
+          END
+          $$;
+          GRANT USAGE ON SCHEMA public TO soc360_app;
+          GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO soc360_app;
+          GRANT USAGE ON ALL SEQUENCES IN SCHEMA public TO soc360_app;
+          ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO soc360_app;
+          ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE ON SEQUENCES TO soc360_app;
+          SQL
 
       - name: Run tests
         run: uv run pytest

--- a/app/modules/reports/models.py
+++ b/app/modules/reports/models.py
@@ -3,7 +3,16 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import CheckConstraint, DateTime, ForeignKey, ForeignKeyConstraint, String, Text, func
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    ForeignKeyConstraint,
+    Index,
+    String,
+    Text,
+    func,
+)
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -64,6 +73,7 @@ class Report(Base):
             ondelete="CASCADE",
             name="fk_reports_asset_tenant",
         ),
+        Index("ix_reports_asset_tenant", "asset_id", "tenant_id"),
     )
 
     def __repr__(self) -> str:

--- a/app/modules/vulnerabilities/models.py
+++ b/app/modules/vulnerabilities/models.py
@@ -3,7 +3,17 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import CheckConstraint, DateTime, ForeignKey, ForeignKeyConstraint, Numeric, String, Text, func
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    ForeignKeyConstraint,
+    Index,
+    Numeric,
+    String,
+    Text,
+    func,
+)
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -63,6 +73,7 @@ class Vulnerability(Base):
             ondelete="CASCADE",
             name="fk_vulnerabilities_scan_tenant",
         ),
+        Index("ix_vulnerabilities_scan_tenant", "scan_id", "tenant_id"),
     )
 
     def __repr__(self) -> str:

--- a/migrations/versions/20260711_1700_restore_fk_child_and_user_indexes_a1b2c3d4e5f6.py
+++ b/migrations/versions/20260711_1700_restore_fk_child_and_user_indexes_a1b2c3d4e5f6.py
@@ -23,12 +23,41 @@ from __future__ import annotations
 
 from typing import Sequence, Union
 
-from alembic import op
+from alembic import context, op
+from sqlalchemy import text
 
 revision: str = "a1b2c3d4e5f6"
 down_revision: Union[str, None] = "c1d2e3f4a5b6"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
+
+
+def _assert_index_def(name: str, required: list) -> None:
+    """Assert that the index in pg_indexes matches the expected tokens.
+
+    `CREATE INDEX IF NOT EXISTS` only checks the NAME; a same-named index with
+    wrong columns/expression would be silently accepted. We re-read
+    ``pg_indexes.indexdef`` and confirm every required substring is present
+    (matching is case-insensitive). On mismatch we raise to surface the drift
+    instead of pretending the schema is correct.
+    """
+    bind = op.get_bind()
+    indexdef = bind.execute(
+        text(
+            "SELECT indexdef FROM pg_indexes "
+            "WHERE schemaname='public' AND indexname=:n"
+        ),
+        {"n": name},
+    ).scalar()
+    if indexdef is None:
+        raise RuntimeError(f"index {name!r} missing after CREATE")
+    low = indexdef.lower()
+    for token in required:
+        if token not in low:
+            raise RuntimeError(
+                f"index {name!r} has an incompatible definition "
+                f"(missing {token!r}): {indexdef}"
+            )
 
 
 def upgrade() -> None:
@@ -47,6 +76,30 @@ def upgrade() -> None:
         "CREATE INDEX IF NOT EXISTS ix_users_tenant_active "
         "ON users (tenant_id, is_active)"
     )
+
+    # Validate: same-named indexes with wrong columns/expression would be
+    # silently kept by IF NOT EXISTS. Re-read pg_indexes.indexdef and fail
+    # loudly if any of the 4 expected definitions differs. Postgres renders
+    # the expression index as `lower((email)::text)` so the token must use
+    # that exact rendering. Skipped in offline mode (--sql), which has no
+    # live connection to read pg_indexes back from.
+    if not context.is_offline_mode():
+        _assert_index_def(
+            "ix_vulnerabilities_scan_tenant",
+            ["on public.vulnerabilities", "(scan_id, tenant_id)"],
+        )
+        _assert_index_def(
+            "ix_reports_asset_tenant",
+            ["on public.reports", "(asset_id, tenant_id)"],
+        )
+        _assert_index_def(
+            "ix_users_email_lower",
+            ["on public.users", "lower((email)"],
+        )
+        _assert_index_def(
+            "ix_users_tenant_active",
+            ["on public.users", "(tenant_id, is_active)"],
+        )
 
 
 def downgrade() -> None:

--- a/migrations/versions/20260711_1700_restore_fk_child_and_user_indexes_a1b2c3d4e5f6.py
+++ b/migrations/versions/20260711_1700_restore_fk_child_and_user_indexes_a1b2c3d4e5f6.py
@@ -1,0 +1,56 @@
+"""restore fk-child composite indexes and dropped user indexes
+
+Creates 4 indexes:
+  1. ix_vulnerabilities_scan_tenant  — composite FK child for vulnerabilities
+  2. ix_reports_asset_tenant         — composite FK child for reports
+  3. ix_users_email_lower            — case-insensitive email lookup (was dropped)
+  4. ix_users_tenant_active          — tenant-scoped active user listing (was dropped)
+
+Indexes 3 and 4 were originally created by migration 70dc591dac68 but were
+dropped by a subsequent migration and never recreated. The ORM models already
+declare them in __table_args__; this migration brings the database into sync.
+
+ix_scans_asset_tenant already exists (created by c1d2e3f4a5b6) and is
+verified but not created here.
+
+Expression index lower(email) requires raw op.execute().
+
+Revision ID: a1b2c3d4e5f6
+Revises: c1d2e3f4a5b6
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "a1b2c3d4e5f6"
+down_revision: Union[str, None] = "c1d2e3f4a5b6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_vulnerabilities_scan_tenant "
+        "ON vulnerabilities (scan_id, tenant_id)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_reports_asset_tenant "
+        "ON reports (asset_id, tenant_id)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_users_email_lower " "ON users (lower(email))"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_users_tenant_active "
+        "ON users (tenant_id, is_active)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_users_tenant_active")
+    op.execute("DROP INDEX IF EXISTS ix_users_email_lower")
+    op.execute("DROP INDEX IF EXISTS ix_reports_asset_tenant")
+    op.execute("DROP INDEX IF EXISTS ix_vulnerabilities_scan_tenant")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import os
+import subprocess
+from pathlib import Path
 
 import bcrypt
 import pytest
@@ -38,7 +40,6 @@ os.environ.setdefault("POSTGRES_DB", "soc360_test")
 os.environ.setdefault("REDIS_URL", "redis://localhost:6379/15")
 
 from app.main import create_app
-from app.core.database import Base
 from app.core.redis import get_redis
 from app.dependencies import get_db, get_db_with_tenant
 from app.modules.users.models import User
@@ -60,17 +61,31 @@ def _seed_password_hash(password: str) -> str:
     return bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
 
 
+def _run_alembic(*args: str) -> None:
+    """Run alembic command with MIGRATION_DATABASE_URL env."""
+    env = {
+        **os.environ,
+        "DATABASE_URL_MIGRATION": MIGRATION_DATABASE_URL,
+    }
+    result = subprocess.run(
+        ["uv", "run", "alembic", *args],
+        cwd=Path(__file__).resolve().parent.parent,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env=env,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"alembic {' '.join(args)} failed:\n"
+            f"stdout: {result.stdout}\n"
+            f"stderr: {result.stderr}"
+        )
+
+
 # ✅ SYNC fixture — usa asyncio.run() para no contaminar ningún loop de test
 @pytest.fixture(scope="session", autouse=True)
 def prepare_database():
-    from app.modules.assets.models import Asset  # noqa: F401
-    from app.modules.auth.models import RefreshToken  # noqa: F401
-    from app.modules.reports.models import Report  # noqa: F401
-    from app.modules.scans.models import Scan  # noqa: F401
-    from app.modules.tenants.models import Tenant  # noqa: F401
-    from app.modules.users.models import User  # noqa: F401
-    from app.modules.vulnerabilities.models import Vulnerability  # noqa: F401
-
     async def _ensure_app_role() -> None:
         """Idempotently create the soc360_app login role for test GRANTs.
 
@@ -100,56 +115,31 @@ def prepare_database():
             port=parsed.port,
             database=parsed.database,
         )
+        # Extract the password for soc360_app from the test DATABASE_URL
+        # so _ensure_app_role and db_session use the same credential.
+        app_parsed = make_url(TEST_DATABASE_URL)
+        app_password = app_parsed.password or "AppSoc360Pass2000futureDev"
         try:
-            await conn.execute("""
-                DO $$
-                BEGIN
-                    IF NOT EXISTS (
-                        SELECT FROM pg_catalog.pg_roles
-                        WHERE rolname = 'soc360_app'
-                    ) THEN
-                        CREATE ROLE soc360_app
-                            WITH LOGIN PASSWORD 'AppSoc360Pass2000futureDev';
-                    END IF;
-                END
-                $$;
-            """)
+            role_exists = await conn.fetchval(
+                "SELECT 1 FROM pg_roles WHERE rolname = 'soc360_app'"
+            )
+            action = "ALTER" if role_exists else "CREATE"
+            await conn.execute(
+                f"{action} ROLE soc360_app WITH LOGIN PASSWORD '{app_password}' "
+                "NOSUPERUSER NOBYPASSRLS"
+            )
         finally:
             await conn.close()
 
     async def _setup() -> None:
         await _ensure_app_role()
-        engine = create_async_engine(
-            MIGRATION_DATABASE_URL, echo=False, poolclass=NullPool
-        )
-        async with engine.begin() as conn:
-            await conn.run_sync(Base.metadata.drop_all)
-            await conn.run_sync(Base.metadata.create_all)
-            await conn.execute(
-                text("GRANT ALL ON ALL TABLES IN SCHEMA public TO soc360_app")
-            )
-            await conn.execute(
-                text("GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO soc360_app")
-            )
-            await conn.execute(
-                text(
-                    "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO soc360_app"
-                )
-            )
-            await conn.execute(
-                text(
-                    "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO soc360_app"
-                )
-            )
-        await engine.dispose()
+        # Drop everything and re-run the full Alembic chain so RLS policies,
+        # GRANTs, triggers, and indexes are created exactly as in production.
+        _run_alembic("downgrade", "base")
+        _run_alembic("upgrade", "head")
 
     async def _teardown() -> None:
-        engine = create_async_engine(
-            MIGRATION_DATABASE_URL, echo=False, poolclass=NullPool
-        )
-        async with engine.begin() as conn:
-            await conn.run_sync(Base.metadata.drop_all)
-        await engine.dispose()
+        _run_alembic("downgrade", "base")
 
     asyncio.run(_setup())
     yield
@@ -426,9 +416,10 @@ async def isolated_db_session(pooled_engine):
     """Factory that yields function-scoped AsyncSession instances from a pooled engine.
 
     Usage in concurrency tests:
-        session1 = await isolated_db_session()
-        session2 = await isolated_db_session()
-    Each call returns a fresh session with its own DB connection.
+        session1 = isolated_db_session()
+        session2 = isolated_db_session()
+    Each call returns a fresh AsyncSession with its own DB connection.
+    Note: isolated_db_session is a sync factory (not async) — do NOT await it.
     """
     session_factory = async_sessionmaker(
         bind=pooled_engine, class_=AsyncSession, expire_on_commit=False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,6 +57,26 @@ TEST_DATABASE_URL = os.environ["DATABASE_URL"]
 MIGRATION_DATABASE_URL = os.environ["DATABASE_URL_MIGRATION"]
 
 
+def _assert_safe_test_database() -> None:
+    """Fail closed before any destructive migration reset.
+
+    Guards against a misconfigured MIGRATION_DATABASE_URL wiping a real
+    database: the environment must not be production/staging and the target
+    DB name must look like a test database.
+    """
+    env = os.environ.get("ENVIRONMENT", "").lower()
+    if env in {"production", "prod", "staging"}:
+        raise RuntimeError(
+            f"Refusing destructive DB reset in ENVIRONMENT={env!r}"
+        )
+    db_name = (make_url(MIGRATION_DATABASE_URL).database or "").lower()
+    if "test" not in db_name:
+        raise RuntimeError(
+            f"Refusing 'alembic downgrade base': database {db_name!r} does not "
+            "look like a test database (name must contain 'test')."
+        )
+
+
 def _seed_password_hash(password: str) -> str:
     return bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
 
@@ -132,6 +152,7 @@ def prepare_database():
             await conn.close()
 
     async def _setup() -> None:
+        _assert_safe_test_database()
         await _ensure_app_role()
         # Drop everything and re-run the full Alembic chain so RLS policies,
         # GRANTs, triggers, and indexes are created exactly as in production.
@@ -139,6 +160,7 @@ def prepare_database():
         _run_alembic("upgrade", "head")
 
     async def _teardown() -> None:
+        _assert_safe_test_database()
         _run_alembic("downgrade", "base")
 
     asyncio.run(_setup())

--- a/tests/modules/auth/test_refresh_token_race.py
+++ b/tests/modules/auth/test_refresh_token_race.py
@@ -148,10 +148,19 @@ async def test_refresh_token_concurrent_race(isolated_db_session):
     """
     user_id = UUID(ADMIN_A_ID)
 
-    # Seed user (committed so login queries can find it)
+    # Seed user (committed so login queries can find it) and hard-DELETE any
+    # pre-existing refresh tokens for this user. The hard DELETE (not revoke)
+    # is required because `after_total` counts ALL rows including revoked
+    # ones; without this, prior tests (e.g. session_cap) that committed
+    # tokens for the same user would pollute the absolute-count assertion.
     seed = isolated_db_session()
     async with seed.begin():
         await _ensure_user_exists(seed)
+        await seed.execute(text("SET LOCAL app.is_superadmin = 'true'"))
+        await seed.execute(
+            text("DELETE FROM refresh_tokens WHERE user_id = :uid"),
+            {"uid": user_id},
+        )
         await seed.commit()
 
     # Login to obtain a refresh token

--- a/tests/modules/auth/test_refresh_token_race.py
+++ b/tests/modules/auth/test_refresh_token_race.py
@@ -45,12 +45,14 @@ async def _refresh_with_cookie(client: AsyncClient, refresh_token: str) -> Respo
 
 
 async def _count_refresh_tokens(db_session: AsyncSession, user_id: UUID) -> int:
+    await db_session.execute(text("SET LOCAL app.is_superadmin = 'true'"))
     return await db_session.scalar(
         select(func.count()).select_from(RefreshToken).where(RefreshToken.user_id == user_id)
     ) or 0
 
 
 async def _count_active_refresh_tokens(db_session: AsyncSession, user_id: UUID) -> int:
+    await db_session.execute(text("SET LOCAL app.is_superadmin = 'true'"))
     return await db_session.scalar(
         select(func.count())
         .select_from(RefreshToken)
@@ -71,7 +73,12 @@ ADMIN_A_PASSWORD = "AdminAlpha123!"
 
 
 async def _ensure_user_exists(db: AsyncSession) -> None:
-    """Seed tenant + user if not present (idempotent, conflict-safe)."""
+    """Seed tenant + user if not present (idempotent, conflict-safe).
+
+    Runs under superadmin context so the RLS WITH CHECK on `tenants` (and the
+    refresh_tokens/users policies) do not reject test bookkeeping writes.
+    """
+    await db.execute(text("SET LOCAL app.is_superadmin = 'true'"))
     tenant_exists = await db.scalar(
         select(func.count()).select_from(Tenant).where(Tenant.id == UUID(TENANT_A_ID))
     )
@@ -88,7 +95,6 @@ async def _ensure_user_exists(db: AsyncSession) -> None:
         select(func.count()).select_from(User).where(User.id == UUID(ADMIN_A_ID))
     )
     if not user_exists:
-        await db.execute(text("SET LOCAL app.is_superadmin = 'true'"))
         await db.execute(
             pg_insert(User).values(
                 id=UUID(ADMIN_A_ID), tenant_id=UUID(TENANT_A_ID),

--- a/tests/modules/auth/test_session_cap_concurrency.py
+++ b/tests/modules/auth/test_session_cap_concurrency.py
@@ -10,6 +10,7 @@ import pytest
 from fakeredis.aioredis import FakeRedis
 from httpx import AsyncClient, ASGITransport
 from sqlalchemy import func, select, text, update
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.core.database import Base
@@ -36,6 +37,10 @@ def _hash_token(raw: str) -> str:
 
 
 async def _count_active(db: AsyncSession, user_id: UUID) -> int:
+    # Read under superadmin context: refresh_tokens is RLS-protected via the
+    # users subquery, so a session without tenant/superadmin context sees zero
+    # rows regardless of what was actually persisted.
+    await db.execute(text("SET LOCAL app.is_superadmin = 'true'"))
     return await db.scalar(
         select(func.count())
         .select_from(RefreshToken)
@@ -46,26 +51,33 @@ async def _count_active(db: AsyncSession, user_id: UUID) -> int:
 
 
 async def _ensure_user_exists(db: AsyncSession) -> None:
-    """Seed tenant + user if not present (idempotent for concurrency tests)."""
+    """Seed tenant + user if not present (idempotent for concurrency tests).
+
+    Runs under superadmin context so the RLS WITH CHECK policies do not reject
+    test bookkeeping writes, and uses ON CONFLICT DO NOTHING so residual state
+    from a prior test run does not raise a duplicate-key error.
+    """
+    await db.execute(text("SET LOCAL app.is_superadmin = 'true'"))
     exists = await db.scalar(
         select(func.count()).select_from(User).where(User.id == UUID(ADMIN_A_ID))
     )
     if exists:
         return
 
-    tenant = Tenant(
-        id=UUID(TENANT_A_ID), name="Empresa Alpha", slug="empresa-alpha",
-        plan="starter", is_active=True, max_assets=50,
+    await db.execute(
+        pg_insert(Tenant).values(
+            id=UUID(TENANT_A_ID), name="Empresa Alpha", slug="empresa-alpha",
+            plan="starter", is_active=True, max_assets=50,
+        ).on_conflict_do_nothing(index_elements=["id"])
     )
-    user = User(
-        id=UUID(ADMIN_A_ID), tenant_id=UUID(TENANT_A_ID),
-        email=ADMIN_A_EMAIL, hashed_password=hash_password(ADMIN_A_PASSWORD),
-        full_name="Admin Alpha", role="admin", is_active=True, is_superadmin=False,
-    )
-    await db.execute(text("SET LOCAL app.is_superadmin = 'true'"))
-    db.add(tenant)
     await db.flush()
-    db.add(user)
+    await db.execute(
+        pg_insert(User).values(
+            id=UUID(ADMIN_A_ID), tenant_id=UUID(TENANT_A_ID),
+            email=ADMIN_A_EMAIL, hashed_password=hash_password(ADMIN_A_PASSWORD),
+            full_name="Admin Alpha", role="admin", is_active=True, is_superadmin=False,
+        ).on_conflict_do_nothing(index_elements=["id"])
+    )
     await db.flush()
 
 

--- a/tests/sdd/conftest.py
+++ b/tests/sdd/conftest.py
@@ -1,7 +1,219 @@
-import pytest
+"""Shared RLS test harness for SDD harden-rls-fk-indexes.
+
+Provides:
+  - PROTECTED_TABLES: list of all 7 RLS-protected table names
+  - seed_two_tenants: function-scoped fixture seeding representative rows in
+    every RLS-protected table for both Tenant A and Tenant B.
+"""
+
+from uuid import UUID
+
+import pytest_asyncio
+from sqlalchemy import text
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import set_tenant_context
+from app.modules.assets.models import Asset
+from app.modules.auth.models import RefreshToken
+from app.modules.reports.models import Report
+from app.modules.scans.models import Scan
+from app.modules.vulnerabilities.models import Vulnerability
+
+from tests.conftest import ADMIN_A_ID, ADMIN_B_ID, TENANT_A_ID, TENANT_B_ID
+
+PROTECTED_TABLES = [
+    "tenants",
+    "users",
+    "refresh_tokens",
+    "assets",
+    "scans",
+    "vulnerabilities",
+    "reports",
+]
 
 
-@pytest.fixture(scope="session", autouse=True)
-def prepare_database():
-    """No-op override of the root DB fixture for packaging-only contract tests."""
-    yield
+@pytest_asyncio.fixture
+async def seed_two_tenants(
+    db_session: AsyncSession,
+    seed_data,
+) -> dict:
+    """Seed representative rows for both tenants across all RLS tables.
+
+    Depends on the root `seed_data` fixture which already creates Tenant A,
+    Tenant B, and their users. This fixture adds one row per table per tenant.
+
+    Returns a dict with seeded row IDs keyed by table and tenant.
+    """
+    await set_tenant_context(db_session, UUID(TENANT_A_ID), is_superadmin=True)
+    await db_session.flush()
+
+    ids: dict[str, dict[str, UUID]] = {
+        "assets": {},
+        "scans": {},
+        "vulnerabilities": {},
+        "reports": {},
+        "refresh_tokens": {},
+    }
+
+    # --- Assets ---
+    asset_a_id = UUID("aaaaaaaa-0000-0000-0000-aaaaaaaaaaaa")
+    asset_b_id = UUID("bbbbbbbb-0000-0000-0000-bbbbbbbbbbbb")
+
+    await db_session.execute(
+        pg_insert(Asset)
+        .values(
+            id=asset_a_id,
+            tenant_id=UUID(TENANT_A_ID),
+            name="Alpha Asset",
+            hostname="alpha-host-1",
+            asset_type="host",
+            status="active",
+        )
+        .on_conflict_do_nothing(index_elements=["id"])
+    )
+    await db_session.execute(
+        pg_insert(Asset)
+        .values(
+            id=asset_b_id,
+            tenant_id=UUID(TENANT_B_ID),
+            name="Beta Asset",
+            hostname="beta-host-1",
+            asset_type="host",
+            status="active",
+        )
+        .on_conflict_do_nothing(index_elements=["id"])
+    )
+    await db_session.flush()
+    ids["assets"]["tenant_a"] = asset_a_id
+    ids["assets"]["tenant_b"] = asset_b_id
+
+    # --- Scans ---
+    scan_a_id = UUID("aaaaaaaa-1111-0000-0000-aaaaaaaaaaaa")
+    scan_b_id = UUID("bbbbbbbb-1111-0000-0000-bbbbbbbbbbbb")
+
+    await db_session.execute(
+        pg_insert(Scan)
+        .values(
+            id=scan_a_id,
+            tenant_id=UUID(TENANT_A_ID),
+            asset_id=asset_a_id,
+            name="Alpha Scan",
+            scan_type="vulnerability",
+            status="completed",
+        )
+        .on_conflict_do_nothing(index_elements=["id"])
+    )
+    await db_session.execute(
+        pg_insert(Scan)
+        .values(
+            id=scan_b_id,
+            tenant_id=UUID(TENANT_B_ID),
+            asset_id=asset_b_id,
+            name="Beta Scan",
+            scan_type="vulnerability",
+            status="completed",
+        )
+        .on_conflict_do_nothing(index_elements=["id"])
+    )
+    await db_session.flush()
+    ids["scans"]["tenant_a"] = scan_a_id
+    ids["scans"]["tenant_b"] = scan_b_id
+
+    # --- Vulnerabilities ---
+    vuln_a_id = UUID("aaaaaaaa-2222-0000-0000-aaaaaaaaaaaa")
+    vuln_b_id = UUID("bbbbbbbb-2222-0000-0000-bbbbbbbbbbbb")
+
+    await db_session.execute(
+        pg_insert(Vulnerability)
+        .values(
+            id=vuln_a_id,
+            tenant_id=UUID(TENANT_A_ID),
+            scan_id=scan_a_id,
+            title="Alpha Vuln",
+            severity="high",
+            status="open",
+        )
+        .on_conflict_do_nothing(index_elements=["id"])
+    )
+    await db_session.execute(
+        pg_insert(Vulnerability)
+        .values(
+            id=vuln_b_id,
+            tenant_id=UUID(TENANT_B_ID),
+            scan_id=scan_b_id,
+            title="Beta Vuln",
+            severity="medium",
+            status="open",
+        )
+        .on_conflict_do_nothing(index_elements=["id"])
+    )
+    await db_session.flush()
+    ids["vulnerabilities"]["tenant_a"] = vuln_a_id
+    ids["vulnerabilities"]["tenant_b"] = vuln_b_id
+
+    # --- Reports ---
+    report_a_id = UUID("aaaaaaaa-3333-0000-0000-aaaaaaaaaaaa")
+    report_b_id = UUID("bbbbbbbb-3333-0000-0000-bbbbbbbbbbbb")
+
+    await db_session.execute(
+        pg_insert(Report)
+        .values(
+            id=report_a_id,
+            tenant_id=UUID(TENANT_A_ID),
+            asset_id=asset_a_id,
+            name="Alpha Report",
+            report_type="vulnerability",
+            status="completed",
+        )
+        .on_conflict_do_nothing(index_elements=["id"])
+    )
+    await db_session.execute(
+        pg_insert(Report)
+        .values(
+            id=report_b_id,
+            tenant_id=UUID(TENANT_B_ID),
+            asset_id=asset_b_id,
+            name="Beta Report",
+            report_type="vulnerability",
+            status="completed",
+        )
+        .on_conflict_do_nothing(index_elements=["id"])
+    )
+    await db_session.flush()
+    ids["reports"]["tenant_a"] = report_a_id
+    ids["reports"]["tenant_b"] = report_b_id
+
+    # --- Refresh Tokens ---
+    rt_a_id = UUID("aaaaaaaa-4444-0000-0000-aaaaaaaaaaaa")
+    rt_b_id = UUID("bbbbbbbb-4444-0000-0000-bbbbbbbbbbbb")
+
+    from datetime import datetime, timezone, timedelta
+
+    future = datetime.now(timezone.utc) + timedelta(days=7)
+
+    await db_session.execute(
+        pg_insert(RefreshToken)
+        .values(
+            id=rt_a_id,
+            user_id=UUID(ADMIN_A_ID),
+            token_hash="hash_alpha_refresh_token_for_testing",
+            expires_at=future,
+        )
+        .on_conflict_do_nothing(index_elements=["id"])
+    )
+    await db_session.execute(
+        pg_insert(RefreshToken)
+        .values(
+            id=rt_b_id,
+            user_id=UUID(ADMIN_B_ID),
+            token_hash="hash_beta_refresh_token_for_testing",
+            expires_at=future,
+        )
+        .on_conflict_do_nothing(index_elements=["id"])
+    )
+    await db_session.flush()
+    ids["refresh_tokens"]["tenant_a"] = rt_a_id
+    ids["refresh_tokens"]["tenant_b"] = rt_b_id
+
+    return ids

--- a/tests/sdd/test_app_role_privileges.py
+++ b/tests/sdd/test_app_role_privileges.py
@@ -1,0 +1,98 @@
+"""App-role privilege validation tests.
+
+Covers spec requirements #11–#15:
+  #11 App role NOT superuser
+  #12 App role NOT BYPASSRLS
+  #13 App role does not own application tables
+  #14 App role DDL rejection (destructive and constructive)
+  #15 CI role separation (dual-role architecture)
+
+RED phase: expected to fail when soc360_app runs as SUPERUSER.
+GREEN phase: after CI hardening (WU-6), all MUST pass.
+"""
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import ProgrammingError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+@pytest.mark.asyncio
+async def test_app_role_not_superuser(
+    db_session: AsyncSession,
+):
+    """Spec #11: soc360_app must NOT be a superuser."""
+    result = await db_session.execute(
+        text("SELECT rolsuper FROM pg_roles WHERE rolname = 'soc360_app'")
+    )
+    row = result.fetchone()
+    assert row is not None, "soc360_app role not found in pg_roles"
+    assert row[0] is False, "soc360_app has rolsuper=true — RLS is completely bypassed"
+
+
+@pytest.mark.asyncio
+async def test_app_role_not_bypassrls(
+    db_session: AsyncSession,
+):
+    """Spec #12: soc360_app must NOT have BYPASSRLS."""
+    result = await db_session.execute(
+        text("SELECT rolbypassrls FROM pg_roles WHERE rolname = 'soc360_app'")
+    )
+    row = result.fetchone()
+    assert row is not None, "soc360_app role not found in pg_roles"
+    assert (
+        row[0] is False
+    ), "soc360_app has rolbypassrls=true — RLS policies are circumvented"
+
+
+@pytest.mark.asyncio
+async def test_app_role_owns_no_tables(
+    db_session: AsyncSession,
+):
+    """Spec #13: No application table is owned by soc360_app."""
+    result = await db_session.execute(
+        text(
+            "SELECT c.relname, c.relowner::regrole::text AS owner "
+            "FROM pg_class c "
+            "JOIN pg_namespace n ON n.oid = c.relnamespace "
+            "WHERE n.nspname = 'public' "
+            "AND c.relkind IN ('r', 'p') "
+            "AND c.relowner = ("
+            "  SELECT oid FROM pg_roles WHERE rolname = 'soc360_app'"
+            ")"
+        )
+    )
+    owned = result.fetchall()
+    assert len(owned) == 0, (
+        f"soc360_app owns {len(owned)} table(s): {[r[0] for r in owned]} — "
+        "application role must not own tables"
+    )
+
+
+@pytest.mark.asyncio
+async def test_destructive_ddl_drop_table_fails(
+    db_session: AsyncSession,
+):
+    """Spec #14: DROP TABLE on application tables must raise permission denied."""
+    with pytest.raises(ProgrammingError):
+        await db_session.execute(text("DROP TABLE IF EXISTS assets CASCADE"))
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_destructive_ddl_alter_table_fails(
+    db_session: AsyncSession,
+):
+    """Spec #14: ALTER TABLE on application tables must raise permission denied."""
+    with pytest.raises(ProgrammingError):
+        await db_session.execute(text("ALTER TABLE assets RENAME TO assets_renamed"))
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_constructive_ddl_fails(
+    db_session: AsyncSession,
+):
+    """Spec #14: CREATE TABLE must raise permission denied."""
+    with pytest.raises(ProgrammingError):
+        await db_session.execute(text("CREATE TABLE hacker_table (id int)"))

--- a/tests/sdd/test_migration_chain_indexes.py
+++ b/tests/sdd/test_migration_chain_indexes.py
@@ -1,0 +1,121 @@
+"""Tests for migration chain index integrity.
+
+Covers spec requirements:
+  #9  Composite FK Child Indexes
+  #10 Dropped User Indexes Restored
+  #16 Migration Idempotency
+  #17 Full Migration Chain Index State
+
+TDD: RED phase — all tests must fail when indexes are missing.
+"""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+EXPECTED_INDEXES = {
+    "ix_vulnerabilities_scan_tenant",
+    "ix_reports_asset_tenant",
+    "ix_users_email_lower",
+    "ix_users_tenant_active",
+    "ix_scans_asset_tenant",
+}
+
+
+def _run_alembic(*args: str) -> str:
+    result = subprocess.run(
+        ["uv", "run", "alembic", *args],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"alembic {' '.join(args)} failed:\n{result.stderr}")
+    return result.stdout
+
+
+def _existing_indexes() -> set[str]:
+    """Return set of index names currently visible in pg_indexes."""
+    import os
+    import sys
+
+    sys.path.insert(0, str(ROOT))
+    os.environ.setdefault("ENVIRONMENT", "development")
+    os.environ.setdefault(
+        "SECRET_KEY",
+        "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz"
+        "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz"
+        "abcdefghijklmnopqrstuvwx",
+    )
+
+    from app.core.config import settings
+    from sqlalchemy import text, make_url
+    import asyncpg
+
+    parsed = make_url(settings.DATABASE_URL_MIGRATION)
+    import asyncio
+
+    async def _fetch() -> set[str]:
+        conn = await asyncpg.connect(
+            user=parsed.username or "soc360_app",
+            password=parsed.password or "",
+            host=parsed.host or "localhost",
+            port=parsed.port or 5432,
+            database=parsed.database or "soc360_pymes_test",
+        )
+        try:
+            rows = await conn.fetch(
+                "SELECT indexname FROM pg_indexes WHERE schemaname = 'public'"
+            )
+            return {r["indexname"] for r in rows}
+        finally:
+            await conn.close()
+
+    return asyncio.run(_fetch())
+
+
+class TestIndexExistence:
+    """RED: All tests expected to fail before migration."""
+
+    def test_full_upgrade_yields_5_indexes(self):
+        """Spec #17: Full upgrade yields 5 specific indexes."""
+        indexes = _existing_indexes()
+        missing = EXPECTED_INDEXES - indexes
+        assert not missing, f"Missing indexes: {missing}"
+
+    def test_round_trip_same_index_state(self):
+        """Spec #16: Downgrade → re-upgrade yields identical index set."""
+        # Capture state after a single upgrade
+        _run_alembic("upgrade", "head")
+        baseline = _existing_indexes()
+
+        # Downgrade one step
+        _run_alembic("downgrade", "-1")
+        # Re-upgrade
+        _run_alembic("upgrade", "head")
+        after_roundtrip = _existing_indexes()
+
+        assert baseline == after_roundtrip, (
+            f"Round-trip index mismatch.\n"
+            f"Baseline: {baseline}\n"
+            f"After:    {after_roundtrip}"
+        )
+
+    def test_alembic_check_clean(self):
+        """Spec #10: alembic check reports no pending differences."""
+        _run_alembic("upgrade", "head")
+        result = subprocess.run(
+            ["uv", "run", "alembic", "check"],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        # alembic check returns exit code 0 when clean, 1 when dirty
+        assert (
+            result.returncode == 0
+        ), f"alembic check reports pending differences:\n{result.stderr}"

--- a/tests/sdd/test_migration_chain_indexes.py
+++ b/tests/sdd/test_migration_chain_indexes.py
@@ -24,6 +24,36 @@ EXPECTED_INDEXES = {
     "ix_scans_asset_tenant",
 }
 
+# Expected substrings (lower-cased) required in each pg_indexes.indexdef.
+# `CREATE INDEX IF NOT EXISTS` only matches the NAME; a same-named index with
+# wrong columns or a wrong expression would be silently accepted, so we
+# re-read pg_indexes.indexdef and validate the table + ordered columns or
+# the expression.
+EXPECTED_INDEX_DEFS: dict[str, list] = {
+    "ix_vulnerabilities_scan_tenant": [
+        "on public.vulnerabilities",
+        "(scan_id, tenant_id)",
+    ],
+    "ix_reports_asset_tenant": [
+        "on public.reports",
+        "(asset_id, tenant_id)",
+    ],
+    "ix_users_email_lower": [
+        "on public.users",
+        # Postgres renders `lower(email)` as `lower((email)::text)`; the
+        # substring must reflect that exact rendering.
+        "lower((email)",
+    ],
+    "ix_users_tenant_active": [
+        "on public.users",
+        "(tenant_id, is_active)",
+    ],
+    "ix_scans_asset_tenant": [
+        "on public.scans",
+        "(asset_id, tenant_id)",
+    ],
+}
+
 
 def _run_alembic(*args: str) -> str:
     result = subprocess.run(
@@ -38,8 +68,8 @@ def _run_alembic(*args: str) -> str:
     return result.stdout
 
 
-def _existing_indexes() -> set[str]:
-    """Return set of index names currently visible in pg_indexes."""
+def _existing_indexes() -> dict[str, str]:
+    """Return {indexname: indexdef} for every index currently in pg_indexes."""
     import os
     import sys
 
@@ -59,7 +89,7 @@ def _existing_indexes() -> set[str]:
     parsed = make_url(settings.DATABASE_URL_MIGRATION)
     import asyncio
 
-    async def _fetch() -> set[str]:
+    async def _fetch() -> dict[str, str]:
         conn = await asyncpg.connect(
             user=parsed.username or "soc360_app",
             password=parsed.password or "",
@@ -69,23 +99,51 @@ def _existing_indexes() -> set[str]:
         )
         try:
             rows = await conn.fetch(
-                "SELECT indexname FROM pg_indexes WHERE schemaname = 'public'"
+                "SELECT indexname, indexdef FROM pg_indexes "
+                "WHERE schemaname = 'public'"
             )
-            return {r["indexname"] for r in rows}
+            return {r["indexname"]: r["indexdef"] for r in rows}
         finally:
             await conn.close()
 
     return asyncio.run(_fetch())
 
 
+def _assert_indexes_have_expected_definitions(indexes: dict[str, str]) -> None:
+    """Validate that each expected index has the required definition tokens.
+
+    Catches same-named indexes with wrong columns/expression that
+    ``CREATE INDEX IF NOT EXISTS`` would silently accept.
+    """
+    missing = EXPECTED_INDEXES - indexes.keys()
+    assert not missing, f"Missing indexes: {missing}"
+    for name, required in EXPECTED_INDEX_DEFS.items():
+        indexdef = indexes[name]
+        low = indexdef.lower()
+        for token in required:
+            assert token in low, (
+                f"index {name!r} definition missing token {token!r}: {indexdef}"
+            )
+
+
 class TestIndexExistence:
     """RED: All tests expected to fail before migration."""
 
     def test_full_upgrade_yields_5_indexes(self):
-        """Spec #17: Full upgrade yields 5 specific indexes."""
+        """Spec #17: Full upgrade yields 5 specific indexes (by name)."""
         indexes = _existing_indexes()
-        missing = EXPECTED_INDEXES - indexes
+        missing = EXPECTED_INDEXES - indexes.keys()
         assert not missing, f"Missing indexes: {missing}"
+
+    def test_indexes_have_expected_definitions(self):
+        """Each expected index's pg_indexes.indexdef matches the spec.
+
+        Same-named indexes with wrong columns/expression are silently kept by
+        ``CREATE INDEX IF NOT EXISTS``; we re-read ``pg_indexes.indexdef`` to
+        fail loudly on definition drift.
+        """
+        indexes = _existing_indexes()
+        _assert_indexes_have_expected_definitions(indexes)
 
     def test_round_trip_same_index_state(self):
         """Spec #16: Downgrade → re-upgrade yields identical index set."""
@@ -99,11 +157,13 @@ class TestIndexExistence:
         _run_alembic("upgrade", "head")
         after_roundtrip = _existing_indexes()
 
-        assert baseline == after_roundtrip, (
-            f"Round-trip index mismatch.\n"
-            f"Baseline: {baseline}\n"
-            f"After:    {after_roundtrip}"
+        assert baseline.keys() == after_roundtrip.keys(), (
+            f"Round-trip index set mismatch.\n"
+            f"Baseline: {sorted(baseline)}\n"
+            f"After:    {sorted(after_roundtrip)}"
         )
+        # Validate definitions too — definitions must round-trip identically.
+        _assert_indexes_have_expected_definitions(after_roundtrip)
 
     def test_alembic_check_clean(self):
         """Spec #10: alembic check reports no pending differences."""

--- a/tests/sdd/test_rls_cross_tenant_crud.py
+++ b/tests/sdd/test_rls_cross_tenant_crud.py
@@ -18,7 +18,7 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.database import set_tenant_context
-from tests.conftest import TENANT_A_ID, TENANT_B_ID
+from tests.conftest import ADMIN_B_ID, TENANT_A_ID, TENANT_B_ID
 from tests.sdd.conftest import PROTECTED_TABLES
 
 
@@ -44,8 +44,18 @@ def _select_b_tenant_rows(table: str) -> str:
         return f"SELECT id FROM {table} WHERE tenant_id = '{TENANT_B_ID}'"
 
 
-def _insert_b_row(table: str) -> str | None:
-    """Return INSERT for a Tenant B row (to verify RLS blocks it)."""
+def _insert_b_row(table: str, seed: dict) -> str | None:
+    """Return INSERT for a Tenant B row (to verify RLS blocks it).
+
+    `seed` is the dict produced by `seed_two_tenants` with shape:
+        seed["<table>"]["tenant_a" | "tenant_b"] -> UUID
+
+    Tables that reference parent rows owned by Tenant B (scans -> assets,
+    vulnerabilities -> scans, reports -> assets, refresh_tokens -> users) use
+    the seeded Tenant B IDs so the FK is logically valid; the INSERT itself
+    must still be rejected because the session is scoped to Tenant A and the
+    RLS WITH CHECK policy does not allow Tenant B ownership.
+    """
     if table == "tenants":
         return (
             f"INSERT INTO {table} (id, name, slug, plan, is_active, max_assets) "
@@ -61,16 +71,40 @@ def _insert_b_row(table: str) -> str | None:
             f"'Intruder', 'viewer', true, false)"
         )
     elif table == "refresh_tokens":
-        # INSERT with user_id from Tenant B — RLS on users FK blocks it
-        return None  # skip — handled separately via FK path
+        # INSERT owned by Tenant B's admin user — FK to users holds; RLS on
+        # refresh_tokens (which scopes by users.tenant_id) must reject.
+        return (
+            f"INSERT INTO {table} (id, user_id, token_hash, expires_at) "
+            f"VALUES (gen_random_uuid(), '{ADMIN_B_ID}', "
+            f"'intruder_refresh_hash', '2030-01-01T00:00:00Z')"
+        )
     elif table == "assets":
         return (
             f"INSERT INTO {table} (id, tenant_id, name, hostname, asset_type, status) "
             f"VALUES ('{UUID('55555555-5555-5555-5555-555555555555')}', "
             f"'{TENANT_B_ID}', 'Intruder Asset', 'intruder-host', 'host', 'active')"
         )
-    elif table in ("scans", "vulnerabilities", "reports"):
-        return None  # skip — these require valid parent FK references in Tenant B
+    elif table == "scans":
+        return (
+            f"INSERT INTO {table} (id, tenant_id, asset_id, name, scan_type, status) "
+            f"VALUES (gen_random_uuid(), '{TENANT_B_ID}', "
+            f"'{seed['assets']['tenant_b']}', "
+            f"'Intruder Scan', 'vulnerability', 'pending')"
+        )
+    elif table == "vulnerabilities":
+        return (
+            f"INSERT INTO {table} (id, tenant_id, scan_id, title, severity, status) "
+            f"VALUES (gen_random_uuid(), '{TENANT_B_ID}', "
+            f"'{seed['scans']['tenant_b']}', "
+            f"'Intruder Vuln', 'high', 'open')"
+        )
+    elif table == "reports":
+        return (
+            f"INSERT INTO {table} (id, tenant_id, asset_id, name, report_type, status) "
+            f"VALUES (gen_random_uuid(), '{TENANT_B_ID}', "
+            f"'{seed['assets']['tenant_b']}', "
+            f"'Intruder Report', 'vulnerability', 'pending')"
+        )
     return None
 
 
@@ -162,33 +196,38 @@ async def test_cross_tenant_write_blocked(
 ):
     """Tenant A cannot INSERT/UPDATE/DELETE Tenant B rows.
 
-    Tests INSERT, UPDATE, and DELETE for each table. Skips operations that
-    require FK references that are invisible to the Tenant A session.
+    Tests INSERT, UPDATE, and DELETE for each table. For INSERT we are
+    strict: an RLS rejection MUST surface as SQLSTATE 42501
+    (insufficient_privilege). Generic IntegrityError (unique/unrelated FK) or
+    broken SQL would otherwise be silently accepted as "RLS enforcement",
+    which masks real regressions.
     """
-    from sqlalchemy.exc import IntegrityError, ProgrammingError
-
     await set_tenant_context(db_session, UUID(TENANT_A_ID), is_superadmin=False)
 
     # --- INSERT ---
-    insert_sql = _insert_b_row(table_name)
+    insert_sql = _insert_b_row(table_name, seed_two_tenants)
     if insert_sql is not None:
+        from sqlalchemy.exc import DBAPIError
+
         try:
             result = await db_session.execute(text(insert_sql))
             await db_session.flush()
+        except DBAPIError as exc:
+            await db_session.rollback()
+            await set_tenant_context(
+                db_session, UUID(TENANT_A_ID), is_superadmin=False
+            )
+            sqlstate = getattr(exc.orig, "sqlstate", None)
+            assert sqlstate == "42501", (
+                f"INSERT on {table_name} was rejected with SQLSTATE "
+                f"{sqlstate!r}, expected '42501' (RLS insufficient_privilege). "
+                f"A generic constraint error does not prove RLS enforcement."
+            )
+        else:
             assert result.rowcount == 0, (
                 f"INSERT on {table_name} affected {result.rowcount} rows "
-                f"for Tenant B when scoped to Tenant A"
+                f"for Tenant B when scoped to Tenant A (RLS bypassed?)"
             )
-        except (IntegrityError, ProgrammingError):
-            await db_session.rollback()
-            await set_tenant_context(db_session, UUID(TENANT_A_ID), is_superadmin=False)
-            # IntegrityError (FK violation) and ProgrammingError
-            # (InsufficientPrivilegeError — RLS rejects new row) are both
-            # acceptable RLS enforcement mechanisms
-            pass
-    else:
-        # Skip tables that require invisible FK parents
-        pass
 
     # --- UPDATE ---
     update_sql = _update_b_rows(table_name)

--- a/tests/sdd/test_rls_cross_tenant_crud.py
+++ b/tests/sdd/test_rls_cross_tenant_crud.py
@@ -1,0 +1,211 @@
+"""Cross-tenant CRUD denial tests for all 7 RLS-protected tables.
+
+Spec requirement #1: A session scoped to Tenant A MUST NOT be able to
+SELECT / INSERT / UPDATE / DELETE rows belonging to Tenant B.
+
+RED phase: all 14 parametrized test cases expected to fail when the
+database session connects as a superuser (current CI setup), because
+superuser bypasses RLS entirely.
+
+GREEN phase: after CI hardening (WU-6) sets soc360_app as NOSUPERUSER
+NOBYPASSRLS, these tests MUST all pass.
+"""
+
+from uuid import UUID
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import set_tenant_context
+from tests.conftest import TENANT_A_ID, TENANT_B_ID
+from tests.sdd.conftest import PROTECTED_TABLES
+
+
+# ---------------------------------------------------------------------------
+# Helper: build dynamic SELECT / INSERT / UPDATE / DELETE statements
+# ---------------------------------------------------------------------------
+
+
+def _select_b_tenant_rows(table: str) -> str:
+    """Return SELECT that would match Tenant B rows."""
+    if table == "tenants":
+        return f"SELECT id FROM {table} WHERE id = '{TENANT_B_ID}'"
+    elif table == "users":
+        return f"SELECT id FROM {table} WHERE tenant_id = '{TENANT_B_ID}'"
+    elif table == "refresh_tokens":
+        # refresh_tokens has no tenant_id; filter via users subquery
+        return (
+            f"SELECT rt.id FROM {table} rt "
+            f"JOIN users u ON u.id = rt.user_id "
+            f"WHERE u.tenant_id = '{TENANT_B_ID}'"
+        )
+    else:
+        return f"SELECT id FROM {table} WHERE tenant_id = '{TENANT_B_ID}'"
+
+
+def _insert_b_row(table: str) -> str | None:
+    """Return INSERT for a Tenant B row (to verify RLS blocks it)."""
+    if table == "tenants":
+        return (
+            f"INSERT INTO {table} (id, name, slug, plan, is_active, max_assets) "
+            f"VALUES ('{UUID('33333333-3333-3333-3333-333333333333')}', "
+            f"'Tenant C', 'tenant-c', 'free', true, 10)"
+        )
+    elif table == "users":
+        return (
+            f"INSERT INTO {table} (id, tenant_id, email, hashed_password, "
+            f"full_name, role, is_active, is_superadmin) "
+            f"VALUES ('{UUID('44444444-4444-4444-4444-444444444444')}', "
+            f"'{TENANT_B_ID}', 'intruder@evil.test', 'hash', "
+            f"'Intruder', 'viewer', true, false)"
+        )
+    elif table == "refresh_tokens":
+        # INSERT with user_id from Tenant B — RLS on users FK blocks it
+        return None  # skip — handled separately via FK path
+    elif table == "assets":
+        return (
+            f"INSERT INTO {table} (id, tenant_id, name, hostname, asset_type, status) "
+            f"VALUES ('{UUID('55555555-5555-5555-5555-555555555555')}', "
+            f"'{TENANT_B_ID}', 'Intruder Asset', 'intruder-host', 'host', 'active')"
+        )
+    elif table in ("scans", "vulnerabilities", "reports"):
+        return None  # skip — these require valid parent FK references in Tenant B
+    return None
+
+
+def _update_b_rows(table: str) -> str | None:
+    """Return UPDATE targeting Tenant B rows."""
+    if table == "tenants":
+        return f"UPDATE {table} SET name = 'hacked' WHERE id = '{TENANT_B_ID}'"
+    elif table == "users":
+        return (
+            f"UPDATE {table} SET full_name = 'hacked' "
+            f"WHERE tenant_id = '{TENANT_B_ID}'"
+        )
+    elif table == "refresh_tokens":
+        return (
+            f"UPDATE {table} rt SET revoked_at = NOW() "
+            f"FROM users u WHERE u.id = rt.user_id "
+            f"AND u.tenant_id = '{TENANT_B_ID}'"
+        )
+    elif table == "assets":
+        return (
+            f"UPDATE {table} SET name = 'hacked' " f"WHERE tenant_id = '{TENANT_B_ID}'"
+        )
+    elif table == "scans":
+        return (
+            f"UPDATE {table} SET name = 'hacked' " f"WHERE tenant_id = '{TENANT_B_ID}'"
+        )
+    elif table == "vulnerabilities":
+        return (
+            f"UPDATE {table} SET title = 'hacked' " f"WHERE tenant_id = '{TENANT_B_ID}'"
+        )
+    elif table == "reports":
+        return (
+            f"UPDATE {table} SET name = 'hacked' " f"WHERE tenant_id = '{TENANT_B_ID}'"
+        )
+    return None
+
+
+def _delete_b_rows(table: str) -> str | None:
+    """Return DELETE targeting Tenant B rows."""
+    if table == "tenants":
+        return f"DELETE FROM {table} WHERE id = '{TENANT_B_ID}'"
+    elif table == "users":
+        return f"DELETE FROM {table} WHERE tenant_id = '{TENANT_B_ID}'"
+    elif table == "refresh_tokens":
+        return (
+            f"DELETE FROM {table} rt USING users u "
+            f"WHERE u.id = rt.user_id AND u.tenant_id = '{TENANT_B_ID}'"
+        )
+    elif table == "assets":
+        return f"DELETE FROM {table} WHERE tenant_id = '{TENANT_B_ID}'"
+    elif table == "scans":
+        return f"DELETE FROM {table} WHERE tenant_id = '{TENANT_B_ID}'"
+    elif table == "vulnerabilities":
+        return f"DELETE FROM {table} WHERE tenant_id = '{TENANT_B_ID}'"
+    elif table == "reports":
+        return f"DELETE FROM {table} WHERE tenant_id = '{TENANT_B_ID}'"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Parametrized tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("table_name", PROTECTED_TABLES)
+@pytest.mark.asyncio
+async def test_cross_tenant_select_returns_zero(
+    table_name: str,
+    db_session: AsyncSession,
+    seed_two_tenants: dict,
+):
+    """Tenant A SELECT on Tenant B rows returns zero rows."""
+    await set_tenant_context(db_session, UUID(TENANT_A_ID), is_superadmin=False)
+    stmt = text(_select_b_tenant_rows(table_name))
+    result = await db_session.execute(stmt)
+    rows = result.fetchall()
+    assert len(rows) == 0, (
+        f"SELECT on {table_name} returned {len(rows)} rows for Tenant B "
+        f"when scoped to Tenant A (RLS bypassed?)"
+    )
+
+
+@pytest.mark.parametrize("table_name", PROTECTED_TABLES)
+@pytest.mark.asyncio
+async def test_cross_tenant_write_blocked(
+    table_name: str,
+    db_session: AsyncSession,
+    seed_two_tenants: dict,
+):
+    """Tenant A cannot INSERT/UPDATE/DELETE Tenant B rows.
+
+    Tests INSERT, UPDATE, and DELETE for each table. Skips operations that
+    require FK references that are invisible to the Tenant A session.
+    """
+    from sqlalchemy.exc import IntegrityError, ProgrammingError
+
+    await set_tenant_context(db_session, UUID(TENANT_A_ID), is_superadmin=False)
+
+    # --- INSERT ---
+    insert_sql = _insert_b_row(table_name)
+    if insert_sql is not None:
+        try:
+            result = await db_session.execute(text(insert_sql))
+            await db_session.flush()
+            assert result.rowcount == 0, (
+                f"INSERT on {table_name} affected {result.rowcount} rows "
+                f"for Tenant B when scoped to Tenant A"
+            )
+        except (IntegrityError, ProgrammingError):
+            await db_session.rollback()
+            await set_tenant_context(db_session, UUID(TENANT_A_ID), is_superadmin=False)
+            # IntegrityError (FK violation) and ProgrammingError
+            # (InsufficientPrivilegeError — RLS rejects new row) are both
+            # acceptable RLS enforcement mechanisms
+            pass
+    else:
+        # Skip tables that require invisible FK parents
+        pass
+
+    # --- UPDATE ---
+    update_sql = _update_b_rows(table_name)
+    if update_sql is not None:
+        result = await db_session.execute(text(update_sql))
+        await db_session.flush()
+        assert result.rowcount == 0, (
+            f"UPDATE on {table_name} affected {result.rowcount} rows "
+            f"for Tenant B when scoped to Tenant A"
+        )
+
+    # --- DELETE ---
+    delete_sql = _delete_b_rows(table_name)
+    if delete_sql is not None:
+        result = await db_session.execute(text(delete_sql))
+        await db_session.flush()
+        assert result.rowcount == 0, (
+            f"DELETE on {table_name} affected {result.rowcount} rows "
+            f"for Tenant B when scoped to Tenant A"
+        )

--- a/tests/sdd/test_rls_edge_cases.py
+++ b/tests/sdd/test_rls_edge_cases.py
@@ -1,0 +1,402 @@
+"""Edge-case RLS behaviour tests.
+
+Covers spec requirements #2–#8:
+  #2  Cross-tenant FK rejection
+  #3  Malicious tenant_id UPDATE blocked
+  #4  Absent / empty / invalid tenant context fails closed
+  #5  Pooled connection context does not leak
+  #6  Superadmin context cleanup is correct
+  #7  refresh_tokens isolation through users subquery
+  #8  Cascade isolation respects tenant boundaries
+
+RED phase: all tests expected to fail under superuser role.
+GREEN phase: after CI hardening, all MUST pass.
+"""
+
+from uuid import UUID
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import set_tenant_context
+from tests.conftest import ADMIN_B_ID, TENANT_A_ID, TENANT_B_ID
+
+
+# ===========================================================================
+# #2 — Cross-tenant foreign-key rejection
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_cross_tenant_fk_vulnerability_scan(
+    db_session: AsyncSession,
+    seed_two_tenants: dict,
+):
+    """INSERT vulnerability with scan_id from Tenant B raises FK violation."""
+    from sqlalchemy.exc import IntegrityError
+
+    await set_tenant_context(db_session, UUID(TENANT_A_ID), is_superadmin=False)
+    scan_b_id = seed_two_tenants["scans"]["tenant_b"]
+
+    with pytest.raises(IntegrityError):
+        await db_session.execute(
+            text(
+                "INSERT INTO vulnerabilities "
+                "(id, tenant_id, scan_id, title, severity, status) "
+                "VALUES (gen_random_uuid(), :tenant, :scan_id, "
+                "'Cross-tenant vuln', 'high', 'open')"
+            ),
+            {"tenant": UUID(TENANT_A_ID), "scan_id": scan_b_id},
+        )
+        await db_session.flush()
+
+
+@pytest.mark.asyncio
+async def test_cross_tenant_fk_report_asset(
+    db_session: AsyncSession,
+    seed_two_tenants: dict,
+):
+    """INSERT report with asset_id from Tenant B raises FK violation."""
+    from sqlalchemy.exc import IntegrityError
+
+    await set_tenant_context(db_session, UUID(TENANT_A_ID), is_superadmin=False)
+    asset_b_id = seed_two_tenants["assets"]["tenant_b"]
+
+    with pytest.raises(IntegrityError):
+        await db_session.execute(
+            text(
+                "INSERT INTO reports "
+                "(id, tenant_id, asset_id, name, report_type, status) "
+                "VALUES (gen_random_uuid(), :tenant, :asset_id, "
+                "'Cross-tenant report', 'vulnerability', 'pending')"
+            ),
+            {"tenant": UUID(TENANT_A_ID), "asset_id": asset_b_id},
+        )
+        await db_session.flush()
+
+
+@pytest.mark.asyncio
+async def test_cross_tenant_fk_scan_asset(
+    db_session: AsyncSession,
+    seed_two_tenants: dict,
+):
+    """INSERT scan with asset_id from Tenant B raises FK violation."""
+    from sqlalchemy.exc import IntegrityError
+
+    await set_tenant_context(db_session, UUID(TENANT_A_ID), is_superadmin=False)
+    asset_b_id = seed_two_tenants["assets"]["tenant_b"]
+
+    with pytest.raises(IntegrityError):
+        await db_session.execute(
+            text(
+                "INSERT INTO scans "
+                "(id, tenant_id, asset_id, name, scan_type, status) "
+                "VALUES (gen_random_uuid(), :tenant, :asset_id, "
+                "'Cross-tenant scan', 'vulnerability', 'pending')"
+            ),
+            {"tenant": UUID(TENANT_A_ID), "asset_id": asset_b_id},
+        )
+        await db_session.flush()
+
+
+# ===========================================================================
+# #3 — Malicious tenant_id UPDATE blocked
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_malicious_tenant_id_update(
+    db_session: AsyncSession,
+    seed_two_tenants: dict,
+):
+    """Moving a row to another tenant is blocked by the RLS WITH CHECK policy.
+
+    Uses `assets` (a simple tenant_id FK to tenants, with NO composite parent
+    FK) so the only mechanism that can reject the UPDATE is the RLS policy —
+    this isolates RLS from foreign-key enforcement. Tenant B exists, so the FK
+    is satisfied and cannot mask an RLS failure the way the vulnerabilities
+    composite FK would.
+    """
+    from sqlalchemy.exc import ProgrammingError
+
+    await set_tenant_context(db_session, UUID(TENANT_A_ID), is_superadmin=False)
+    asset_a_id = seed_two_tenants["assets"]["tenant_a"]
+
+    with pytest.raises(ProgrammingError):
+        await db_session.execute(
+            text("UPDATE assets SET tenant_id = :new_tenant WHERE id = :asset_id"),
+            {"new_tenant": UUID(TENANT_B_ID), "asset_id": asset_a_id},
+        )
+        await db_session.flush()
+    await db_session.rollback()
+    await set_tenant_context(db_session, UUID(TENANT_A_ID), is_superadmin=False)
+
+
+# ===========================================================================
+# #4 — Absent / empty / invalid tenant context fails closed
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_no_context_returns_zero(
+    db_session: AsyncSession,
+    seed_two_tenants: dict,
+):
+    """Without SET LOCAL, any query returns zero rows.
+
+    The seed_two_tenants fixture runs inside the same transaction and sets
+    is_superadmin=True via SET LOCAL (transaction-scoped GUC). Override
+    both GUCs to empty to simulate a fresh session without context.
+    """
+    await db_session.execute(text("SELECT set_config('app.is_superadmin', '', true)"))
+    await db_session.execute(text("SELECT set_config('app.current_tenant', '', true)"))
+    result = await db_session.execute(
+        text("SELECT id FROM assets WHERE tenant_id = :tid"),
+        {"tid": UUID(TENANT_A_ID)},
+    )
+    rows = result.fetchall()
+    assert len(rows) == 0, (
+        f"No-context query returned {len(rows)} rows — " "should fail closed"
+    )
+
+
+@pytest.mark.asyncio
+async def test_empty_context_returns_zero(
+    db_session: AsyncSession,
+    seed_two_tenants: dict,
+):
+    """SET LOCAL app.current_tenant = '' → zero rows."""
+    await db_session.execute(text("SELECT set_config('app.current_tenant', '', true)"))
+    await db_session.execute(
+        text("SELECT set_config('app.is_superadmin', 'false', true)")
+    )
+    result = await db_session.execute(
+        text("SELECT id FROM assets WHERE tenant_id = :tid"),
+        {"tid": UUID(TENANT_A_ID)},
+    )
+    rows = result.fetchall()
+    assert len(rows) == 0, (
+        f"Empty-context query returned {len(rows)} rows — " "should fail closed"
+    )
+
+
+@pytest.mark.asyncio
+async def test_invalid_context_returns_zero(
+    db_session: AsyncSession,
+    seed_two_tenants: dict,
+):
+    """SET LOCAL app.current_tenant = 'malicious' → zero rows."""
+    await db_session.execute(
+        text("SELECT set_config('app.current_tenant', 'malicious', true)")
+    )
+    await db_session.execute(
+        text("SELECT set_config('app.is_superadmin', 'false', true)")
+    )
+    result = await db_session.execute(
+        text("SELECT id FROM assets WHERE tenant_id = :tid"),
+        {"tid": UUID(TENANT_A_ID)},
+    )
+    rows = result.fetchall()
+    assert len(rows) == 0, (
+        f"Invalid-context query returned {len(rows)} rows — " "should fail closed"
+    )
+
+
+# ===========================================================================
+# #5 — Pooled connection context does not leak
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_pooled_context_does_not_leak(
+    pooled_engine,
+    isolated_db_session,
+    seed_two_tenants: dict,
+):
+    """After committing Tenant A context, a fresh session has none."""
+    # Session 1: set Tenant A context and commit
+    # isolated_db_session is a synchronous factory, not an async one
+    session1 = isolated_db_session()
+    async with session1.begin():
+        await set_tenant_context(session1, UUID(TENANT_A_ID), is_superadmin=False)
+        await session1.execute(text("SELECT 1"))
+    await session1.close()
+
+    # Session 2 (same pool): should have NO inherited context
+    session2 = isolated_db_session()
+    async with session2.begin():
+        result = await session2.execute(
+            text("SELECT current_setting('app.current_tenant', true)")
+        )
+        tenant_val = result.scalar()
+        assert (
+            tenant_val is None or tenant_val == ""
+        ), f"app.current_tenant leaked: {tenant_val!r}"
+
+        result = await session2.execute(
+            text("SELECT current_setting('app.is_superadmin', true)")
+        )
+        super_val = result.scalar()
+        assert (
+            super_val is None or super_val == ""
+        ), f"app.is_superadmin leaked: {super_val!r}"
+
+        # NOTE: a data-visibility assertion here would be vacuous — the
+        # seed_two_tenants rows are written on the NullPool db_session inside an
+        # uncommitted transaction, so this separate pooled connection can never
+        # see them regardless of RLS context. The GUC-leak assertions above are
+        # the meaningful check for connection-pool context bleed.
+    await session2.close()
+
+
+# ===========================================================================
+# #6 — Superadmin context cleanup is correct
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_superadmin_transition_sequence(
+    db_session: AsyncSession,
+    seed_two_tenants: dict,
+):
+    """superadmin → A → superadmin → B → only B visible."""
+    # Step 1: superadmin sees everything
+    r1 = await db_session.execute(
+        text(
+            "SELECT set_config('app.is_superadmin', 'true', true), "
+            "set_config('app.current_tenant', '', true)"
+        )
+    )
+    r1.fetchall()  # consume result to avoid ResourceClosedError on next execute
+    r2 = await db_session.execute(text("SELECT COUNT(*) FROM vulnerabilities"))
+    total = r2.scalar()
+    assert (
+        total is not None and total >= 2
+    ), f"Superadmin should see all vulnerabilities, got {total}"
+
+    # Step 2: Tenant A sees only Tenant A rows
+    await set_tenant_context(db_session, UUID(TENANT_A_ID), is_superadmin=False)
+    r3 = await db_session.execute(
+        text("SELECT id FROM vulnerabilities WHERE tenant_id = :tid"),
+        {"tid": UUID(TENANT_A_ID)},
+    )
+    a_rows = r3.fetchall()
+    assert len(a_rows) >= 1
+
+    r4 = await db_session.execute(
+        text("SELECT id FROM vulnerabilities WHERE tenant_id = :tid"),
+        {"tid": UUID(TENANT_B_ID)},
+    )
+    b_rows_in_a = r4.fetchall()
+    assert len(b_rows_in_a) == 0
+
+    # Step 3: superadmin again — consume the set_tenant_context result
+    r5 = await db_session.execute(
+        text(
+            "SELECT set_config('app.is_superadmin', 'true', true), "
+            "set_config('app.current_tenant', '', true)"
+        )
+    )
+    r5.fetchall()  # consume result to avoid ResourceClosedError on next execute
+    r6 = await db_session.execute(text("SELECT COUNT(*) FROM vulnerabilities"))
+    total2 = r6.scalar()
+    assert total2 is not None and total2 >= 2
+
+    # Step 4: Tenant B — only Tenant B rows visible
+    await set_tenant_context(db_session, UUID(TENANT_B_ID), is_superadmin=False)
+    r7 = await db_session.execute(
+        text("SELECT id FROM vulnerabilities WHERE tenant_id = :tid"),
+        {"tid": UUID(TENANT_B_ID)},
+    )
+    b_rows = r7.fetchall()
+    assert len(b_rows) >= 1
+
+    r8 = await db_session.execute(
+        text("SELECT id FROM vulnerabilities WHERE tenant_id = :tid"),
+        {"tid": UUID(TENANT_A_ID)},
+    )
+    a_rows_in_b = r8.fetchall()
+    assert (
+        len(a_rows_in_b) == 0
+    ), f"Tenant B should not see Tenant A rows, got {len(a_rows_in_b)}"
+
+
+# ===========================================================================
+# #7 — refresh_tokens isolation through users subquery
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_refresh_tokens_isolation(
+    db_session: AsyncSession,
+    seed_two_tenants: dict,
+):
+    """Tenant A cannot access Tenant B refresh tokens."""
+    from sqlalchemy.exc import IntegrityError, ProgrammingError
+
+    await set_tenant_context(db_session, UUID(TENANT_A_ID), is_superadmin=False)
+    rt_b_id = seed_two_tenants["refresh_tokens"]["tenant_b"]
+
+    # SELECT — should return zero rows
+    result = await db_session.execute(
+        text(
+            "SELECT rt.id FROM refresh_tokens rt "
+            "JOIN users u ON u.id = rt.user_id "
+            "WHERE u.tenant_id = :tid"
+        ),
+        {"tid": UUID(TENANT_B_ID)},
+    )
+    assert (
+        len(result.fetchall()) == 0
+    ), "Tenant A should not see Tenant B refresh tokens"
+
+    # INSERT — blocked by RLS WITH CHECK (InsufficientPrivilege) or by the FK
+    # to the Tenant B user, which is invisible under Tenant A context.
+    with pytest.raises((IntegrityError, ProgrammingError)):
+        await db_session.execute(
+            text(
+                "INSERT INTO refresh_tokens (user_id, token_hash, expires_at) "
+                "VALUES (:uid, 'hash_test', '2030-01-01T00:00:00Z')"
+            ),
+            {"uid": UUID(ADMIN_B_ID)},
+        )
+        await db_session.flush()
+    await db_session.rollback()
+    await set_tenant_context(db_session, UUID(TENANT_A_ID), is_superadmin=False)
+
+
+# ===========================================================================
+# #8 — Cascade isolation respects tenant boundaries
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_cascade_isolation(
+    db_session: AsyncSession,
+    seed_two_tenants: dict,
+):
+    """Tenant A DELETE on Tenant B asset affects zero rows (no cascade)."""
+    await set_tenant_context(db_session, UUID(TENANT_A_ID), is_superadmin=False)
+    asset_b_id = seed_two_tenants["assets"]["tenant_b"]
+
+    # Attempt to delete Tenant B's asset while scoped to Tenant A
+    result = await db_session.execute(
+        text("DELETE FROM assets WHERE id = :asset_id"),
+        {"asset_id": asset_b_id},
+    )
+    await db_session.flush()
+    assert result.rowcount == 0, (
+        f"DELETE on Tenant B asset from Tenant A session affected "
+        f"{result.rowcount} rows — RLS should have blocked it"
+    )
+
+    # Verify Tenant B's data is intact (use superadmin to check)
+    await set_tenant_context(db_session, None, is_superadmin=True)
+    result = await db_session.execute(
+        text("SELECT id FROM assets WHERE id = :asset_id"),
+        {"asset_id": asset_b_id},
+    )
+    assert (
+        result.fetchone() is not None
+    ), "Tenant B asset should still exist after blocked delete"


### PR DESCRIPTION
## Summary
- Restores FK-child + user indexes via new Alembic migration `a1b2c3d4e5f6` and ORM declarations.
- Adds a tenant-isolation RLS test suite that runs as the hardened `soc360_app` role (`NOSUPERUSER NOBYPASSRLS`), so Row-Level Security is genuinely exercised — not bypassed by a superuser.
- Test DB setup now runs the full Alembic chain (instead of `Base.metadata.create_all`) so RLS policies and GRANTs exist; CI separates the migration role from the app role.

## Review — Judgment Day (dual blind adversarial)
Two blind read-only judges + runtime verification. Confirmed severe findings were fixed:
- **RLS false-confidence:** `test_malicious_tenant_id_update` previously passed via the composite-FK `IntegrityError`, so it passed even with RLS disabled → rewritten on `assets` (simple FK) to assert an RLS-specific `ProgrammingError` (WITH CHECK).
- **`_ensure_app_role` bare `except`:** masked real `ALTER ROLE` failures → replaced with an explicit `pg_roles` existence check.
- Removed a vacuous pooled-leak assertion and a redundant nested `try/except`.

Non-blocking follow-ups (optional): migration uses raw `op.execute` for 3 plain composite indexes; CI could add an `ELSE ALTER ROLE ... NOSUPERUSER NOBYPASSRLS` branch to re-harden a wrong-state role.

## Test plan
- [x] `uv run pytest tests/sdd/` → **48 passed** against `soc360_postgres_test` (app-role NOSUPERUSER NOBYPASSRLS)
- [x] RLS-specific malicious-move test passes → RLS WITH CHECK verified enforced
- [x] CI green on the hardened-role job

Closes #263