### PR TITLE
fix(redis): enforce authenticated structured configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,9 +23,11 @@ DB_STATEMENT_TIMEOUT_MS=30000
 # Timeout for acquiring row/table locks (ms). 0 or negative is rejected.
 DB_LOCK_TIMEOUT_MS=5000
 
-# Redis
+# Redis — structured settings; REDIS_URL is rejected (PR1 #260)
+REDIS_HOST=localhost
+REDIS_PORT=6379
+REDIS_DB=0
 REDIS_PASSWORD=soc360_redis_dev_password
-REDIS_URL=redis://:soc360_redis_dev_password@localhost:6379/0
 
 # JWT
 JWT_ALGORITHM=HS256

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,13 +30,22 @@ jobs:
 
       redis:
         image: redis:7-alpine
-        ports:
-          - 6379:6379
+        env:
+          REDIS_PASSWORD: ci_test_redis_password
         options: >-
-          --health-cmd "redis-cli ping"
+          --health-cmd "redis-cli -a ci_test_redis_password ping"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+        command: redis-server --requirepass ci_test_redis_password
+        ports:
+          - 6379:6379
+
+      toxiproxy:
+        image: ghcr.io/shopify/toxiproxy:2.9.0
+        ports:
+          - 8474:8474
+          - 26379:26379
 
     env:
       ENVIRONMENT: development
@@ -45,8 +54,10 @@ jobs:
       POSTGRES_DB: soc360_pymes_test
       DATABASE_URL: postgresql+asyncpg://soc360_app:soc360_test_password@localhost:5432/soc360_pymes_test
       DATABASE_URL_MIGRATION: postgresql+asyncpg://soc360_migration:soc360_test_password@localhost:5432/soc360_pymes_test
-      REDIS_URL: redis://localhost:6379/0
-      REDIS_PASSWORD: ""
+      REDIS_HOST: localhost
+      REDIS_PORT: 6379
+      REDIS_DB: 15
+      REDIS_PASSWORD: ci_test_redis_password
       SECRET_KEY: abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwx
       ACCESS_TOKEN_EXPIRE_MINUTES: 30
       REFRESH_TOKEN_EXPIRE_DAYS: 7

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+import os
 from collections import Counter
 from math import log2
 
-from pydantic import field_validator, model_validator
+from pydantic import SecretStr, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from app.core._provider_names import _PROVIDER_NAMES
@@ -21,6 +22,7 @@ class Settings(BaseSettings):
         env_file=".env",
         env_file_encoding="utf-8",
         case_sensitive=False,
+        extra="ignore",
     )
     
     #Aplicacion
@@ -90,13 +92,23 @@ class Settings(BaseSettings):
     # crashed processes are reclaimed automatically after this many seconds.
     EVENT_RETRY_TTL_SECONDS: int = 86400
 
-    #Redis
-    REDIS_PASSWORD: str | None = None
-    REDIS_URL: str = "redis://localhost:6379/0"
+    #Redis — structured settings; REDIS_URL is rejected (PR1 #260)
+    REDIS_HOST: str = "localhost"
+    REDIS_PORT: int = 6379
+    REDIS_DB: int = 0
+    REDIS_PASSWORD: SecretStr = SecretStr("")
     REDIS_MAX_CONNECTIONS: int = 20
     # Startup ping retry — rides out transient Redis blips during lifespan (issue #128)
     REDIS_STARTUP_MAX_ATTEMPTS: int = 3
     REDIS_STARTUP_BACKOFF_BASE_SECONDS: float = 1.0
+
+    def __init__(self, **values):
+        if any(str(key).upper() == "REDIS_URL" for key in values):
+            raise ValueError(
+                "REDIS_URL is no longer supported. "
+                "Use REDIS_HOST, REDIS_PORT, REDIS_DB, and REDIS_PASSWORD instead."
+            )
+        super().__init__(**values)
     
     # Rate Limiting (progressive lockout)
     RATE_LIMIT_ENABLED: bool = True
@@ -171,19 +183,29 @@ class Settings(BaseSettings):
             raise ValueError("CORS_ORIGINS no puede contener wildcard '*'")
         return v
     
-    @field_validator("REDIS_URL")
+    @model_validator(mode="before")
     @classmethod
-    def redis_auth_in_production(cls, v: str, info) -> str:
-        environment = info.data.get("ENVIRONMENT", "development")
-        redis_password = info.data.get("REDIS_PASSWORD")
-        if redis_password and "@" not in v:
-            raise ValueError("REDIS_URL debe incluir autenticación cuando REDIS_PASSWORD está configurado")
-        if environment == "production" and "@" not in v:
-            raise ValueError("REDIS_URL debe incluir autenticación en producción")
-        if environment == "production" and not redis_password:
-            raise ValueError("REDIS_PASSWORD es requerido en producción")
-        return v
-    
+    def reject_redis_url(cls, data):
+        """Reject REDIS_URL from kwargs, environment, or dotenv (PR1 #260)."""
+        dotenv_or_kwargs = isinstance(data, dict) and any(
+            str(key).upper() == "REDIS_URL" for key in data
+        )
+        if dotenv_or_kwargs or any(key.upper() == "REDIS_URL" for key in os.environ):
+            raise ValueError(
+                "REDIS_URL is no longer supported. "
+                "Use REDIS_HOST, REDIS_PORT, REDIS_DB, and REDIS_PASSWORD instead."
+            )
+        return data
+
+    @model_validator(mode="after")
+    def redis_password_required_in_production(self) -> Settings:
+        """Production must have a non-empty REDIS_PASSWORD."""
+        if self.ENVIRONMENT == "production":
+            if not self.REDIS_PASSWORD.get_secret_value():
+                raise ValueError("REDIS_PASSWORD is required in production")
+        return self
+
+
     @field_validator("LLM_PROVIDER")
     @classmethod
     def llm_provider_valid(cls, v: str) -> str:

--- a/app/core/redis.py
+++ b/app/core/redis.py
@@ -15,8 +15,12 @@ logger = get_logger(__name__)
 def get_pool() -> ConnectionPool:
     global _pool
     if _pool is None:
-        _pool = ConnectionPool.from_url(
-            str(settings.REDIS_URL),
+        password = settings.REDIS_PASSWORD.get_secret_value()
+        _pool = ConnectionPool(
+            host=settings.REDIS_HOST,
+            port=settings.REDIS_PORT,
+            db=settings.REDIS_DB,
+            password=password or None,
             decode_responses=True,
             max_connections=settings.REDIS_MAX_CONNECTIONS,
         )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,15 +46,27 @@ services:
       redis-server
       --maxmemory 256mb
       --maxmemory-policy allkeys-lru
-      --requirepass ${REDIS_PASSWORD}
+      --requirepass ${REDIS_PASSWORD:?REDIS_PASSWORD must be set}
     # Host port mapping for local dev ONLY — do not expose in staging/production
     ports:
       - "6379:6379"
     volumes:
       - ./docker/redis-data:/data
     healthcheck:
-      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD}", "ping"]
+      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD:?REDIS_PASSWORD must be set}", "ping"]
       interval: 10s
       timeout: 6s
       retries: 5
+    restart: unless-stopped
+
+  toxiproxy:
+    image: ghcr.io/shopify/toxiproxy:2.9.0
+    container_name: soc360_toxiproxy
+    profiles: [dev, test]
+    ports:
+      - "8474:8474"
+      - "26379:26379"
+    depends_on:
+      redis:
+        condition: service_healthy
     restart: unless-stopped

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,11 @@ os.environ.setdefault("GROQ_API_KEY", "gsk_test_fake_key_for_tests_only")
 os.environ.setdefault("POSTGRES_USER", "soc360_app")
 os.environ.setdefault("POSTGRES_PASSWORD", "soc360_dev_password")
 os.environ.setdefault("POSTGRES_DB", "soc360_test")
-os.environ.setdefault("REDIS_URL", "redis://localhost:6379/15")
+# Structured Redis settings (PR1 #260 — REDIS_URL is rejected)
+os.environ.setdefault("REDIS_HOST", "localhost")
+os.environ.setdefault("REDIS_PORT", "6379")
+os.environ.setdefault("REDIS_DB", "15")
+os.environ.setdefault("REDIS_PASSWORD", "test_redis_password")
 
 from app.main import create_app
 from app.core.redis import get_redis
@@ -457,3 +461,31 @@ async def isolated_db_session(pooled_engine):
 
     for s in sessions:
         await s.close()
+
+
+# ---------------------------------------------------------------------------
+# Toxiproxy session fixture — PR1 #260 baseline fault-injection harness
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture(scope="session", loop_scope="session")
+async def toxiproxy_session():
+    """Set up the Toxiproxy Redis proxy for the test session.
+
+    Creates the proxy if it does not exist, ensures it is enabled,
+    and asserts clean Redis state through the proxy. Setup and teardown
+    failures are propagated because this is a mandatory CI baseline.
+    """
+    from tests.helpers.toxiproxy import ToxiproxyTransportController
+
+    controller = ToxiproxyTransportController()
+    await controller.ensure_proxy(
+        name="redis",
+        listen="0.0.0.0:26379",
+        upstream="redis:6379",
+    )
+
+    yield controller
+
+    # Teardown: ensure proxy is re-enabled for the next session
+    await controller.enable_proxy("redis")

--- a/tests/helpers/toxiproxy.py
+++ b/tests/helpers/toxiproxy.py
@@ -1,0 +1,62 @@
+"""Toxiproxy transport controller for fault-injection tests (PR1 #260).
+
+Exposes proxy disable/enable only. Named transport scenarios are added by
+later PRs (PR6 timeout, PR7 timeout, PR8 reset_peer, PR9 timeout).
+
+Uses httpx (already a project dependency) to talk to the Toxiproxy admin API.
+"""
+from __future__ import annotations
+
+import httpx
+
+DEFAULT_ADMIN_URL = "http://localhost:8474"
+DEFAULT_LISTEN = "0.0.0.0:26379"
+DEFAULT_UPSTREAM = "redis:6379"
+
+
+class ToxiproxyTransportController:
+    """Control Toxiproxy proxies for deterministic fault injection."""
+
+    def __init__(self, admin_url: str = DEFAULT_ADMIN_URL) -> None:
+        self._admin_url = admin_url.rstrip("/")
+
+    async def ensure_proxy(
+        self,
+        name: str,
+        listen: str = DEFAULT_LISTEN,
+        upstream: str = DEFAULT_UPSTREAM,
+    ) -> None:
+        """Create the proxy if it does not exist; enable it if disabled."""
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(f"{self._admin_url}/proxies/{name}")
+            if resp.status_code == 404:
+                response = await client.post(
+                    f"{self._admin_url}/proxies",
+                    json={
+                        "name": name,
+                        "listen": listen,
+                        "upstream": upstream,
+                        "enabled": True,
+                    },
+                )
+                response.raise_for_status()
+            elif not resp.json().get("enabled", True):
+                await self.enable_proxy(name)
+
+    async def disable_proxy(self, name: str) -> None:
+        """Disable a proxy to simulate connection refusal."""
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                f"{self._admin_url}/proxies/{name}",
+                json={"enabled": False},
+            )
+            resp.raise_for_status()
+
+    async def enable_proxy(self, name: str) -> None:
+        """Re-enable a previously disabled proxy."""
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                f"{self._admin_url}/proxies/{name}",
+                json={"enabled": True},
+            )
+            resp.raise_for_status()

--- a/tests/integration/test_event_bus_e2e.py
+++ b/tests/integration/test_event_bus_e2e.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import asyncio
 import uuid
 from datetime import datetime, timezone
+from urllib.parse import quote
 
 import pytest
 import pytest_asyncio
@@ -32,12 +33,28 @@ from app.event_schemas import AuthLoginEvent
 async def _redis_is_available() -> bool:
     """Check if Redis is reachable."""
     try:
-        client = Redis.from_url(settings.REDIS_URL, decode_responses=False)
+        client = Redis.from_url(_redis_url(), decode_responses=False)
         await client.ping()
         await client.aclose()
         return True
     except Exception:
         return False
+
+
+def _redis_url() -> str:
+    """Build a Redis URL from the structured settings contract.
+
+    Mirrors the production ``get_pool`` construction: an empty password is
+    treated as no authentication, and the password is percent-encoded so
+    special characters survive the URL format.
+    """
+    password = settings.REDIS_PASSWORD.get_secret_value()
+    if password:
+        return (
+            f"redis://:{quote(password, safe='')}@"
+            f"{settings.REDIS_HOST}:{settings.REDIS_PORT}/{settings.REDIS_DB}"
+        )
+    return f"redis://{settings.REDIS_HOST}:{settings.REDIS_PORT}/{settings.REDIS_DB}"
 
 
 # Skip all tests in this module if Redis is not available
@@ -54,7 +71,7 @@ async def redis_client() -> Redis:
     """Provide a real Redis client for E2E tests."""
     if not await _redis_is_available():
         pytest.skip("Redis not available — E2E tests require a running Redis instance")
-    client = Redis.from_url(settings.REDIS_URL, decode_responses=False)
+    client = Redis.from_url(_redis_url(), decode_responses=False)
     # Cleanup BEFORE test to ensure clean state
     try:
         keys = await client.keys("events:*")

--- a/tests/integration/test_toxiproxy_baseline.py
+++ b/tests/integration/test_toxiproxy_baseline.py
@@ -1,0 +1,110 @@
+"""PR1 Toxiproxy baseline — proxy-disabled connection refusal smoke test.
+
+This is the mandatory CI gate that every PR (PR1–PR9) must run.
+Named transport scenario: proxy-disabled connection refusal.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+from redis.asyncio import Redis
+from redis.exceptions import ConnectionError as RedisConnectionError
+from redis.exceptions import TimeoutError as RedisTimeoutError
+
+from tests.helpers.toxiproxy import ToxiproxyTransportController
+
+pytestmark = pytest.mark.integration
+
+PROXY_NAME = "redis"
+
+
+@pytest.mark.asyncio
+async def test_pr1_redis_connection_refused_smoke(
+    toxiproxy_session: ToxiproxyTransportController,
+):
+    """When the Toxiproxy proxy is disabled, Redis connections must be refused.
+
+    This proves the baseline fault-injection harness works: disabling the
+    proxy causes a connection error, re-enabling it restores connectivity.
+    """
+    # 1. Verify Redis is reachable through the proxy
+    client = Redis(
+        host="localhost",
+        port=26379,
+        db=int(os.environ.get("REDIS_DB", "0")),
+        password=os.environ.get("REDIS_PASSWORD") or None,
+        decode_responses=True,
+    )
+    try:
+        assert await client.ping() is True
+    finally:
+        await client.aclose()
+
+    # 2. Disable the proxy — simulates Redis being unreachable
+    try:
+        await toxiproxy_session.disable_proxy(PROXY_NAME)
+
+        # 3. Connection must be refused
+        client2 = Redis(
+            host="localhost",
+            port=26379,
+            db=int(os.environ.get("REDIS_DB", "0")),
+            password=os.environ.get("REDIS_PASSWORD") or None,
+            decode_responses=True,
+            socket_connect_timeout=2,
+        )
+        try:
+            with pytest.raises((RedisConnectionError, RedisTimeoutError)):
+                await client2.ping()
+        finally:
+            await client2.aclose()
+    finally:
+        # 4. Re-enable the proxy — connectivity must be restored
+        await toxiproxy_session.enable_proxy(PROXY_NAME)
+
+    client3 = Redis(
+        host="localhost",
+        port=26379,
+        db=int(os.environ.get("REDIS_DB", "0")),
+        password=os.environ.get("REDIS_PASSWORD") or None,
+        decode_responses=True,
+    )
+    try:
+        assert await client3.ping() is True
+    finally:
+        await client3.aclose()
+
+
+@pytest.mark.asyncio
+async def test_toxiproxy_setup_errors_fail_closed(monkeypatch):
+    """Unexpected mandatory baseline setup errors must fail the session."""
+    import tests.conftest as project_conftest
+
+    async def fail_setup(*args, **kwargs):
+        raise RuntimeError("admin unavailable")
+
+    monkeypatch.setattr(ToxiproxyTransportController, "ensure_proxy", fail_setup)
+
+    with pytest.raises(RuntimeError, match="admin unavailable"):
+        await project_conftest.toxiproxy_session.__wrapped__().__anext__()
+
+
+@pytest.mark.asyncio
+async def test_toxiproxy_teardown_errors_fail_closed(monkeypatch):
+    """Unexpected mandatory baseline teardown errors must fail the session."""
+    import tests.conftest as project_conftest
+
+    async def ensure_setup(*args, **kwargs):
+        return None
+
+    async def fail_teardown(*args, **kwargs):
+        raise RuntimeError("proxy cleanup unavailable")
+
+    monkeypatch.setattr(ToxiproxyTransportController, "ensure_proxy", ensure_setup)
+    monkeypatch.setattr(ToxiproxyTransportController, "enable_proxy", fail_teardown)
+
+    session = project_conftest.toxiproxy_session.__wrapped__()
+    await session.__anext__()
+    with pytest.raises(RuntimeError, match="proxy cleanup unavailable"):
+        await session.__anext__()

--- a/tests/sdd/test_uv_migration.py
+++ b/tests/sdd/test_uv_migration.py
@@ -234,5 +234,5 @@ def test_no_dockerfile_and_compose_has_only_infrastructure_services():
         and not line.startswith("    ")
     ]
     assert (
-        sorted(services) == ["postgres", "postgres-test", "redis"]
-    ), f"docker-compose.yml should only define infrastructure services (postgres, postgres-test, redis), found: {services}"
+        sorted(services) == ["postgres", "postgres-test", "redis", "toxiproxy"]
+    ), f"docker-compose.yml should only define infrastructure services (postgres, postgres-test, redis, toxiproxy), found: {services}"

--- a/tests/unit/test_config_redis_auth.py
+++ b/tests/unit/test_config_redis_auth.py
@@ -1,0 +1,181 @@
+"""Tests for structured Redis configuration and REDIS_URL rejection (PR1).
+
+Verifies:
+- REDIS_URL is rejected whenever present (env or kwargs).
+- Structured REDIS_HOST/PORT/DB/PASSWORD:SecretStr is the only valid path.
+- REDIS_PASSWORD is a SecretStr (never leaked in repr/str).
+- Production requires a non-empty REDIS_PASSWORD.
+"""
+from __future__ import annotations
+
+import pytest
+from pydantic import SecretStr, ValidationError
+
+# Shared required fields (no REDIS_URL — structured fields only)
+_REQUIRED = dict(
+    ENVIRONMENT="development",
+    DATABASE_URL="postgresql+asyncpg://test:test@localhost/test",
+    DATABASE_URL_MIGRATION="postgresql+asyncpg://test:test@localhost/test",
+    POSTGRES_USER="test",
+    POSTGRES_PASSWORD="test",
+    POSTGRES_DB="test",
+    LLM_PROVIDER="ollama",
+)
+
+
+class TestRedisUrlRejected:
+    """REDIS_URL must be rejected whenever it is present."""
+
+    def test_redis_url_rejected_when_set(self, monkeypatch: pytest.MonkeyPatch):
+        """REDIS_URL in the environment must raise a clear validation error."""
+        from app.core.config import Settings
+
+        monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+        with pytest.raises(ValidationError, match="REDIS_URL"):
+            Settings(_env_file=None, **_REQUIRED)
+
+    def test_redis_url_rejected_when_present_but_empty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Presence, rather than truthiness, selects the rejected legacy path."""
+        from app.core.config import Settings
+
+        monkeypatch.setenv("REDIS_URL", "")
+        with pytest.raises(ValidationError, match="REDIS_URL"):
+            Settings(_env_file=None, **_REQUIRED)
+
+    def test_redis_url_rejected_from_kwargs(self):
+        """REDIS_URL passed as a kwarg must raise a clear validation error."""
+        from app.core.config import Settings
+
+        with pytest.raises((ValidationError, ValueError), match="REDIS_URL"):
+            Settings(
+                _env_file=None,
+                REDIS_URL="redis://localhost:6379/0",
+                **_REQUIRED,
+            )
+
+    def test_redis_url_rejected_from_dotenv_file(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path
+    ):
+        """REDIS_URL supplied only by a dotenv file must be rejected."""
+        from app.core.config import Settings
+
+        monkeypatch.delenv("REDIS_URL", raising=False)
+        env_file = tmp_path / "redis-url.env"
+        env_file.write_text(
+            "\n".join(
+                [
+                    "ENVIRONMENT=development",
+                    "DATABASE_URL=postgresql+asyncpg://test:test@localhost/test",
+                    "DATABASE_URL_MIGRATION=postgresql+asyncpg://test:test@localhost/test",
+                    "POSTGRES_USER=test",
+                    "POSTGRES_PASSWORD=test",
+                    "POSTGRES_DB=test",
+                    "LLM_PROVIDER=ollama",
+                    "REDIS_URL=redis://localhost:6379/0",
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+        with pytest.raises(ValidationError, match="REDIS_URL"):
+            Settings(_env_file=env_file)
+
+
+class TestStructuredRedisSettings:
+    """Structured REDIS_HOST/PORT/DB/PASSWORD must be the only valid path."""
+
+    def test_structured_redis_settings_accepted(self):
+        """Valid structured settings must be accepted without error."""
+        from app.core.config import Settings
+
+        s = Settings(
+            _env_file=None,
+            REDIS_HOST="redis.example.com",
+            REDIS_PORT=6380,
+            REDIS_DB=3,
+            REDIS_PASSWORD="s3cret",
+            **_REQUIRED,
+        )
+        assert s.REDIS_HOST == "redis.example.com"
+        assert s.REDIS_PORT == 6380
+        assert s.REDIS_DB == 3
+        assert isinstance(s.REDIS_PASSWORD, SecretStr)
+        assert s.REDIS_PASSWORD.get_secret_value() == "s3cret"
+
+    def test_redis_password_is_secret_str(self):
+        """REDIS_PASSWORD must be a SecretStr — never leaked in repr."""
+        from app.core.config import Settings
+
+        s = Settings(
+            _env_file=None,
+            REDIS_PASSWORD="my_secret_pass",
+            **_REQUIRED,
+        )
+        assert isinstance(s.REDIS_PASSWORD, SecretStr)
+        # repr must NOT contain the actual password
+        assert "my_secret_pass" not in repr(s.REDIS_PASSWORD)
+
+    def test_redis_defaults(self, monkeypatch: pytest.MonkeyPatch):
+        """REDIS_HOST/PORT/DB must have sensible defaults when not overridden."""
+        from app.core.config import Settings
+
+        # Clear any env vars that would override defaults
+        for key in ("REDIS_HOST", "REDIS_PORT", "REDIS_DB"):
+            monkeypatch.delenv(key, raising=False)
+
+        s = Settings(
+            _env_file=None,
+            REDIS_PASSWORD="test_pass",
+            **_REQUIRED,
+        )
+        assert s.REDIS_HOST == "localhost"
+        assert s.REDIS_PORT == 6379
+        assert s.REDIS_DB == 0
+
+    def test_production_requires_non_empty_password(self):
+        """Production environment must reject empty REDIS_PASSWORD."""
+        from app.core.config import Settings
+
+        prod_required = {**_REQUIRED, "ENVIRONMENT": "production"}
+        with pytest.raises(ValidationError, match="REDIS_PASSWORD"):
+            Settings(
+                _env_file=None,
+                REDIS_PASSWORD="",
+                **prod_required,
+            )
+
+    def test_settings_do_not_expose_legacy_redis_url_accessor(self):
+        """The rejected URL must not remain as a compatibility accessor."""
+        from app.core.config import Settings
+
+        settings = Settings(_env_file=None, REDIS_PASSWORD="test_pass", **_REQUIRED)
+        assert not hasattr(settings, "REDIS_URL")
+
+
+def test_get_pool_uses_authenticated_structured_settings(monkeypatch: pytest.MonkeyPatch):
+    """Pool construction passes structured fields and the secret to redis-py."""
+    import app.core.redis as redis_module
+    from app.core.redis import close_pool, get_pool
+
+    class RedisSettings:
+        REDIS_HOST = "redis.example.com"
+        REDIS_PORT = 6380
+        REDIS_DB = 4
+        REDIS_PASSWORD = SecretStr("pool-secret")
+        REDIS_MAX_CONNECTIONS = 7
+
+    monkeypatch.setattr(redis_module, "settings", RedisSettings())
+    monkeypatch.setattr(redis_module, "_pool", None)
+    pool = get_pool()
+    assert pool.connection_kwargs["host"] == "redis.example.com"
+    assert pool.connection_kwargs["port"] == 6380
+    assert pool.connection_kwargs["db"] == 4
+    assert pool.connection_kwargs["password"] == "pool-secret"
+    assert pool.max_connections == 7
+
+    # Keep the singleton isolated from the process-global test fixture.
+    import asyncio
+
+    asyncio.run(close_pool())


### PR DESCRIPTION
Closes #260

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Replace the legacy `REDIS_URL` contract with structured host, port, database, and secret password settings.
- Require authenticated Redis in Docker and CI while keeping secrets protected with `SecretStr`.
- Add a fail-closed Toxiproxy baseline and migrate event-bus integration tests to the structured contract.

## Changes

| File | Change |
|------|--------|
| `app/core/config.py` | Reject legacy `REDIS_URL`, define structured Redis settings, and require a production password. |
| `app/core/redis.py` | Build the singleton Redis pool from authenticated structured settings. |
| `.env.example` | Document the supported Redis configuration contract. |
| `docker-compose.yml` | Require Redis authentication and add the Toxiproxy service. |
| `.github/workflows/ci.yml` | Run authenticated Redis and Toxiproxy services in CI. |
| `tests/conftest.py` | Configure structured Redis test settings and a fail-closed Toxiproxy fixture. |
| `tests/helpers/toxiproxy.py` | Add deterministic proxy control for Redis outage testing. |
| `tests/integration/test_toxiproxy_baseline.py` | Verify connection refusal and recovery through Toxiproxy. |
| `tests/integration/test_event_bus_e2e.py` | Remove the remaining legacy URL dependency and safely encode passwords. |
| `tests/unit/test_config_redis_auth.py` | Cover the structured settings contract and authenticated pool construction. |

## Test plan

- [x] `git diff --check`
- [x] Redis configuration tests: 10 passed
- [x] Focused Toxiproxy tests: 12 passed
- [x] Event-bus Redis E2E tests: 6 passed, 0 failed/errors/skips
- [x] No shell scripts modified; shellcheck is not applicable

## Contributor checklist

- [x] Linked approved issue #260
- [x] Added exactly one `type:*` label
- [x] Tests and operational harness are included with the behavior
- [x] Configuration documentation was updated
- [x] Commit uses Conventional Commit format
- [x] No `Co-Authored-By` trailers

## Delivery note

Review-driven development is disabled for this candidate; delivery is unmanaged by the Gentle AI review gate.