### PR TITLE
test(redis): add toxiproxy fault injection matrix [slice 2 of 3]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,33 @@ jobs:
             echo "context=" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Run tests
+      - name: Run direct tests
         env:
           SDD_PR_CONTEXT: ${{ steps.sdd_pr.outputs.context }}
-        run: uv run pytest
+        run: uv run pytest -m "not toxiproxy"
+
+      - name: Wait for Toxiproxy readiness
+        shell: bash
+        run: |
+          for attempt in {1..30}; do
+            if curl --fail --silent --show-error --max-time 2 \
+                http://localhost:8474/version; then
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Toxiproxy admin API did not become ready within 30 seconds" >&2
+          exit 1
+
+      - name: Validate Toxiproxy Redis routing
+        env:
+          SDD_PR_CONTEXT: ${{ steps.sdd_pr.outputs.context }}
+        run: >
+          uv run pytest
+          tests/integration/test_toxiproxy_baseline.py::test_pr1_redis_connection_refused_smoke
+          -q
+
+      - name: Run proxy tests (serial)
+        env:
+          SDD_PR_CONTEXT: ${{ steps.sdd_pr.outputs.context }}
+        run: uv run pytest -m "integration and toxiproxy" -x

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -513,6 +513,8 @@ async def isolated_db_session(pooled_engine):
 # Toxiproxy session fixture — PR1 #260 baseline fault-injection harness
 # ---------------------------------------------------------------------------
 
+TOXIPROXY_CLEANUP_TIMEOUT_SECONDS = 5.0
+
 
 @pytest_asyncio.fixture(scope="session", loop_scope="session")
 async def toxiproxy_session():
@@ -554,12 +556,18 @@ async def toxiproxy_client(toxiproxy_session):
     """Yield a clean function-scoped controller for the Redis proxy."""
 
     async def reset_state() -> None:
-        await toxiproxy_session.reset_toxics()
-        await close_pool()
-        await _flush_toxiproxy_database()
+        results = await asyncio.gather(
+            toxiproxy_session.reset_toxics(),
+            close_pool(),
+            _flush_toxiproxy_database(),
+            return_exceptions=True,
+        )
+        failures = [result for result in results if isinstance(result, BaseException)]
+        if failures:
+            raise RuntimeError("Toxiproxy fixture cleanup failed") from failures[0]
 
-    await reset_state()
+    await asyncio.wait_for(reset_state(), timeout=TOXIPROXY_CLEANUP_TIMEOUT_SECONDS)
     try:
         yield toxiproxy_session
     finally:
-        await reset_state()
+        await asyncio.wait_for(reset_state(), timeout=TOXIPROXY_CLEANUP_TIMEOUT_SECONDS)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -14,6 +14,8 @@ import os
 import re
 import subprocess
 import sys
+from collections.abc import Callable, Generator
+from typing import Any
 
 import pytest
 import pytest_asyncio
@@ -21,8 +23,9 @@ from httpx import ASGITransport, AsyncClient
 
 from app.core.config import settings
 from app.core.redis import close_pool
-from app.dependencies import get_db, get_db_with_tenant
+from app.dependencies import get_current_user, get_db, get_db_with_tenant
 from app.main import create_app
+from app.modules.users.models import User
 
 # Global marker for all tests in this directory
 pytestmark = pytest.mark.integration
@@ -250,6 +253,31 @@ async def app_via_proxy(proxy_redis, db_session, monkeypatch):
         await close_pool()
         monkeypatch.setattr(settings, "REDIS_HOST", previous_host)
         monkeypatch.setattr(settings, "REDIS_PORT", previous_port)
+
+
+@pytest.fixture(scope="function")
+def lock_test_overrides() -> Generator[
+    Callable[[AsyncClient, User], None], None, None
+]:
+    """Override only current-user resolution for real deactivation lock tests."""
+    installed_apps: list[Any] = []
+
+    def install(client: AsyncClient, current_user: User) -> None:
+        transport = getattr(client, "_transport", None)
+        app = getattr(transport, "app", None)
+        if app is None:
+            raise RuntimeError("app_via_proxy does not expose an ASGI app")
+
+        async def override_get_current_user() -> User:
+            return current_user
+
+        app.dependency_overrides[get_current_user] = override_get_current_user
+        installed_apps.append(app)
+
+    yield install
+
+    for app in reversed(installed_apps):
+        app.dependency_overrides.pop(get_current_user, None)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_toxiproxy_fault_injection.py
+++ b/tests/integration/test_toxiproxy_fault_injection.py
@@ -1,0 +1,319 @@
+"""Focused Redis/Toxiproxy fault-injection matrix.
+
+All toxics are applied after the proxy-backed application lifespan is healthy.
+The matrix deliberately excludes startup failure, ``/metrics``, the catalog-only
+ghost FlowId, scan locks, one-test-per-FlowId expansion, raw Redis translation,
+``ServiceUnavailableError`` normalization, revocation/event behavior, and
+Redis/Postgres atomicity.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from typing import AsyncIterator, Awaitable, Callable
+
+import pytest
+from httpx import AsyncClient, Response
+from redis.asyncio import Redis
+from redis.exceptions import ConnectionError as RedisConnectionError
+from redis.exceptions import TimeoutError as RedisTimeoutError
+
+from app.core.config import settings
+from app.core.redis import close_pool
+from tests.conftest import (
+    ANALYST_A_ID,
+    TENANT_B_ID,
+)
+from tests.helpers.toxiproxy import ToxiproxyTransportController
+
+pytestmark = [pytest.mark.integration, pytest.mark.toxiproxy]
+
+REQUEST_TIMEOUT_SECONDS = 3.0
+CLEANUP_TIMEOUT_SECONDS = 5.0
+PROXY_PORT = 26379
+DIRECT_REDIS_PORT = 6379
+REDIS_TEST_DATABASE = 15
+
+
+def _redis_client(port: int) -> Redis:
+    """Build a Redis client for either the proxy or direct test route."""
+    return Redis(
+        host="localhost",
+        port=port,
+        db=REDIS_TEST_DATABASE,
+        password=settings.REDIS_PASSWORD.get_secret_value() or None,
+        decode_responses=True,
+        socket_connect_timeout=REQUEST_TIMEOUT_SECONDS,
+    )
+
+
+async def _flush_direct_database() -> None:
+    """Flush only the disposable Redis database used by this matrix."""
+    client = _redis_client(DIRECT_REDIS_PORT)
+    try:
+        await asyncio.wait_for(client.flushdb(), timeout=CLEANUP_TIMEOUT_SECONDS)
+    finally:
+        await asyncio.wait_for(client.aclose(), timeout=CLEANUP_TIMEOUT_SECONDS)
+
+
+async def _reset_proxy_state(
+    toxiproxy_client: ToxiproxyTransportController,
+) -> None:
+    """Reset every mutable Redis test boundary and surface cleanup failures."""
+    failures: list[tuple[str, BaseException]] = []
+
+    cleanup_steps: tuple[tuple[str, Callable[[], Awaitable[object]]], ...] = (
+        ("toxics", toxiproxy_client.reset_toxics),
+        ("pool", close_pool),
+        ("database", _flush_direct_database),
+    )
+    for name, cleanup in cleanup_steps:
+        try:
+            await asyncio.wait_for(cleanup(), timeout=CLEANUP_TIMEOUT_SECONDS)
+        except BaseException as exc:
+            failures.append((name, exc))
+
+    if failures:
+        name, error = failures[0]
+        raise RuntimeError(f"Toxiproxy cleanup failed at {name}") from error
+
+
+@asynccontextmanager
+async def _connection_drop(
+    toxiproxy_client: ToxiproxyTransportController,
+) -> AsyncIterator[None]:
+    """Apply a bounded post-startup connection drop and always reset it."""
+    try:
+        await asyncio.wait_for(
+            toxiproxy_client.add_connection_drop(1.0),
+            timeout=CLEANUP_TIMEOUT_SECONDS,
+        )
+        yield
+    finally:
+        await _reset_proxy_state(toxiproxy_client)
+
+
+async def _login(client: AsyncClient) -> tuple[str, str]:
+    """Perform a healthy login and return its access token and refresh cookie."""
+    response = await asyncio.wait_for(
+        client.post(
+            "/api/v1/auth/login",
+            json={
+                "email": "admin@alpha.test",
+                "password": "AdminAlpha123!",
+            },
+        ),
+        timeout=REQUEST_TIMEOUT_SECONDS,
+    )
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    refresh_token = client.cookies.get("refresh_token")
+    assert isinstance(payload.get("access_token"), str)
+    assert isinstance(refresh_token, str)
+    return payload["access_token"], refresh_token
+
+
+def _assert_lock_outage(response: Response) -> None:
+    """Assert the existing sanitized RedisOutageError HTTP boundary."""
+    assert response.status_code == 503
+    assert response.json() == {"detail": "service temporarily unavailable"}
+    assert response.headers["retry-after"] == str(
+        settings.REDIS_OUTAGE_RETRY_AFTER_SECONDS
+    )
+
+
+@pytest.mark.asyncio
+async def test_login_rate_outage_is_masked(
+    seed_data,
+    app_via_proxy: AsyncClient,
+    toxiproxy_client: ToxiproxyTransportController,
+):
+    """A Redis outage during login-rate evaluation remains generic 401."""
+    async with _connection_drop(toxiproxy_client):
+        response = await asyncio.wait_for(
+            app_via_proxy.post(
+                "/api/v1/auth/login",
+                json={
+                    "email": "admin@alpha.test",
+                    "password": "AdminAlpha123!",
+                },
+            ),
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Credenciales incorrectas"}
+
+    access_token, refresh_token = await _login(app_via_proxy)
+    assert access_token
+    assert refresh_token
+
+
+@pytest.mark.asyncio
+async def test_refresh_outage_fails_closed(
+    seed_data,
+    app_via_proxy: AsyncClient,
+    toxiproxy_client: ToxiproxyTransportController,
+):
+    """Refresh fails closed through the current service-health 503 contract."""
+    await _login(app_via_proxy)
+
+    async with _connection_drop(toxiproxy_client):
+        response = await asyncio.wait_for(
+            app_via_proxy.post("/api/v1/auth/refresh"),
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
+
+    assert response.status_code == 503
+    assert response.json() == {"detail": "Servicio temporalmente no disponible"}
+    assert "access_token" not in response.json()
+    assert "set-cookie" not in response.headers
+
+    recovered = await asyncio.wait_for(
+        app_via_proxy.post("/api/v1/auth/refresh"),
+        timeout=REQUEST_TIMEOUT_SECONDS,
+    )
+    assert recovered.status_code == 200, recovered.text
+    assert isinstance(recovered.json().get("access_token"), str)
+
+
+@pytest.mark.asyncio
+async def test_current_user_token_outage_direct_503(
+    seed_data,
+    app_via_proxy: AsyncClient,
+    toxiproxy_client: ToxiproxyTransportController,
+):
+    """Current-user token lookup keeps its direct HTTP 503 boundary."""
+    access_token, _ = await _login(app_via_proxy)
+    headers = {"Authorization": f"Bearer {access_token}"}
+
+    async with _connection_drop(toxiproxy_client):
+        response = await asyncio.wait_for(
+            app_via_proxy.get("/api/v1/users/me", headers=headers),
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
+
+    assert response.status_code == 503
+    assert response.json() == {"detail": "Servicio temporalmente no disponible"}
+
+    recovered = await asyncio.wait_for(
+        app_via_proxy.get("/api/v1/users/me", headers=headers),
+        timeout=REQUEST_TIMEOUT_SECONDS,
+    )
+    assert recovered.status_code == 200, recovered.text
+    assert recovered.json()["email"] == "admin@alpha.test"
+
+
+@pytest.mark.parametrize(
+    ("target_id", "current_user_key"),
+    [(ANALYST_A_ID, "admin_a")],
+    ids=["user-deactivation"],
+)
+@pytest.mark.asyncio
+async def test_user_deactivation_lock_transport_503(
+    target_id: str,
+    current_user_key: str,
+    seed_data,
+    app_via_proxy: AsyncClient,
+    toxiproxy_client: ToxiproxyTransportController,
+    lock_test_overrides,
+):
+    """User deactivation lock transport failure stays a sanitized 503."""
+    lock_test_overrides(app_via_proxy, seed_data[current_user_key])
+    path = f"/api/v1/users/{target_id}"
+
+    async with _connection_drop(toxiproxy_client):
+        response = await asyncio.wait_for(
+            app_via_proxy.delete(path),
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
+
+    _assert_lock_outage(response)
+
+    recovered = await asyncio.wait_for(
+        app_via_proxy.delete(path),
+        timeout=REQUEST_TIMEOUT_SECONDS,
+    )
+    assert recovered.status_code == 204, recovered.text
+
+
+@pytest.mark.parametrize(
+    ("target_id", "current_user_key"),
+    [(TENANT_B_ID, "superadmin")],
+    ids=["tenant-deactivation"],
+)
+@pytest.mark.asyncio
+async def test_tenant_deactivation_lock_transport_503(
+    target_id: str,
+    current_user_key: str,
+    seed_data,
+    app_via_proxy: AsyncClient,
+    toxiproxy_client: ToxiproxyTransportController,
+    lock_test_overrides,
+):
+    """Tenant deactivation lock transport failure stays a sanitized 503."""
+    lock_test_overrides(app_via_proxy, seed_data[current_user_key])
+    path = f"/api/v1/tenants/{target_id}"
+
+    async with _connection_drop(toxiproxy_client):
+        response = await asyncio.wait_for(
+            app_via_proxy.delete(path),
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
+
+    _assert_lock_outage(response)
+
+    recovered = await asyncio.wait_for(
+        app_via_proxy.delete(path),
+        timeout=REQUEST_TIMEOUT_SECONDS,
+    )
+    assert recovered.status_code == 204, recovered.text
+
+
+@pytest.mark.asyncio
+async def test_toxic_reset_recovers_pool_and_proxy_state(
+    seed_data,
+    app_via_proxy: AsyncClient,
+    toxiproxy_client: ToxiproxyTransportController,
+):
+    """A failed faulted operation leaves clean proxy, pool, and DB-15 state."""
+    direct_client = _redis_client(DIRECT_REDIS_PORT)
+    try:
+        assert await asyncio.wait_for(
+            direct_client.set("toxiproxy:isolation-sentinel", "contaminated"),
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
+    finally:
+        await asyncio.wait_for(direct_client.aclose(), timeout=CLEANUP_TIMEOUT_SECONDS)
+
+    async with _connection_drop(toxiproxy_client):
+        proxy_client = _redis_client(PROXY_PORT)
+        try:
+            with pytest.raises((RedisConnectionError, RedisTimeoutError)):
+                await asyncio.wait_for(
+                    proxy_client.ping(), timeout=REQUEST_TIMEOUT_SECONDS
+                )
+        finally:
+            await asyncio.wait_for(
+                proxy_client.aclose(), timeout=CLEANUP_TIMEOUT_SECONDS
+            )
+
+    clean_client = _redis_client(DIRECT_REDIS_PORT)
+    try:
+        assert (
+            await asyncio.wait_for(
+                clean_client.get("toxiproxy:isolation-sentinel"),
+                timeout=REQUEST_TIMEOUT_SECONDS,
+            )
+            is None
+        )
+        assert (
+            await asyncio.wait_for(clean_client.ping(), timeout=REQUEST_TIMEOUT_SECONDS)
+            is True
+        )
+    finally:
+        await asyncio.wait_for(clean_client.aclose(), timeout=CLEANUP_TIMEOUT_SECONDS)
+
+    access_token, _ = await _login(app_via_proxy)
+    assert access_token


### PR DESCRIPTION
Closes #260

## Summary
- Adds the PR6 Toxiproxy fault-injection matrix characterizing reachable Redis transport failures on auth, token, user, and tenant paths through a real proxy route, proving recovery without production changes.
- Bounds Toxiproxy fixture cleanup (concurrent reset with timeout, fails closed) and narrows the test-local lock override to current-user resolution only.
- Splits CI into a direct phase (`-m "not toxiproxy"`) and a readiness-gated serial proxy phase (`-m "integration and toxiproxy" -x`), preserving the 400-line review budget.

## What is intentionally missing
- Production `app/` changes: none. This is a test-only characterization matrix on top of the existing typed `RedisOutageError` contract.
- Follow-up isolation work for the pre-existing single-process Redis pool/event-loop contamination (CI uses separate processes and passes).

## Design and specification references
- Engram verify #2240: `sdd/pr6-redis-fault-injection-v2/verify-report`
- Engram design #2226: `sdd/pr6-redis-fault-injection-v2/design`
- Engram spec #2225: `sdd/pr6-redis-fault-injection-v2/spec`
- Engram tasks #2230: `sdd/pr6-redis-fault-injection-v2/tasks`

## Verification
- `uv run pytest -m "integration and toxiproxy" -x` → 9 passed (proxy suite).
- `uv run pytest -m "not toxiproxy"` → 1092 passed, 1 skipped, 9 deselected, 2 xfailed.
- Focused fault matrix → 6 passed; CI routing smoke → 1 passed.
- `uv run ruff check` on changed files → pass.
- `uv run ruff check .` and `uv run mypy app/` still report pre-existing repository errors; no production files were changed to mask them.

## Changes
| File | Change |
|------|--------|
| `tests/integration/test_toxiproxy_fault_injection.py` | Add the v2 fault-injection matrix (auth, token, user, tenant paths) with recovery assertions. |
| `tests/conftest.py` | Bound Toxiproxy fixture cleanup: concurrent reset with timeout, fails closed. |
| `tests/integration/conftest.py` | Narrow the test-local lock override to current-user resolution for real deactivation lock tests. |
| `.github/workflows/ci.yml` | Split direct vs serial proxy phases with Toxiproxy readiness gating. |

## Test plan
- [x] Focused matrix: `uv run pytest tests/integration/test_toxiproxy_fault_injection.py -v`
- [x] Proxy suite: `uv run pytest -m "integration and toxiproxy" -x`
- [x] Direct suite: `uv run pytest -m "not toxiproxy"`
- [x] No production `app/` diff

## Contributor checklist
- [x] Linked approved issue #260
- [x] Added exactly one `type:*` label: `type:chore`
- [x] Conventional commits
- [x] No `Co-Authored-By` trailers

PR6 is ready for review; do not merge until the maintainer reviews it.