### PR TITLE
test(redis): govern ghost FlowIds and characterize scan-lock faults (PR7-A)

### DIFF
--- a/tests/integration/test_toxiproxy_scan_lock_faults.py
+++ b/tests/integration/test_toxiproxy_scan_lock_faults.py
@@ -1,0 +1,345 @@
+"""Real-Toxiproxy characterization of the four deferred scan lock FlowIds."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
+
+import pytest
+from redis.asyncio import Redis
+from redis.exceptions import ConnectionError as RedisConnectionError
+from redis.exceptions import TimeoutError as RedisTimeoutError
+
+from app.core import dist_lock, metrics
+from app.core.config import settings
+from app.core.dist_lock import acquire_dist_lock, build_lock_key
+from app.core.exceptions import RedisOutageError, TemporaryUnavailableError
+from app.core.redis import close_pool, get_redis_client
+from tests.helpers.toxiproxy import ToxiproxyTransportController
+
+pytestmark = [pytest.mark.integration, pytest.mark.toxiproxy]
+
+SCAN_LOCKS = (
+    ("scan_start_lock", "scan_start"),
+    ("scan_update_lock", "scan_update"),
+    ("scan_complete_lock", "scan_complete"),
+    ("scan_cancel_lock", "scan_cancel"),
+)
+REQUEST_TIMEOUT_SECONDS = 3.0
+CLEANUP_TIMEOUT_SECONDS = 5.0
+PROXY_PORT = 26379
+DIRECT_REDIS_PORT = 6379
+REDIS_TEST_DATABASE = 15
+LOCK_TENANT_ID = "pr7-tenant"
+LOCK_ASSET_ID = "pr7-asset"
+
+
+def _redis_client(port: int) -> Redis:
+    """Build a bounded Redis client for the proxy or direct test route."""
+    return Redis(
+        host="localhost",
+        port=port,
+        db=REDIS_TEST_DATABASE,
+        password=settings.REDIS_PASSWORD.get_secret_value() or None,
+        decode_responses=True,
+        socket_connect_timeout=REQUEST_TIMEOUT_SECONDS,
+        socket_timeout=REQUEST_TIMEOUT_SECONDS,
+    )
+
+
+def _metric_flows(flow_id: str) -> set[str]:
+    """Return flow labels emitted by the distributed-lock metric families."""
+    flows: set[str] = set()
+    for metric in (
+        metrics.METRIC_LOCK_ACQUIRE_TOTAL,
+        metrics.METRIC_LOCK_RELEASE_TOTAL,
+        metrics.METRIC_LOCK_CONTENTION_TOTAL,
+        metrics.METRIC_LOCK_WAIT_SECONDS,
+    ):
+        for family in metric.collect():
+            for sample in family.samples:
+                if sample.labels.get("flow") == flow_id:
+                    flows.add(flow_id)
+    return flows
+
+
+async def _run_lock_attempt(
+    flow_id: str,
+    operation: str,
+    *,
+    waiter: Any = None,
+    wait_timeout_seconds: float = 0.5,
+) -> str:
+    """Run one direct lock operation through the proxy with a hard bound."""
+    redis = await get_redis_client()
+    try:
+
+        async def _attempt() -> str:
+            async with acquire_dist_lock(
+                flow_id=flow_id,
+                tenant_id=LOCK_TENANT_ID,
+                asset_id=LOCK_ASSET_ID,
+                ttl_seconds=30,
+                operation=operation,
+                wait_timeout_seconds=wait_timeout_seconds,
+                redis=redis,
+                waiter=waiter,
+            ) as handle:
+                key = handle.key
+                assert await redis.get(key) == handle.owner_token
+                return key
+
+        return await asyncio.wait_for(_attempt(), timeout=REQUEST_TIMEOUT_SECONDS)
+    finally:
+        await asyncio.wait_for(redis.aclose(), timeout=CLEANUP_TIMEOUT_SECONDS)
+
+
+async def _acquire_scan_lock(flow_id: str, operation: str) -> tuple[str, set[str]]:
+    """Acquire, release, and inspect one scan lock's safe evidence."""
+    key = await _run_lock_attempt(flow_id, operation)
+    probe = await get_redis_client()
+    try:
+        assert await probe.get(key) is None
+    finally:
+        await asyncio.wait_for(probe.aclose(), timeout=CLEANUP_TIMEOUT_SECONDS)
+    return key, _metric_flows(flow_id)
+
+
+async def _seed_held_key(flow_id: str) -> tuple[Redis, str]:
+    """Create a real proxy-backed owner key for contention scenarios."""
+    owner = await get_redis_client()
+    key = build_lock_key(flow_id, LOCK_TENANT_ID, LOCK_ASSET_ID)
+    await asyncio.wait_for(
+        owner.set(key, "held-by-owner", nx=True, px=30_000),
+        timeout=REQUEST_TIMEOUT_SECONDS,
+    )
+    return owner, key
+
+
+async def _flush_direct_database() -> None:
+    """Flush only the disposable Redis database used by this matrix."""
+    client = _redis_client(DIRECT_REDIS_PORT)
+    try:
+        await asyncio.wait_for(client.flushdb(), timeout=CLEANUP_TIMEOUT_SECONDS)
+    finally:
+        await asyncio.wait_for(client.aclose(), timeout=CLEANUP_TIMEOUT_SECONDS)
+
+
+async def _reset_proxy_state(
+    toxiproxy_client: ToxiproxyTransportController,
+) -> None:
+    """Reset toxics, the application pool, and disposable Redis state."""
+    failures: list[tuple[str, BaseException]] = []
+    cleanup_steps = (
+        ("toxics", toxiproxy_client.reset_toxics),
+        ("pool", close_pool),
+        ("database", _flush_direct_database),
+    )
+    for name, cleanup in cleanup_steps:
+        try:
+            await asyncio.wait_for(cleanup(), timeout=CLEANUP_TIMEOUT_SECONDS)
+        except BaseException as exc:
+            failures.append((name, exc))
+    if failures:
+        name, error = failures[0]
+        raise RuntimeError(f"Toxiproxy cleanup failed at {name}") from error
+
+
+@asynccontextmanager
+async def _connection_drop(
+    toxiproxy_client: ToxiproxyTransportController,
+) -> AsyncIterator[None]:
+    """Apply a post-startup connection drop and always perform bounded cleanup."""
+    try:
+        await asyncio.wait_for(
+            toxiproxy_client.add_connection_drop(1.0),
+            timeout=CLEANUP_TIMEOUT_SECONDS,
+        )
+        yield
+    finally:
+        await _reset_proxy_state(toxiproxy_client)
+
+
+@asynccontextmanager
+async def _cleanup_after_failure(
+    toxiproxy_client: ToxiproxyTransportController,
+) -> AsyncIterator[None]:
+    """Provide the same fail-closed cleanup without pre-injecting a toxic."""
+    try:
+        yield
+    finally:
+        await _reset_proxy_state(toxiproxy_client)
+
+
+class TimeoutRecordingWaiter:
+    """Deterministic waiter that makes production cancel the retry task."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[Any, float]] = []
+
+    async def wait(self, awaitable: Any, *, timeout: float) -> Any:
+        self.calls.append((awaitable, timeout))
+        raise asyncio.TimeoutError()
+
+
+class RetryDropWaiter:
+    """Inject a toxic after contention starts and before retry Redis I/O."""
+
+    def __init__(self, toxiproxy_client: ToxiproxyTransportController) -> None:
+        self._toxiproxy_client = toxiproxy_client
+        self.calls: list[tuple[Any, float]] = []
+
+    async def wait(self, awaitable: Any, *, timeout: float) -> Any:
+        self.calls.append((awaitable, timeout))
+        await asyncio.wait_for(
+            self._toxiproxy_client.add_connection_drop(1.0),
+            timeout=CLEANUP_TIMEOUT_SECONDS,
+        )
+        return await asyncio.wait_for(awaitable, timeout=timeout)
+
+
+@pytest.mark.parametrize(("flow_id", "operation"), SCAN_LOCKS)
+@pytest.mark.asyncio
+async def test_scan_lock_healthy_acquires_and_releases(
+    flow_id: str,
+    operation: str,
+    app_via_proxy,
+    toxiproxy_client,
+) -> None:
+    """Each scan FlowId MUST acquire and release through the healthy proxy."""
+    key, metric_flows = await _acquire_scan_lock(flow_id, operation)
+
+    assert key.split(":", 2)[1] == flow_id
+    assert flow_id in metric_flows
+
+
+@pytest.mark.parametrize(("flow_id", "operation"), SCAN_LOCKS)
+@pytest.mark.asyncio
+async def test_scan_lock_initial_drop_is_typed_outage(
+    flow_id: str,
+    operation: str,
+    app_via_proxy,
+    toxiproxy_client: ToxiproxyTransportController,
+) -> None:
+    """A post-startup initial drop MUST remain a typed Redis outage."""
+    async with _connection_drop(toxiproxy_client):
+        with pytest.raises(RedisOutageError) as exc_info:
+            await _run_lock_attempt(flow_id, operation)
+
+    assert not isinstance(exc_info.value, TemporaryUnavailableError)
+    await _acquire_scan_lock(flow_id, operation)
+
+
+@pytest.mark.parametrize(("flow_id", "operation"), SCAN_LOCKS)
+@pytest.mark.asyncio
+async def test_scan_lock_contention_cancels_one_retry(
+    flow_id: str,
+    operation: str,
+    app_via_proxy,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Held-key contention MUST cancel one retry and leave no waiter lease."""
+    monkeypatch.setattr(dist_lock.random, "uniform", lambda _low, _high: 0.25)
+    owner, key = await _seed_held_key(flow_id)
+    waiter = TimeoutRecordingWaiter()
+    try:
+        with pytest.raises(TemporaryUnavailableError, match="lock_timeout"):
+            await _run_lock_attempt(
+                flow_id,
+                operation,
+                waiter=waiter,
+                wait_timeout_seconds=0.25,
+            )
+
+        assert len(waiter.calls) == 1
+        assert waiter.calls[0][0].done()
+        assert waiter.calls[0][0].cancelled()
+        assert await owner.get(key) == "held-by-owner"
+    finally:
+        await asyncio.wait_for(owner.delete(key), timeout=CLEANUP_TIMEOUT_SECONDS)
+        await asyncio.wait_for(owner.aclose(), timeout=CLEANUP_TIMEOUT_SECONDS)
+
+    await _acquire_scan_lock(flow_id, operation)
+
+
+@pytest.mark.parametrize(("flow_id", "operation"), SCAN_LOCKS)
+@pytest.mark.asyncio
+async def test_scan_lock_retry_drop_preserves_outage_precedence(
+    flow_id: str,
+    operation: str,
+    app_via_proxy,
+    toxiproxy_client: ToxiproxyTransportController,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A retry-phase drop MUST beat the lock timeout outcome."""
+    monkeypatch.setattr(dist_lock.random, "uniform", lambda _low, _high: 0.25)
+    owner, key = await _seed_held_key(flow_id)
+    waiter = RetryDropWaiter(toxiproxy_client)
+    try:
+        async with _cleanup_after_failure(toxiproxy_client):
+            with pytest.raises(RedisOutageError) as exc_info:
+                await _run_lock_attempt(
+                    flow_id,
+                    operation,
+                    waiter=waiter,
+                    wait_timeout_seconds=0.5,
+                )
+
+        assert not isinstance(exc_info.value, TemporaryUnavailableError)
+        assert len(waiter.calls) == 1
+    finally:
+        await asyncio.wait_for(owner.aclose(), timeout=CLEANUP_TIMEOUT_SECONDS)
+
+    await _acquire_scan_lock(flow_id, operation)
+
+
+@pytest.mark.asyncio
+async def test_failed_scan_lock_scenario_resets_proxy_pool_and_database(
+    app_via_proxy,
+    toxiproxy_client: ToxiproxyTransportController,
+) -> None:
+    """Failed toxic scenarios MUST leave every shared boundary recoverable."""
+    direct_client = _redis_client(DIRECT_REDIS_PORT)
+    try:
+        await asyncio.wait_for(
+            direct_client.set("pr7:isolation-sentinel", "contaminated"),
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
+    finally:
+        await asyncio.wait_for(direct_client.aclose(), timeout=CLEANUP_TIMEOUT_SECONDS)
+
+    async with _connection_drop(toxiproxy_client):
+        proxy_client = _redis_client(PROXY_PORT)
+        try:
+            with pytest.raises((RedisConnectionError, RedisTimeoutError)):
+                await asyncio.wait_for(
+                    proxy_client.ping(), timeout=REQUEST_TIMEOUT_SECONDS
+                )
+        finally:
+            await asyncio.wait_for(
+                proxy_client.aclose(), timeout=CLEANUP_TIMEOUT_SECONDS
+            )
+
+    assert await toxiproxy_client.list_toxics() == []
+    from app.core import redis as redis_module
+
+    assert redis_module._pool is None
+    clean_client = _redis_client(DIRECT_REDIS_PORT)
+    try:
+        assert (
+            await asyncio.wait_for(
+                clean_client.get("pr7:isolation-sentinel"),
+                timeout=REQUEST_TIMEOUT_SECONDS,
+            )
+            is None
+        )
+        assert (
+            await asyncio.wait_for(clean_client.ping(), timeout=REQUEST_TIMEOUT_SECONDS)
+            is True
+        )
+    finally:
+        await asyncio.wait_for(clean_client.aclose(), timeout=CLEANUP_TIMEOUT_SECONDS)
+
+    await _acquire_scan_lock("scan_cancel_lock", "scan_cancel")

--- a/tests/unit/test_dist_lock.py
+++ b/tests/unit/test_dist_lock.py
@@ -25,6 +25,21 @@ class RecordingWaiter:
         return await awaitable
 
 
+class AwaitingWaiter(RecordingWaiter):
+    """RedisLockWaiter-compatible waiter that records retry deadlines."""
+
+
+class TimeoutRecordingWaiter:
+    """Deterministic waiter that forces production retry cancellation."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[Any, float]] = []
+
+    async def wait(self, awaitable: Any, *, timeout: float) -> Any:
+        self.calls.append((awaitable, timeout))
+        raise asyncio.TimeoutError()
+
+
 class ScriptedFakeRedis(FakeRedis):
     """fakeredis fixture with Lua semantics without the optional lupa package."""
 
@@ -197,6 +212,92 @@ async def test_contention_and_reentry_have_distinct_details(
                 pass
     finally:
         await first.__aexit__(None, None, None)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("flow_id", "operation"),
+    [("scan_start_lock", "scan_start"), ("scan_cancel_lock", "scan_cancel")],
+)
+async def test_contention_timeout_cancels_single_retry(
+    monkeypatch: pytest.MonkeyPatch,
+    redis: ScriptedFakeRedis,
+    flow_id: str,
+    operation: str,
+) -> None:
+    from app.core.exceptions import TemporaryUnavailableError
+
+    dist_lock = _set_secret(monkeypatch, "deterministic timeout secret")
+    monkeypatch.setattr(dist_lock.random, "uniform", lambda _low, _high: 0.25)
+    key = dist_lock.build_lock_key(flow_id, "tenant-1", "asset-1")
+    await redis.set(key, "held-by-owner", nx=True, px=30_000)
+    waiter = TimeoutRecordingWaiter()
+
+    with pytest.raises(TemporaryUnavailableError, match="lock_timeout"):
+        async with dist_lock.acquire_dist_lock(
+            **_lock_args(
+                redis,
+                flow_id=flow_id,
+                operation=operation,
+                waiter=waiter,
+                wait_timeout_seconds=0.25,
+            )
+        ):
+            pass
+
+    assert len(waiter.calls) == 1
+    assert waiter.calls[0][0].done()
+    assert waiter.calls[0][0].cancelled()
+    assert await redis.get(key) == b"held-by-owner"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "transport_error",
+    [
+        ConnectionError("retry transport failed"),
+        asyncio.TimeoutError("retry timed out"),
+    ],
+    ids=["connection", "timeout"],
+)
+async def test_retry_outage_precedence(
+    monkeypatch: pytest.MonkeyPatch,
+    redis: ScriptedFakeRedis,
+    transport_error: BaseException,
+) -> None:
+    from app.core.exceptions import RedisOutageError, TemporaryUnavailableError
+
+    dist_lock = _set_secret(monkeypatch, "retry outage secret")
+    monkeypatch.setattr(dist_lock.random, "uniform", lambda _low, _high: 0.0)
+    key = dist_lock.build_lock_key("scan_update_lock", "tenant-1", "asset-1")
+    await redis.set(key, "held-by-owner", nx=True, px=30_000)
+    original_set = redis.set
+    set_calls = 0
+
+    async def scripted_set(*args: Any, **kwargs: Any) -> Any:
+        nonlocal set_calls
+        set_calls += 1
+        if set_calls == 2:
+            raise transport_error
+        return await original_set(*args, **kwargs)
+
+    monkeypatch.setattr(redis, "set", scripted_set)
+
+    with pytest.raises(RedisOutageError) as exc_info:
+        async with dist_lock.acquire_dist_lock(
+            **_lock_args(
+                redis,
+                flow_id="scan_update_lock",
+                operation="scan_update",
+                waiter=AwaitingWaiter(),
+                wait_timeout_seconds=0.25,
+            )
+        ):
+            pass
+
+    assert isinstance(exc_info.value, RedisOutageError)
+    assert not isinstance(exc_info.value, TemporaryUnavailableError)
+    assert set_calls == 2
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_outage_primitives.py
+++ b/tests/unit/test_outage_primitives.py
@@ -1,7 +1,7 @@
 """Unit tests for PR2 outage primitives — DB-free, Redis-free.
 
 Covers the typed foundation: RedisOutageError hierarchy, TemporaryUnavailableError,
-AsyncWaiter Protocol, 25-FlowId catalog, FlowPolicy, RetryableOp enum,
+AsyncWaiter Protocol, 29-FlowId catalog, FlowPolicy, RetryableOp enum,
 and the pure classify_redis_error helper.
 """
 
@@ -281,10 +281,10 @@ class TestAsyncWaiterProtocol:
 
 
 # ---------------------------------------------------------------------------
-# 25-FlowId catalog
+# 29-FlowId catalog
 # ---------------------------------------------------------------------------
 
-EXPECTED_25_FLOW_IDS = frozenset(
+EXPECTED_FLOW_IDS = frozenset(
     [
         "auth_login_rate_precheck",
         "auth_refresh_rate_precheck",
@@ -318,21 +318,298 @@ EXPECTED_25_FLOW_IDS = frozenset(
     ]
 )
 
+FlowIdEvidence = tuple[str, str, str, str, str, str]
+
+_CATALOG_ONLY_EVIDENCE = "AST audit: no production FlowId reference outside outage.py"
+_RUNTIME_LOCK_EVIDENCE = (
+    "AST audit: imported and passed to acquire_dist_lock in lock_deps"
+)
+_SCAN_PRIMITIVE_EVIDENCE = "AST audit: no app scan path; direct primitive matrix only"
+
+FLOW_ID_EVIDENCE: tuple[FlowIdEvidence, ...] = (
+    (
+        "auth_account_lockout_check",
+        "app.modules.auth.service._check_account_lockout",
+        "account_lockout_check",
+        "fail_open",
+        "catalog-only",
+        _CATALOG_ONLY_EVIDENCE,
+    ),
+    (
+        "auth_change_password_rate_precheck",
+        "app.modules.auth.router.change_password",
+        "rate_precheck",
+        "masked",
+        "catalog-only",
+        _CATALOG_ONLY_EVIDENCE,
+    ),
+    (
+        "auth_change_password_rate_record",
+        "app.modules.auth.router.change_password",
+        "rate_record",
+        "fail_closed",
+        "catalog-only",
+        _CATALOG_ONLY_EVIDENCE,
+    ),
+    (
+        "auth_change_password_revoke",
+        "app.modules.auth.service.change_password",
+        "revoke",
+        "fail_closed",
+        "catalog-only",
+        _CATALOG_ONLY_EVIDENCE,
+    ),
+    (
+        "auth_change_password_service",
+        "app.modules.auth.service.change_password",
+        "service",
+        "fail_closed",
+        "catalog-only",
+        _CATALOG_ONLY_EVIDENCE,
+    ),
+    (
+        "auth_current_user_dep",
+        "app.dependencies.auth.get_current_user",
+        "current_user",
+        "fail_closed",
+        "catalog-only",
+        _CATALOG_ONLY_EVIDENCE,
+    ),
+    (
+        "auth_failed_attempt_record",
+        "app.modules.auth.service._record_failed_attempt",
+        "failed_attempt_record",
+        "best_effort",
+        "catalog-only",
+        _CATALOG_ONLY_EVIDENCE,
+    ),
+    (
+        "auth_login_attempts_clear",
+        "app.modules.auth.service._clear_login_attempts",
+        "attempts_clear",
+        "best_effort",
+        "catalog-only",
+        _CATALOG_ONLY_EVIDENCE,
+    ),
+    (
+        "auth_login_event_publish",
+        "app.modules.auth.service.login",
+        "event_publish",
+        "best_effort",
+        "catalog-only",
+        _CATALOG_ONLY_EVIDENCE,
+    ),
+    (
+        "auth_login_rate_precheck",
+        "app.modules.auth.router.login",
+        "rate_precheck",
+        "masked",
+        "catalog-only",
+        _CATALOG_ONLY_EVIDENCE,
+    ),
+    (
+        "auth_login_rate_record",
+        "app.modules.auth.router.login",
+        "rate_record",
+        "fail_closed",
+        "catalog-only",
+        _CATALOG_ONLY_EVIDENCE,
+    ),
+    (
+        "auth_login_service",
+        "app.modules.auth.service.login",
+        "service",
+        "fail_closed",
+        "catalog-only",
+        _CATALOG_ONLY_EVIDENCE,
+    ),
+    (
+        "auth_logout_rate_precheck",
+        "app.modules.auth.router.logout",
+        "rate_precheck",
+        "masked",
+        "catalog-only",
+        _CATALOG_ONLY_EVIDENCE,
+    ),
+    (
+        "auth_logout_rate_record",
+        "app.modules.auth.router.logout",
+        "rate_record",
+        "fail_closed",
+        "catalog-only",
+        _CATALOG_ONLY_EVIDENCE,
+    ),
+    (
+        "auth_logout_service",
+        "app.modules.auth.service.logout",
+        "service",
+        "best_effort",
+        "catalog-only",
+        _CATALOG_ONLY_EVIDENCE,
+    ),
+    (
+        "auth_post_credential_session_lock",
+        "app.modules.auth.service._acquire_session_cap_lock",
+        "session_cap_lock",
+        "fail_closed",
+        "catalog-only",
+        _CATALOG_ONLY_EVIDENCE,
+    ),
+    (
+        "auth_post_credential_user_deactivate_lock",
+        "app.dependencies.lock_deps.get_user_deactivation_db",
+        "deactivate",
+        "fail_closed",
+        "runtime-reachable",
+        _RUNTIME_LOCK_EVIDENCE,
+    ),
+    (
+        "auth_refresh_rate_precheck",
+        "app.modules.auth.router.refresh",
+        "rate_precheck",
+        "masked",
+        "catalog-only",
+        _CATALOG_ONLY_EVIDENCE,
+    ),
+    (
+        "auth_refresh_rate_record",
+        "app.modules.auth.router.refresh",
+        "rate_record",
+        "fail_closed",
+        "catalog-only",
+        _CATALOG_ONLY_EVIDENCE,
+    ),
+    (
+        "auth_refresh_service",
+        "app.modules.auth.service.refresh_tokens",
+        "service",
+        "fail_closed",
+        "catalog-only",
+        _CATALOG_ONLY_EVIDENCE,
+    ),
+    (
+        "auth_tenant_deactivate_lock",
+        "app.dependencies.lock_deps.get_tenant_deactivation_db",
+        "deactivate",
+        "fail_closed",
+        "runtime-reachable",
+        _RUNTIME_LOCK_EVIDENCE,
+    ),
+    (
+        "scan_cancel_lock",
+        "app.core.dist_lock.acquire_dist_lock",
+        "scan_cancel",
+        "fail_closed",
+        "primitive-only",
+        _SCAN_PRIMITIVE_EVIDENCE,
+    ),
+    (
+        "scan_complete_lock",
+        "app.core.dist_lock.acquire_dist_lock",
+        "scan_complete",
+        "fail_closed",
+        "primitive-only",
+        _SCAN_PRIMITIVE_EVIDENCE,
+    ),
+    (
+        "scan_start_lock",
+        "app.core.dist_lock.acquire_dist_lock",
+        "scan_start",
+        "fail_closed",
+        "primitive-only",
+        _SCAN_PRIMITIVE_EVIDENCE,
+    ),
+    (
+        "scan_update_lock",
+        "app.core.dist_lock.acquire_dist_lock",
+        "scan_update",
+        "fail_closed",
+        "primitive-only",
+        _SCAN_PRIMITIVE_EVIDENCE,
+    ),
+    (
+        "tenants_deactivate_tenant_revoke",
+        "app.modules.tenants.router.deactivate_tenant",
+        "revoke",
+        "fail_closed",
+        "catalog-only",
+        _CATALOG_ONLY_EVIDENCE,
+    ),
+    (
+        "tenants_update_tenant_revoke",
+        "app.modules.tenants.router.update_tenant",
+        "revoke",
+        "fail_closed",
+        "catalog-only",
+        _CATALOG_ONLY_EVIDENCE,
+    ),
+    (
+        "users_deactivate_user_revoke",
+        "app.modules.users.router.deactivate_user",
+        "revoke",
+        "fail_closed",
+        "catalog-only",
+        _CATALOG_ONLY_EVIDENCE,
+    ),
+    (
+        "users_update_user_revoke",
+        "app.modules.users.router.update_user",
+        "revoke",
+        "fail_closed",
+        "catalog-only",
+        _CATALOG_ONLY_EVIDENCE,
+    ),
+)
+
 
 class TestFlowIdCatalog:
-    """Exactly 25 FlowId constants MUST exist and match spec rev 9."""
+    """Exactly 29 FlowId constants MUST exist and match spec rev 9."""
 
-    def test_catalog_has_exactly_25_items(self) -> None:
-        """ALL_FLOW_IDS MUST contain exactly 25 identifiers."""
+    def test_catalog_has_complete_evidence_matrix(self) -> None:
+        """Every catalog entry MUST have a six-field governance row."""
+        rows = FLOW_ID_EVIDENCE
+
+        assert len(rows) == len(set(rows)) == len(ALL_FLOW_IDS) == 29
+        assert {row[0] for row in rows} == set(ALL_FLOW_IDS)
+        assert all(len(row) == 6 for row in rows)
+        assert all(
+            all(isinstance(field, str) and field.strip() for field in row)
+            for row in rows
+        )
+
+    def test_catalog_has_exactly_29_items(self) -> None:
+        """ALL_FLOW_IDS MUST contain exactly 29 identifiers."""
         assert len(ALL_FLOW_IDS) == 29, f"Expected 29 FlowIds, got {len(ALL_FLOW_IDS)}"
 
     def test_catalog_matches_spec_set(self) -> None:
-        """ALL_FLOW_IDS MUST contain exactly the 25 spec mandated identifiers."""
+        """ALL_FLOW_IDS MUST contain exactly the 29 spec identifiers."""
         actual = frozenset(ALL_FLOW_IDS)
-        assert actual == EXPECTED_25_FLOW_IDS, (
-            f"Missing: {sorted(EXPECTED_25_FLOW_IDS - actual)}\n"
-            f"Extra:   {sorted(actual - EXPECTED_25_FLOW_IDS)}"
+        assert actual == EXPECTED_FLOW_IDS, (
+            f"Missing: {sorted(EXPECTED_FLOW_IDS - actual)}\n"
+            f"Extra:   {sorted(actual - EXPECTED_FLOW_IDS)}"
         )
+
+    def test_evidence_classification_matches_reference_audit(self) -> None:
+        """The audit MUST distinguish live, ghost, and primitive-only entries."""
+        by_flow_id = {row[0]: row for row in FLOW_ID_EVIDENCE}
+
+        assert {
+            flow_id
+            for flow_id, row in by_flow_id.items()
+            if row[4] == "runtime-reachable"
+        } == {
+            "auth_post_credential_user_deactivate_lock",
+            "auth_tenant_deactivate_lock",
+        }
+        assert {
+            flow_id for flow_id, row in by_flow_id.items() if row[4] == "primitive-only"
+        } == {
+            "scan_start_lock",
+            "scan_update_lock",
+            "scan_complete_lock",
+            "scan_cancel_lock",
+        }
+        assert sum(row[4] == "catalog-only" for row in FLOW_ID_EVIDENCE) == 23
 
     def test_every_flow_id_is_a_string(self) -> None:
         """Every FlowId constant MUST be a str."""
@@ -352,21 +629,21 @@ class TestFlowIdCatalog:
 
 
 class TestFlowPolicy:
-    """FlowPolicy maps each FlowId to a policy behaviour."""
+    """FlowPolicy maps each of the 29 FlowIds to a policy behaviour."""
 
-    def test_policy_map_keys_equal_exact_25(self) -> None:
-        """FlowPolicy MUST have exactly 25 keys."""
+    def test_policy_map_keys_equal_exact_29(self) -> None:
+        """FlowPolicy MUST have exactly 29 keys."""
         assert (
             len(FlowPolicy) == 29
         ), f"FlowPolicy has {len(FlowPolicy)} keys, expected 29"
 
     def test_policy_map_keys_match_flow_ids(self) -> None:
-        """FlowPolicy keys MUST be exactly the 25 FlowId constants."""
+        """FlowPolicy keys MUST be exactly the 29 FlowId constants."""
         policy_keys = frozenset(FlowPolicy.keys())
-        assert policy_keys == EXPECTED_25_FLOW_IDS, (
+        assert policy_keys == EXPECTED_FLOW_IDS, (
             f"Policy keys mismatch.\n"
-            f"Missing: {sorted(EXPECTED_25_FLOW_IDS - policy_keys)}\n"
-            f"Extra:   {sorted(policy_keys - EXPECTED_25_FLOW_IDS)}"
+            f"Missing: {sorted(EXPECTED_FLOW_IDS - policy_keys)}\n"
+            f"Extra:   {sorted(policy_keys - EXPECTED_FLOW_IDS)}"
         )
 
     def test_every_policy_value_is_a_string(self) -> None:

--- a/tests/unit/test_outage_scan_flows.py
+++ b/tests/unit/test_outage_scan_flows.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from app.core.outage import ALL_FLOW_IDS, FlowPolicy
@@ -7,8 +9,16 @@ from app.core.outage import (
     _FLOW_ID_SCAN_START_LOCK,
     _FLOW_ID_SCAN_UPDATE_LOCK,
 )
+from tests.unit.test_outage_primitives import FLOW_ID_EVIDENCE
 
-SCAN_FLOWS = ((_FLOW_ID_SCAN_START_LOCK, "scan_start_lock"), (_FLOW_ID_SCAN_UPDATE_LOCK, "scan_update_lock"), (_FLOW_ID_SCAN_COMPLETE_LOCK, "scan_complete_lock"), (_FLOW_ID_SCAN_CANCEL_LOCK, "scan_cancel_lock"))  # fmt: skip
+SCAN_FLOWS = (
+    (_FLOW_ID_SCAN_START_LOCK, "scan_start_lock"),
+    (_FLOW_ID_SCAN_UPDATE_LOCK, "scan_update_lock"),
+    (_FLOW_ID_SCAN_COMPLETE_LOCK, "scan_complete_lock"),
+    (_FLOW_ID_SCAN_CANCEL_LOCK, "scan_cancel_lock"),
+)
+EVIDENCE_BY_FLOW_ID = {row[0]: row for row in FLOW_ID_EVIDENCE}
+SCAN_FLOW_EVIDENCE = EVIDENCE_BY_FLOW_ID
 
 
 @pytest.mark.parametrize(("flow_id", "expected"), SCAN_FLOWS)
@@ -16,3 +26,14 @@ def test_scan_lock_flow_ids_are_named_catalogued_and_fail_closed(flow_id, expect
     assert flow_id == expected
     assert flow_id in ALL_FLOW_IDS
     assert FlowPolicy[flow_id] == "fail_closed"
+
+
+@pytest.mark.parametrize("flow_id", [flow_id for flow_id, _ in SCAN_FLOWS])
+def test_scan_lock_evidence_is_primitive_only(flow_id: str) -> None:
+    """Scan rows MUST document primitive coverage, not endpoint reachability."""
+    row = SCAN_FLOW_EVIDENCE[flow_id]
+
+    assert row[1] == "app.core.dist_lock.acquire_dist_lock"
+    assert row[3] == FlowPolicy[flow_id]
+    assert row[4] == "primitive-only"
+    assert "no app scan path" in row[5]


### PR DESCRIPTION
Closes #260

## Summary
- Adds the PR7-A governance matrix making the 29-FlowId outage catalog auditable: 29-row six-field evidence rows, 2 runtime-reachable / 23 catalog-only / 4 primitive-only reachability classification, and explicit scan primitive-only evidence for the four deferred scan FlowIds.
- Characterizes the generic distributed-lock primitive deterministically: one bounded retry with timeout/cancellation, and typed retry-phase transport outage taking precedence over lock timeout — no production changes.
- Adds a real-Toxiproxy scan-lock fault matrix (17 cases) covering healthy ownership, initial transport outage typing, bounded contention cancellation, retry-outage precedence, and failed-test cleanup/recovery isolation across the four scan FlowIds.

## What is intentionally missing
- Production `app/` changes: none. This is a test-only governance/characterization slice on top of the existing typed `RedisOutageError` contract.
- The stale `25`-FlowId comment in `app/core/outage.py` stays as a separate documentation-only follow-up (outside this test-only scope).
- Pre-existing unawaited-coroutine RuntimeWarning in `TestAsyncWaiterProtocol::test_deterministic_waiter_times_out` (present in baseline, does not fail the suite).

## Design and specification references
- Engram verify #2269: `sdd/pr7-ghost-flowid-scan-locks/verify-report` (verdict PASS, 7/7 requirements, 7/7 scenarios)
- Engram archive #2271: `sdd/pr7-ghost-flowid-scan-locks/archive-report`
- Engram tasks #2257: `sdd/pr7-ghost-flowid-scan-locks/tasks` (16/16)
- Engram design #2253: `sdd/pr7-ghost-flowid-scan-locks/design`
- Engram spec #2251: `sdd/pr7-ghost-flowid-scan-locks/spec`
- Engram apply-progress #2263: `sdd/pr7-ghost-flowid-scan-locks/apply-progress`

## Verification
- Focused real-proxy matrix: `uv run pytest tests/integration/test_toxiproxy_scan_lock_faults.py -q -m 'integration and toxiproxy'` → 17 passed (44.15s).
- Required sweep: `uv run pytest tests/unit/test_outage_primitives.py tests/unit/test_outage_scan_flows.py tests/unit/test_dist_lock.py tests/integration/test_toxiproxy_scan_lock_faults.py -q -m 'integration and toxiproxy or not integration'` → 114 passed (97 unit + 17 integration), 1 pre-existing RuntimeWarning, exit 0.
- `uv run ruff check` + `uv run ruff format --check` on the four authored files → pass.
- `git diff --check` → clean. PR6 v2 module and CI workflow untouched.
- Authored change: 780 lines (below the accepted 800-line `size:exception` ceiling).

## Changes
| File | Change |
|------|--------|
| `tests/unit/test_outage_primitives.py` | 29-row six-field FlowId evidence matrix; 2/23/4 reachability classification; 29 wording cleanup. |
| `tests/unit/test_outage_scan_flows.py` | Explicit primitive-only scan evidence for the four scan FlowIds. |
| `tests/unit/test_dist_lock.py` | Deterministic one-retry timeout/cancellation and retry transport-outage precedence. |
| `tests/integration/test_toxiproxy_scan_lock_faults.py` | New: 17 real-proxy fault/recovery cases over the four scan FlowIds. |

## Test plan
- [x] Focused matrix: `uv run pytest tests/integration/test_toxiproxy_scan_lock_faults.py -q -m 'integration and toxiproxy'`
- [x] Required sweep: 114 passed, exit 0
- [x] `uv run ruff check` / `ruff format --check` on changed files
- [x] No production `app/` diff

## Contributor checklist
- [x] Linked approved issue #260
- [x] Added exactly one `type:*` label: `type:chore`
- [x] Conventional commits
- [x] No `Co-Authored-By` trailers

PR7-A is ready for review; do not merge until the maintainer reviews it.
