### PR TITLE
fix(redis): fail closed revocation and durable DLQ ack (PR8)

### DIFF
--- a/app/core/security.py
+++ b/app/core/security.py
@@ -1,3 +1,4 @@
+# fmt: off
 from __future__ import annotations
 
 import hmac
@@ -8,12 +9,13 @@ from typing import Any
 import anyio
 import bcrypt
 import jwt
-from jwt import ExpiredSignatureError, InvalidTokenError
+from jwt import InvalidTokenError
 from redis.asyncio import Redis
 
 from app.core.config import settings
 from app.core.exceptions import UserError
 from app.core.logging import get_logger
+from app.core.outage import classify_redis_error
 
 logger = get_logger(__name__)
 
@@ -143,13 +145,19 @@ _ACTIVE_JTIS_PREFIX = "active_jtis:"
 async def revoke_access_token(jti: str, ttl_seconds: int, redis: Redis) -> None:
     """Añade el JTI a la denylist con TTL igual al tiempo restante del token"""
     if ttl_seconds > 0:
-        await redis.set(f"{_DENYLIST_PREFIX}{jti}", "1", ex=ttl_seconds)
+        try:
+            await redis.set(f"{_DENYLIST_PREFIX}{jti}", "1", ex=ttl_seconds)
+        except Exception as exc:
+            raise classify_redis_error(exc) from exc
         logger.debug("Token revocado", extra={"jti": jti, "ttl": ttl_seconds})
 
 
 async def is_token_revoked(jti: str, redis: Redis) -> bool:
     """Devuelve True si el token esta en la denylist"""
-    result = await redis.exists(f"{_DENYLIST_PREFIX}{jti}")
+    try:
+        result = await redis.exists(f"{_DENYLIST_PREFIX}{jti}")
+    except Exception as exc:
+        raise classify_redis_error(exc) from exc
     return int(result) > 0
 
 
@@ -166,19 +174,28 @@ async def revoke_tokens_by_jtis(jtis: list[str], redis: Redis, ttl_seconds: int 
 
 async def track_jti(user_id: str, jti: str, redis: Redis) -> None:
     """Añade el JTI al conjunto de JTIs activos del usuario. Idempotente (SADD)."""
-    await redis.sadd(f"{_ACTIVE_JTIS_PREFIX}{user_id}", jti)
+    try:
+        await redis.sadd(f"{_ACTIVE_JTIS_PREFIX}{user_id}", jti)
+    except Exception as exc:
+        raise classify_redis_error(exc) from exc
     logger.debug("JTI trackeado", extra={"user_id": user_id, "jti": jti})
 
 
 async def untrack_jti(user_id: str, jti: str, redis: Redis) -> None:
     """Remueve el JTI del conjunto de JTIs activos. Seguro si no existe (SREM)."""
-    await redis.srem(f"{_ACTIVE_JTIS_PREFIX}{user_id}", jti)
+    try:
+        await redis.srem(f"{_ACTIVE_JTIS_PREFIX}{user_id}", jti)
+    except Exception as exc:
+        raise classify_redis_error(exc) from exc
     logger.debug("JTI untrackeado", extra={"user_id": user_id, "jti": jti})
 
 
 async def get_active_jtis(user_id: str, redis: Redis) -> list[str]:
     """Devuelve la lista de JTIs activos para el usuario. Lista vacía si no hay ninguno."""
-    members = await redis.smembers(f"{_ACTIVE_JTIS_PREFIX}{user_id}")
+    try:
+        members = await redis.smembers(f"{_ACTIVE_JTIS_PREFIX}{user_id}")
+    except Exception as exc:
+        raise classify_redis_error(exc) from exc
     return [m.decode() if isinstance(m, bytes) else m for m in members]
 
 
@@ -189,22 +206,30 @@ async def revoke_all_user_access_tokens(
 ) -> None:
     """Revoca todos los JTIs activos del usuario usando comandos ordenados (REQ-140-R05).
 
-    Estrategia defense-in-depth:
+    Estrategia fail-closed:
     1. Escribe cada entrada denylist con ``redis.set(...)`` ordenado (sin pipeline).
-    2. Si al menos una SET tuvo éxito, intenta eliminar el set ``active_jtis``
-       (best-effort) incluso si alguna SET posterior falló.
-    3. Si ninguna SET tuvo éxito, propaga el error para que el caller reintente.
+    2. Detiene la operación en el primer fallo y conserva ``active_jtis`` para
+       retry o recuperación.
+    3. Elimina ``active_jtis`` únicamente después de que todas las SET tengan éxito.
 
     Esto evita el estado parcial ambiguo de usar ``pipeline(transaction=True)``:
     si el pipeline falla en ``execute()``, no sabemos cuántas SET llegaron a Redis.
     """
     key = f"{_ACTIVE_JTIS_PREFIX}{user_id}"
-    jtis = await redis.smembers(key)
+    try:
+        jtis = await redis.smembers(key)
+    except Exception as exc:
+        logger.warning(
+            "redis_revoke_active_jtis_read_failed",
+            extra={"user_id": user_id},
+        )
+        raise classify_redis_error(exc) from exc
+
     if not jtis:
         logger.debug("No hay JTIs activos para revocar", extra={"user_id": user_id})
         return
 
-    jti_strs = [j.decode() if isinstance(j, bytes) else j for j in jtis]
+    jti_strs = sorted(j.decode() if isinstance(j, bytes) else j for j in jtis)
     denylisted_count = 0
 
     # Fase 1: denylist SETs ordenados (sin pipeline, REQ-140-R05)
@@ -212,33 +237,32 @@ async def revoke_all_user_access_tokens(
         try:
             await redis.set(f"{_DENYLIST_PREFIX}{jti}", "1", ex=ttl_seconds)
             denylisted_count += 1
-        except Exception:
+        except Exception as exc:
             if denylisted_count == 0:
-                # Zero success — propagate for retry
                 logger.warning(
                     "redis_revoke_zero_success",
                     extra={"user_id": user_id, "jtis_count": len(jti_strs)},
                 )
-                raise
-            # Partial success — log and continue to best-effort cleanup
-            logger.warning(
-                "redis_revoke_all_partial_failure",
-                extra={
-                    "user_id": user_id,
-                    "jtis_count": len(jti_strs),
-                    "denylisted_count": denylisted_count,
-                },
-            )
-            break
+            else:
+                logger.warning(
+                    "redis_revoke_all_partial_failure",
+                    extra={
+                        "user_id": user_id,
+                        "jtis_count": len(jti_strs),
+                        "denylisted_count": denylisted_count,
+                    },
+                )
+            raise classify_redis_error(exc) from exc
 
-    # Fase 2: best-effort DELETE del set active_jtis
+    # Fase 2: DELETE del set active_jtis only after total success
     try:
         await redis.delete(key)
-    except Exception:
+    except Exception as exc:
         logger.warning(
             "redis_active_jtis_cleanup_failed",
             extra={"user_id": user_id},
         )
+        raise classify_redis_error(exc) from exc
 
     logger.info(
         "Todos los JTIs del usuario revocados",

--- a/app/event_bus/bus.py
+++ b/app/event_bus/bus.py
@@ -2,20 +2,19 @@
 
 Wraps Redis Streams primitives with typed Pydantic event schemas.
 """
-from __future__ import annotations
 
-import asyncio
+# fmt: off
+from __future__ import annotations
 
 from redis.asyncio import Redis
 
 from app.core.config import settings
 from app.core.logging import get_logger
+from app.core.outage import classify_redis_error
 from app.event_bus._helpers import (
-    _INFLIGHT_DLQ,
     _RETRY_COUNT_KEY,
     _RETRY_HASH_FIELD,
     _retry_key,
-    drain_dlq_tasks,
 )
 from app.event_bus.consumer import EventConsumer
 from app.event_schemas import BaseEvent
@@ -71,13 +70,28 @@ class EventBus:
             if v is not None
         }
         # XADD with bounded stream length (approximate)
-        msg_id = await self._redis.xadd(
-            stream,
-            payload,
-            maxlen=settings.EVENT_STREAM_MAXLEN,
-            approximate=True,
-        )
+        try:
+            msg_id = await self._redis.xadd(
+                stream,
+                payload,
+                maxlen=settings.EVENT_STREAM_MAXLEN,
+                approximate=True,
+            )
+        except Exception as exc:
+            raise classify_redis_error(exc) from exc
         return msg_id
+
+    @staticmethod
+    async def _append_to_dlq(
+        redis_client: Redis,
+        stream: str,
+        payload: dict,
+    ) -> None:
+        """Persist one DLQ record before the caller is allowed to ACK."""
+        try:
+            await redis_client.xadd(stream, payload)
+        except Exception as exc:
+            raise classify_redis_error(exc) from exc
 
     def get_consumer(self, consumer_name: str, event_type: str) -> EventConsumer:
         """Create a consumer for a specific event type.
@@ -143,11 +157,11 @@ class EventBus:
                     _retry_key(event_type, message_id), _RETRY_HASH_FIELD
                 )
                 retry_count = int(persisted) if persisted is not None else 0
-            except Exception as exc:
+            except Exception:
                 logger.warning(
                     "retry_count_read_failed_fallback_in_memory",
                     event_type=event_type,
-                    error=str(exc),
+                    reason="redis_error",
                 )
                 retry_count = int(data.get(_RETRY_COUNT_KEY, 0))
         else:
@@ -159,11 +173,11 @@ class EventBus:
                 return
             try:
                 await redis_client.delete(_retry_key(event_type, message_id))
-            except Exception as exc:
+            except Exception:
                 logger.warning(
                     "retry_count_cleanup_failed",
                     event_type=event_type,
-                    error=str(exc),
+                    reason="redis_error",
                 )
 
         try:
@@ -190,11 +204,11 @@ class EventBus:
                             key, settings.EVENT_RETRY_TTL_SECONDS
                         )
                         retry_count = new_count
-                    except Exception as redis_exc:
+                    except Exception:
                         logger.warning(
                             "retry_count_write_failed_fallback_in_memory",
                             event_type=event_type,
-                            error=str(redis_exc),
+                            reason="redis_error",
                         )
                         retry_count += 1
                         data[_RETRY_COUNT_KEY] = retry_count
@@ -206,7 +220,7 @@ class EventBus:
                     event_type=event_type,
                     retry_count=retry_count,
                     max_retries=settings.EVENT_MAX_RETRIES,
-                    error=str(exc),
+                    reason="handler_error",
                 )
                 raise  # Re-raise to trigger retry in consumer loop
             else:
@@ -215,11 +229,8 @@ class EventBus:
                     "event_exhausted_retries_moving_to_dlq",
                     event_type=event_type,
                     retry_count=retry_count,
-                    error=str(exc),
+                    reason="handler_error",
                 )
-                # Clear the persistent counter so a recycled message_id
-                # doesn't immediately re-DLQ.
-                await _cleanup_retry_key()
                 if redis_client is None:
                     # No Redis client available — the DLQ entry would be lost
                     # forever. Surface this as a CRITICAL so ops can alert.
@@ -240,18 +251,15 @@ class EventBus:
                     k: str(v) if hasattr(v, "__str__") else v
                     for k, v in dlq_payload.items()
                 }
-                # Schedule the DLQ write as a Task and hold a strong reference
-                # in the module-level registry. Without this strong reference
-                # the Task can be garbage-collected before the xadd coroutine
-                # resumes, silently dropping the event (issue #126).
-                task = asyncio.ensure_future(
-                    redis_client.xadd(dlq_stream, dlq_payload)
+                await EventBus._append_to_dlq(
+                    redis_client,
+                    dlq_stream,
+                    dlq_payload,
                 )
-                _INFLIGHT_DLQ.add(task)
-                task.add_done_callback(_INFLIGHT_DLQ.discard)
-                # The xadd errors will surface as the task's exception; the
-                # done callback in lifespan drain reports them.
-                return False
+                # Clear the counter only after durable DLQ persistence. If the
+                # append fails, the PEL retry must still observe exhaustion.
+                await _cleanup_retry_key()
+                return True
 
     @staticmethod
     def _handle_auth_login(data: dict) -> None:

--- a/app/event_bus/consumer.py
+++ b/app/event_bus/consumer.py
@@ -1,10 +1,14 @@
 """EventConsumer — consumer group abstraction over Redis Streams."""
+
+# fmt: off
 from __future__ import annotations
 
 from redis.asyncio import Redis
+from redis.exceptions import ResponseError
 
 from app.core.config import settings
 from app.core.logging import get_logger
+from app.core.outage import classify_redis_error
 
 logger = get_logger(__name__)
 
@@ -52,9 +56,13 @@ class EventConsumer:
                 "0",  # start reading from the beginning (or use "$" for new only)
                 mkstream=True,
             )
-        except Exception:
-            # Group already exists — safe to ignore
-            pass
+        except ResponseError as exc:
+            # Redis uses BUSYGROUP for the idempotent already-exists case.
+            if "BUSYGROUP" in str(exc).upper():
+                return
+            raise classify_redis_error(exc) from exc
+        except Exception as exc:
+            raise classify_redis_error(exc) from exc
 
     async def read_pending(self) -> list[dict]:
         """Read pending messages for this consumer in this group.
@@ -76,13 +84,16 @@ class EventConsumer:
         # Get detailed pending entries: XPENDING stream group [start end count consumer]
         # Use "0" + "+" to get all pending entries
         # Signature: xpending_range(stream, group, min_id, max_id, count)
-        pending_entries = await self.redis_client.xpending_range(
-            stream_key,
-            self.group_name,
-            "0",
-            "+",
-            100,
-        )
+        try:
+            pending_entries = await self.redis_client.xpending_range(
+                stream_key,
+                self.group_name,
+                "0",
+                "+",
+                100,
+            )
+        except Exception as exc:
+            raise classify_redis_error(exc) from exc
 
         # Consumer lag monitoring: warn if pending entries exceed threshold
         pending_count = len(pending_entries)
@@ -127,16 +138,15 @@ class EventConsumer:
                         "message_id": cid if isinstance(cid, bytes) else cid.encode(),
                         "data": str_fields,
                     })
-        except Exception:
+        except Exception as exc:
             # XCLAIM may fail if messages are already acked or deleted.
-            # Log for observability but don't crash — the consumer loop
-            # will retry on the next iteration.
             logger.warning(
                 "batch_xclaim_failed",
                 event_type=self.event_type,
                 consumer_name=self.consumer_name,
                 message_count=len(msg_ids),
             )
+            raise classify_redis_error(exc) from exc
         return result
 
     async def read_new(self, block: int = 5000) -> list[dict]:
@@ -160,13 +170,16 @@ class EventConsumer:
         await self._ensure_group_exists()
         stream_key = self._stream_key()
 
-        result = await self.redis_client.xreadgroup(
-            self.group_name,
-            self.consumer_name,
-            {stream_key: ">"},
-            count=10,
-            block=block,
-        )
+        try:
+            result = await self.redis_client.xreadgroup(
+                self.group_name,
+                self.consumer_name,
+                {stream_key: ">"},
+                count=10,
+                block=block,
+            )
+        except Exception as exc:
+            raise classify_redis_error(exc) from exc
 
         if not result:
             return []
@@ -221,7 +234,10 @@ class EventConsumer:
         stream_key = self._stream_key()
         if isinstance(message_id, str):
             message_id = message_id.encode()
-        await self.redis_client.xack(stream_key, self.group_name, message_id)
+        try:
+            await self.redis_client.xack(stream_key, self.group_name, message_id)
+        except Exception as exc:
+            raise classify_redis_error(exc) from exc
 
     async def delete(self, message_id: str | bytes) -> None:
         """Delete a message from the stream entirely.

--- a/app/main.py
+++ b/app/main.py
@@ -83,13 +83,14 @@ async def _consumer_loop(
                         if isinstance(raw_msg_id, bytes)
                         else raw_msg_id
                     )
-                    await EventBus._dispatch_event(
+                    acknowledgement_eligible = await EventBus._dispatch_event(
                         "auth.login",
                         msg.get("data", {}),
                         redis_client,
                         message_id=msg_id,
                     )
-                    await consumer.ack(msg["message_id"])
+                    if acknowledgement_eligible:
+                        await consumer.ack(msg["message_id"])
             except asyncio.CancelledError:
                 logger.info("event_consumer_loop_cancelled")
                 raise

--- a/tests/integration/test_toxiproxy_revocation_event_faults.py
+++ b/tests/integration/test_toxiproxy_revocation_event_faults.py
@@ -1,0 +1,180 @@
+"""Serial post-startup Toxiproxy characterization for PR8 primitives.
+
+The shared fixture resets toxics, pools, and disposable Redis state.
+"""
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+from app.core.config import settings
+from app.core.exceptions import RedisOutageError
+from app.core.security import revoke_all_user_access_tokens
+from app.event_bus import EventBus, EventConsumer
+from app.event_bus._helpers import _RETRY_COUNT_KEY
+from app.event_schemas import AuthLoginEvent
+from tests.integration import test_toxiproxy_scan_lock_faults as toxiproxy
+
+pytestmark = [pytest.mark.integration, pytest.mark.toxiproxy]
+
+
+async def _close(client) -> None:
+    await asyncio.wait_for(client.aclose(), timeout=toxiproxy.CLEANUP_TIMEOUT_SECONDS)
+
+
+async def _seed_pending(group: str) -> tuple[str, dict]:
+    client = toxiproxy._redis_client(toxiproxy.PROXY_PORT)
+    try:
+        await asyncio.wait_for(
+            EventBus(client).publish(
+                AuthLoginEvent(
+                    event_id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                    tenant_id="bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+                    user_id="pr8-user",
+                    email_hash="c" * 32,
+                )
+            ),
+            timeout=toxiproxy.REQUEST_TIMEOUT_SECONDS,
+        )
+        consumer = EventConsumer(client, "auth.login", "pr8-worker", group)
+        messages = await asyncio.wait_for(
+            consumer.read_new(block=100), timeout=toxiproxy.REQUEST_TIMEOUT_SECONDS
+        )
+        assert len(messages) == 1
+        message = messages[0]
+        return message["message_id"], message["data"]
+    finally:
+        await _close(client)
+
+
+async def _pending_count(group: str) -> int:
+    client = toxiproxy._redis_client(toxiproxy.DIRECT_REDIS_PORT)
+    try:
+        return len(
+            await asyncio.wait_for(
+                client.xpending_range("events:auth.login", group, "0", "+", 100),
+                timeout=toxiproxy.REQUEST_TIMEOUT_SECONDS,
+            )
+        )
+    finally:
+        await _close(client)
+
+
+async def test_post_startup_drop_bulk_revocation_retains_active_jtis(
+    app_via_proxy, toxiproxy_client
+) -> None:
+    seed = toxiproxy._redis_client(toxiproxy.PROXY_PORT)
+    try:
+        await seed.sadd("active_jtis:pr8-drop", "jti-drop-a", "jti-drop-b")
+    finally:
+        await _close(seed)
+
+    async with toxiproxy._connection_drop(toxiproxy_client):
+        failing = toxiproxy._redis_client(toxiproxy.PROXY_PORT)
+        try:
+            with pytest.raises(RedisOutageError):
+                await asyncio.wait_for(
+                    revoke_all_user_access_tokens("pr8-drop", failing, 60),
+                    timeout=toxiproxy.REQUEST_TIMEOUT_SECONDS,
+                )
+        finally:
+            await _close(failing)
+        direct = toxiproxy._redis_client(toxiproxy.DIRECT_REDIS_PORT)
+        try:
+            assert set(await direct.smembers("active_jtis:pr8-drop")) == {
+                "jti-drop-a",
+                "jti-drop-b",
+            }
+        finally:
+            await _close(direct)
+
+
+@pytest.mark.parametrize("operation", ["read_pending", "ack"])
+async def test_post_startup_drop_classifies_stream_boundary(
+    operation: str,
+    app_via_proxy,
+    toxiproxy_client,
+) -> None:
+    group = f"pr8-{operation}-group"
+    message_id, _ = await _seed_pending(group)
+    async with toxiproxy._connection_drop(toxiproxy_client):
+        failing = toxiproxy._redis_client(toxiproxy.PROXY_PORT)
+        consumer = EventConsumer(failing, "auth.login", "pr8-worker", group)
+        try:
+            with pytest.raises(RedisOutageError):
+                operation_call = (
+                    consumer.read_pending()
+                    if operation == "read_pending"
+                    else consumer.ack(message_id)
+                )
+                await asyncio.wait_for(
+                    operation_call, timeout=toxiproxy.REQUEST_TIMEOUT_SECONDS
+                )
+        finally:
+            await _close(failing)
+
+
+async def test_post_startup_drop_dlq_failure_retains_pel_until_recovery(
+    app_via_proxy, toxiproxy_client
+) -> None:
+    group = "pr8-dlq-group"
+    message_id, data = await _seed_pending(group)
+    retry = toxiproxy._redis_client(toxiproxy.PROXY_PORT)
+    try:
+        await retry.hset(
+            f"event_retry:auth.login:{message_id}",
+            mapping={"retry_count": settings.EVENT_MAX_RETRIES},
+        )
+    finally:
+        await _close(retry)
+
+    try:
+        await asyncio.wait_for(
+            toxiproxy_client.add_connection_drop(1.0),
+            timeout=toxiproxy.CLEANUP_TIMEOUT_SECONDS,
+        )
+        failing = toxiproxy._redis_client(toxiproxy.PROXY_PORT)
+        try:
+            with patch.object(EventBus, "_handle_auth_login", side_effect=RuntimeError):
+                with pytest.raises(RedisOutageError):
+                    data[_RETRY_COUNT_KEY] = settings.EVENT_MAX_RETRIES
+                    await asyncio.wait_for(
+                        EventBus._dispatch_event(
+                            "auth.login", data, failing, message_id
+                        ),
+                        timeout=toxiproxy.REQUEST_TIMEOUT_SECONDS,
+                    )
+        finally:
+            await _close(failing)
+        assert await _pending_count(group) == 1
+
+        await asyncio.wait_for(
+            toxiproxy_client.reset_toxics(), timeout=toxiproxy.CLEANUP_TIMEOUT_SECONDS
+        )
+        await asyncio.wait_for(
+            toxiproxy.close_pool(), timeout=toxiproxy.CLEANUP_TIMEOUT_SECONDS
+        )
+        healthy = toxiproxy._redis_client(toxiproxy.PROXY_PORT)
+        try:
+            consumer = EventConsumer(
+                healthy, "auth.login", "pr8-recovery-worker", group
+            )
+            pending = await asyncio.wait_for(
+                consumer.read_pending(), timeout=toxiproxy.REQUEST_TIMEOUT_SECONDS
+            )
+            assert len(pending) == 1
+            with patch.object(EventBus, "_handle_auth_login", side_effect=RuntimeError):
+                eligible = await asyncio.wait_for(
+                    EventBus._dispatch_event(
+                        "auth.login", pending[0]["data"], healthy, message_id
+                    ),
+                    timeout=toxiproxy.REQUEST_TIMEOUT_SECONDS,
+                )
+            assert eligible is True
+            await consumer.ack(pending[0]["message_id"])
+            assert await _pending_count(group) == 0
+            assert len(await healthy.xrange("events:dlq:auth.login")) == 1
+        finally:
+            await _close(healthy)
+    finally:
+        await toxiproxy._reset_proxy_state(toxiproxy_client)

--- a/tests/unit/test_auth_service_event_publish.py
+++ b/tests/unit/test_auth_service_event_publish.py
@@ -4,6 +4,8 @@ T4.1: After credentials are validated and tokens are created,
 the login function MUST publish an auth.login event without blocking
 the login response if event publishing fails.
 """
+
+# fmt: off
 from __future__ import annotations
 
 import pytest
@@ -215,6 +217,8 @@ class TestAuthLoginEventPublish:
         mock_warning.assert_called_once_with(
             "event_publish_failed", event_type="auth.login", reason="redis_error"
         )
+        mock_event_bus.publish.assert_awaited_once()
+        assert "Connection refused" not in repr(mock_warning.call_args)
 
     @pytest.mark.asyncio
     async def test_login_blocked_if_credentials_invalid(self):
@@ -699,7 +703,6 @@ class TestUserAgentSanitizationInEvents:
     async def test_missing_ua_sends_none(self):
         """When User-Agent header is absent, event receives None."""
         from app.modules.auth import service
-        from app.event_schemas import AuthLoginEvent
         from app.event_bus import EventBus
 
         mock_user = MagicMock()

--- a/tests/unit/test_event_bus.py
+++ b/tests/unit/test_event_bus.py
@@ -1,11 +1,15 @@
 """Tests for event_bus.py (T2.2) — EventBus and EventConsumer classes."""
+
+# fmt: off
 from __future__ import annotations
 
 import uuid
+from unittest.mock import AsyncMock
 
 import pytest
 import pytest_asyncio
 from fakeredis.aioredis import FakeRedis
+from redis.exceptions import ConnectionError as RedisConnectionError
 
 
 class TestEventBusStreamName:
@@ -267,7 +271,7 @@ class TestEventConsumerReadPending:
         makes ONE XCLAIM call with all message_ids instead of N individual XCLAIM calls.
         This is a performance optimization that reduces Redis round-trips from O(n) to O(1).
         """
-        from unittest.mock import AsyncMock, MagicMock, patch
+        from unittest.mock import AsyncMock, patch
         from app.event_bus import EventConsumer
 
         # Create mock Redis client
@@ -464,3 +468,55 @@ class TestEventBusGetConsumer:
         assert consumer.consumer_name == "worker-1"
         assert consumer.group_name == settings.EVENT_CONSUMER_GROUP
         await client.aclose()
+
+
+class TestEventBusRedisOutageBoundaries:
+    """Redis Streams transport failures are exposed as typed outages."""
+    @pytest.mark.asyncio
+    async def test_publish_classifies_xadd_transport_failure(self):
+        from app.core.exceptions import RedisOutageError
+        from app.event_bus import EventBus
+        from app.event_schemas import AuthLoginEvent
+        class BrokenRedis(FakeRedis):
+            async def xadd(self, *args, **kwargs):  # type: ignore[override]
+                raise RedisConnectionError("raw-redis-transport-detail")
+        client = BrokenRedis()
+        try:
+            event = AuthLoginEvent(
+                event_id=uuid.uuid4(),
+                tenant_id=uuid.uuid4(),
+                user_id="user-outage",
+                email_hash="a" * 32,
+            )
+            with pytest.raises(RedisOutageError):
+                await EventBus(client).publish(event)
+        finally:
+            await client.aclose()
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("operation", ["group", "pending", "new", "ack"])
+    async def test_consumer_boundaries_classify_transport_failure(self, operation: str):
+        from app.core.exceptions import RedisOutageError
+        from app.event_bus import EventConsumer
+        redis = AsyncMock()
+        if operation == "group":
+            redis.xgroup_create.side_effect = RedisConnectionError("connection refused")
+        else:
+            redis.xgroup_create.return_value = None
+            method_name = {
+                "pending": "xpending_range",
+                "new": "xreadgroup",
+                "ack": "xack",
+            }[operation]
+            getattr(redis, method_name).side_effect = RedisConnectionError(
+                "connection refused"
+            )
+        consumer = EventConsumer(redis, "auth.login", "worker-1", "group-1")
+        with pytest.raises(RedisOutageError):
+            if operation == "group":
+                await consumer._ensure_group_exists()
+            elif operation == "pending":
+                await consumer.read_pending()
+            elif operation == "new":
+                await consumer.read_new(block=1)
+            else:
+                await consumer.ack("1-0")

--- a/tests/unit/test_event_bus_edge_cases.py
+++ b/tests/unit/test_event_bus_edge_cases.py
@@ -6,17 +6,20 @@ Extends test_event_bus.py coverage with:
 - malformed event data handling via _dispatch_event
 - publish serializes UUIDs correctly to Redis
 """
+
+# fmt: off
 from __future__ import annotations
 
 import asyncio
 import logging
 import uuid
 from datetime import datetime, timezone
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 import pytest_asyncio
 from fakeredis.aioredis import FakeRedis
+from redis.exceptions import ConnectionError as RedisConnectionError
 
 
 class TestEventBusDispatchRouting:
@@ -111,9 +114,8 @@ class TestEventBusDispatchRouting:
     async def test_dlq_write_lands_in_stream(self, caplog):
         """Regression #126: exhausted retries MUST actually write the event to the DLQ stream.
 
-        Before the fix, the XADD was wrapped in `asyncio.ensure_future` without
-        a strong reference, so the task could be GC'd before completing. This
-        test proves the event ends up in the DLQ stream and is not lost.
+        The dispatch contract now awaits XADD, so the event is durable before
+        the caller is allowed to acknowledge it.
         """
         from app.event_bus import EventBus, drain_dlq_tasks
         from app.core.config import settings
@@ -132,10 +134,10 @@ class TestEventBusDispatchRouting:
         try:
             with patch.object(EventBus, "_handle_auth_login", side_effect=RuntimeError("handler boom")):
                 result = await EventBus._dispatch_event("auth.login", bad_data, redis_client=client)
-            assert result is False
+            assert result is True
 
-            # The fix holds a strong reference to the task; drain it so we can
-            # inspect the stream deterministically.
+            # The dispatch call has already awaited the append; this remains a
+            # no-op compatibility check for the bounded shutdown drain.
             await drain_dlq_tasks(timeout=2.0)
 
             dlq_stream = f"{settings.EVENT_STREAM_PREFIX}:dlq:auth.login"
@@ -186,6 +188,93 @@ class TestEventBusDispatchRouting:
             "dlq_skipped_no_redis_client" in (r.message or "")
             for r in caplog.records
         ), f"Expected CRITICAL log 'dlq_skipped_no_redis_client', got: {[r.message for r in caplog.records]}"
+
+    @pytest.mark.asyncio
+    async def test_dispatch_event_dlq_before_ack(self):
+        """A durable DLQ write must complete before the consumer can ACK."""
+        from app.core.config import settings
+        from app.event_bus import EventBus, EventConsumer
+        class RecordingRedis:
+            def __init__(self) -> None:
+                self.calls: list[str] = []
+            async def hget(self, *args, **kwargs):
+                return str(settings.EVENT_MAX_RETRIES).encode()
+            async def delete(self, *args, **kwargs):
+                self.calls.append("retry-delete")
+                return 1
+            async def xadd(self, *args, **kwargs):
+                self.calls.append("dlq-xadd")
+                return b"2-0"
+            async def xack(self, *args, **kwargs):
+                self.calls.append("xack")
+                return 1
+        redis = RecordingRedis()
+        consumer = EventConsumer(redis, "auth.login", "worker-1", "group-1")
+        with patch.object(EventBus, "_handle_auth_login", side_effect=RuntimeError("handler boom")):
+            result = await EventBus._dispatch_event("auth.login", {"user_id": "u1"}, redis_client=redis, message_id="1-0")
+        assert result is True
+        await consumer.ack("1-0")
+        assert redis.calls.index("dlq-xadd") < redis.calls.index("xack")
+
+    @pytest.mark.asyncio
+    async def test_xclaim_recovery_persists_then_acks_after_dlq_failure(self):
+        """A failed DLQ write leaves the PEL recoverable for XCLAIM retry."""
+        from app.core.config import settings
+        from app.core.exceptions import RedisOutageError
+        from app.event_bus import EventBus, EventConsumer
+        class ToggleDlqRedis(FakeRedis):
+            def __init__(self) -> None:
+                super().__init__()
+                self.fail_dlq = True
+            async def xadd(self, stream, fields, *args, **kwargs):  # type: ignore[override]
+                if ":dlq:" in stream and self.fail_dlq:
+                    raise RedisConnectionError("raw-redis-transport-detail")
+                return await super().xadd(stream, fields, *args, **kwargs)
+        redis = ToggleDlqRedis()
+        stream = "events:auth.login"
+        group = "pr8-recovery-group"
+        consumer = EventConsumer(redis, "auth.login", "worker-1", group)
+        try:
+            await redis.xgroup_create(stream, group, "0", mkstream=True)
+            await redis.xadd(stream, {"user_id": "u1"})
+            messages = await consumer.read_new(block=1)
+            assert len(messages) == 1
+            message = messages[0]
+            message_id_str = message["message_id"].decode()
+            retry_key = f"event_retry:auth.login:{message_id_str}"
+            await redis.hset(retry_key, mapping={"retry_count": settings.EVENT_MAX_RETRIES})
+            with patch.object(EventBus, "_handle_auth_login", side_effect=RuntimeError("handler boom")):
+                with pytest.raises(RedisOutageError):
+                    await EventBus._dispatch_event("auth.login", message["data"], redis_client=redis, message_id=message_id_str)
+            assert await redis.hget(retry_key, "retry_count") == b"3"
+            pending = await consumer.read_pending()
+            assert len(pending) == 1
+            redis.fail_dlq = False
+            with patch.object(EventBus, "_handle_auth_login", side_effect=RuntimeError("handler boom")):
+                result = await EventBus._dispatch_event("auth.login", pending[0]["data"], redis_client=redis, message_id=message_id_str)
+            assert result is True
+            await consumer.ack(pending[0]["message_id"])
+            assert await redis.xpending_range(stream, group, "0", "+", 100) == []
+            dlq_entries = await redis.xrange("events:dlq:auth.login")
+            assert len(dlq_entries) == 1
+            assert await redis.hget(retry_key, "retry_count") is None
+        finally:
+            await redis.aclose()
+
+    @pytest.mark.asyncio
+    async def test_consumer_loop_skips_ack_when_dispatch_is_not_eligible(self):
+        """The consumer must not ACK a message whose terminal write failed."""
+        from app.main import _consumer_loop
+        redis = AsyncMock()
+        message = {"message_id": b"1-0", "data": {"user_id": "u1"}}
+        consumer = AsyncMock()
+        consumer.read_pending.side_effect = [[message], asyncio.CancelledError()]
+        consumer.read_new.return_value = []
+        with patch("app.main.EventBus._dispatch_event", new=AsyncMock(return_value=False)):
+            with pytest.raises(asyncio.CancelledError):
+                await _consumer_loop(redis_client=redis, consumer=consumer, stop_event=asyncio.Event())
+        consumer.ack.assert_not_awaited()
+        redis.aclose.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_dlq_survives_gc_pressure(self):
@@ -423,7 +512,7 @@ class TestEventBusRetryCounterPersistence:
                     )
 
             # HINCRBY wrote the field, EXPIRE set a TTL.
-            key = f"event_retry:auth.login:100-0"
+            key = "event_retry:auth.login:100-0"
             assert (await client.hget(key, "retry_count")) == b"1"
             ttl = await client.ttl(key)
             assert 0 < ttl <= settings.EVENT_RETRY_TTL_SECONDS
@@ -515,7 +604,7 @@ class TestEventBusRetryCounterPersistence:
                     "auth.login", {"user_id": "u-final"},
                     redis_client=client, message_id=msg_id,
                 )
-            assert result is False
+            assert result is True
 
             await drain_dlq_tasks(timeout=2.0)
             dlq_key = f"{settings.EVENT_STREAM_PREFIX}:dlq:auth.login"
@@ -591,7 +680,7 @@ class TestEventBusRetryCounterPersistence:
                     "auth.login", {"user_id": "u"},
                     redis_client=client, message_id=msg_id,
                 )
-            assert result is False
+            assert result is True
             await drain_dlq_tasks(timeout=2.0)
             assert (await client.hget(key, "retry_count")) is None
         finally:
@@ -605,8 +694,6 @@ class TestEventBusRetryCounterPersistence:
         data dict. This MUST still work.
         """
         from app.event_bus import EventBus
-        from app.core.config import settings
-
         client = FakeRedis()
         try:
             data = {"user_id": "u", "_retry_count": 0}
@@ -628,8 +715,6 @@ class TestEventBusRetryCounterPersistence:
     async def test_retry_count_falls_back_to_in_memory_on_redis_error(self):
         """If Redis hget raises, dispatch must fall back to the data dict."""
         from app.event_bus import EventBus
-        from app.core.config import settings
-
         # FakeRedis whose hget always raises to simulate a Redis hiccup.
         class BrokenRedis(FakeRedis):
             def __init__(self) -> None:

--- a/tests/unit/test_security.py
+++ b/tests/unit/test_security.py
@@ -1,19 +1,27 @@
+# fmt: off
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
+from httpx import ASGITransport, AsyncClient
 import pytest
 from fakeredis.aioredis import FakeRedis
 from pydantic import ValidationError
+from redis.exceptions import ConnectionError as RedisConnectionError
 
 from app.core.security import (
     can_assign_role,
     has_minimum_role,
     is_token_revoked,
+    get_active_jtis,
+    revoke_access_token,
+    revoke_all_user_access_tokens,
     revoke_tokens_by_jtis,
     secure_compare,
+    track_jti,
+    untrack_jti,
 )
 from app.modules.auth.schemas import ChangePasswordRequest
 from app.modules.users.schemas import RoleEnum, UserCreate
@@ -234,6 +242,138 @@ class TestBulkRevocation:
     """Unit coverage for bulk token revocation with fakeredis."""
 
     @pytest.mark.asyncio
+    async def test_revoke_all_zero_success_is_typed_and_retains_tracking_set(self):
+        """A first SET failure must classify the outage and preserve active JTIs."""
+        class FailingRedis(FakeRedis):
+            async def set(self, key: str, *args, **kwargs):  # type: ignore[override]
+                raise RedisConnectionError("raw-redis-transport-detail")
+        redis = FailingRedis()
+        try:
+            await redis.sadd("active_jtis:user-zero", "jti-zero")
+            with patch("app.core.security.logger.warning") as warning:
+                from app.core.exceptions import RedisUnreachableError
+
+                with pytest.raises(RedisUnreachableError):
+                    await revoke_all_user_access_tokens(
+                        "user-zero", redis, ttl_seconds=60
+                    )
+
+            assert await redis.smembers("active_jtis:user-zero") == {b"jti-zero"}
+            assert await redis.keys("revoked:*") == []
+            assert "raw-redis-transport-detail" not in repr(warning.call_args)
+        finally:
+            await redis.aclose()
+    @pytest.mark.asyncio
+    async def test_revoke_all_partial_failure_stops_and_retains_tracking_set(self):
+        """A later SET failure must not delete the tracking set or continue writes."""
+        class FailingRedis(FakeRedis):
+            def __init__(self) -> None:
+                super().__init__()
+                self.set_calls: list[str] = []
+                self.delete_calls: list[str] = []
+
+            async def smembers(self, key: str):  # type: ignore[override]
+                if key == "active_jtis:user-partial":
+                    return [b"jti-a", b"jti-b", b"jti-c"]
+                return await super().smembers(key)
+
+            async def set(self, key: str, *args, **kwargs):  # type: ignore[override]
+                self.set_calls.append(key)
+                if key == "revoked:jti-b":
+                    raise RedisConnectionError("partial transport failure")
+                return await super().set(key, *args, **kwargs)
+
+            async def delete(self, key: str, *args, **kwargs):  # type: ignore[override]
+                self.delete_calls.append(key)
+                return await super().delete(key, *args, **kwargs)
+        redis = FailingRedis()
+        try:
+            await redis.sadd("active_jtis:user-partial", "jti-a", "jti-b", "jti-c")
+            from app.core.exceptions import RedisUnreachableError
+            with pytest.raises(RedisUnreachableError):
+                await revoke_all_user_access_tokens(
+                    "user-partial", redis, ttl_seconds=60
+                )
+
+            assert redis.set_calls == ["revoked:jti-a", "revoked:jti-b"]
+            assert redis.delete_calls == []
+            assert set(await redis.smembers("active_jtis:user-partial")) == {
+                b"jti-a",
+                b"jti-b",
+                b"jti-c",
+            }
+            assert await redis.exists("revoked:jti-a") == 1
+            assert await redis.exists("revoked:jti-c") == 0
+        finally:
+            await redis.aclose()
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "operation",
+        [
+            "revoke_access_token",
+            "is_token_revoked",
+            "track_jti",
+            "untrack_jti",
+            "get_active_jtis",
+        ],
+    )
+    async def test_revocation_primitive_transport_errors_are_typed(
+        self, operation: str
+    ):
+        """Direct revocation Redis failures must expose RedisOutageError subclasses."""
+        redis = MagicMock()
+        failure = RedisConnectionError("transport unavailable")
+        for method_name in ("set", "exists", "sadd", "srem", "smembers"):
+            setattr(redis, method_name, AsyncMock(side_effect=failure))
+        from app.core.exceptions import RedisOutageError
+        operations = {
+            "revoke_access_token": lambda: revoke_access_token(
+                "jti-primitive", 60, redis
+            ),
+            "is_token_revoked": lambda: is_token_revoked("jti-primitive", redis),
+            "track_jti": lambda: track_jti("user-primitive", "jti-primitive", redis),
+            "untrack_jti": lambda: untrack_jti(
+                "user-primitive", "jti-primitive", redis
+            ),
+            "get_active_jtis": lambda: get_active_jtis("user-primitive", redis),
+        }
+        with pytest.raises(RedisOutageError):
+            await operations[operation]()
+
+    @pytest.mark.asyncio
+    async def test_revocation_outage_reaches_sanitized_http_boundary(self):
+        """A typed revocation outage must retain the global sanitized 503 contract."""
+        from app.core.config import settings
+        from app.core.security import revoke_access_token
+        from app.main import create_app
+
+        raw_detail = "raw-redis-transport-detail"
+
+        class BrokenRedis:
+            async def set(self, *args, **kwargs):
+                raise RedisConnectionError(raw_detail)
+
+        app = create_app()
+
+        @app.post("/_test/revoke-outage", include_in_schema=False)
+        async def _revoke_outage():
+            await revoke_access_token("jti-http", 60, BrokenRedis())
+            return {"ok": True}
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app, raise_app_exceptions=False),
+            base_url="http://test",
+        ) as client:
+            response = await client.post("/_test/revoke-outage")
+
+        assert response.status_code == 503
+        assert response.headers["Retry-After"] == str(
+            settings.REDIS_OUTAGE_RETRY_AFTER_SECONDS
+        )
+        assert response.json() == {"detail": "service temporarily unavailable"}
+        assert raw_detail not in response.text
+
+    @pytest.mark.asyncio
     async def test_empty_jti_list_is_noop(self):
         redis = FakeRedis()
         try:
@@ -397,12 +537,12 @@ class TestBcryptAsyncWrappers:
 
 
 class TestRevokeAllUserAccessTokensOrdered:
-    """REQ-140-R05: Ordered token revocation with best-effort cleanup."""
+    """REQ-140-R05: Ordered token revocation with fail-closed cleanup."""
 
     @pytest.mark.asyncio
     async def test_success_path(self):
         """All JTIs denylisted, active set deleted on success."""
-        from app.core.security import revoke_all_user_access_tokens, is_token_revoked
+        from app.core.security import revoke_all_user_access_tokens
 
         redis = FakeRedis()
         try:
@@ -442,14 +582,13 @@ class TestRevokeAllUserAccessTokensOrdered:
             await redis.aclose()
 
     @pytest.mark.asyncio
-    async def test_partial_failure_still_attempts_cleanup(self):
-        """After a partial denylist write, DELETE must still be attempted."""
+    async def test_partial_failure_retains_tracking_set(self):
+        """After a partial denylist write, DELETE must not be attempted."""
         from app.core.security import revoke_all_user_access_tokens
+        from app.core.exceptions import RedisUnreachableError
 
         redis = AsyncMock()
-        redis.smembers = AsyncMock(
-            return_value={b"jti-1", b"jti-2", b"jti-3"}
-        )
+        redis.smembers = AsyncMock(return_value=[b"jti-1", b"jti-2", b"jti-3"])
 
         call_count = 0
 
@@ -463,27 +602,27 @@ class TestRevokeAllUserAccessTokensOrdered:
         redis.set = mock_set
         redis.delete = AsyncMock()
 
-        await revoke_all_user_access_tokens(
-            user_id="user-pfail",
-            redis=redis,
-            ttl_seconds=3600,
-        )
+        with pytest.raises(RedisUnreachableError):
+            await revoke_all_user_access_tokens(
+                user_id="user-pfail",
+                redis=redis,
+                ttl_seconds=3600,
+            )
 
         # First JTI should have been denylisted
         assert call_count == 2  # Only 2 set calls made (third not attempted after fail)
 
-        # DELETE must have been attempted (best-effort cleanup)
-        redis.delete.assert_awaited_once_with("active_jtis:user-pfail")
+        # DELETE must not be attempted while tracking state is incomplete.
+        redis.delete.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_zero_success_raises_error(self):
-        """Zero denylist writes → error propagates for retry."""
+        """Zero denylist writes → classified error propagates for retry."""
         from app.core.security import revoke_all_user_access_tokens
+        from app.core.exceptions import RedisUnreachableError
 
         redis = AsyncMock()
-        redis.smembers = AsyncMock(
-            return_value={b"jti-1", b"jti-2"}
-        )
+        redis.smembers = AsyncMock(return_value={b"jti-1", b"jti-2"})
 
         async def mock_set(key, value, ex):
             raise ConnectionError("Redis down")
@@ -491,7 +630,7 @@ class TestRevokeAllUserAccessTokensOrdered:
         redis.set = mock_set
         redis.delete = AsyncMock()
 
-        with pytest.raises(ConnectionError):
+        with pytest.raises(RedisUnreachableError):
             await revoke_all_user_access_tokens(
                 user_id="user-zero",
                 redis=redis,
@@ -502,23 +641,23 @@ class TestRevokeAllUserAccessTokensOrdered:
         redis.delete.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_delete_failure_logs_but_does_not_raise(self):
-        """DELETE failure after successful denylist must log warning, not raise."""
-        from app.core.security import revoke_all_user_access_tokens, is_token_revoked
+    async def test_delete_failure_is_typed_and_logs(self):
+        """DELETE failure after successful denylist must remain recoverable."""
+        from app.core.security import revoke_all_user_access_tokens
+        from app.core.exceptions import RedisUnreachableError
 
         redis = AsyncMock()
-        redis.smembers = AsyncMock(
-            return_value={b"jti-1", b"jti-2"}
-        )
+        redis.smembers = AsyncMock(return_value={b"jti-1", b"jti-2"})
         redis.set = AsyncMock(return_value=True)
         redis.delete = AsyncMock(side_effect=ConnectionError("Delete failed"))
 
         with patch("app.core.security.logger") as mock_logger:
-            await revoke_all_user_access_tokens(
-                user_id="user-del-fail",
-                redis=redis,
-                ttl_seconds=3600,
-            )
+            with pytest.raises(RedisUnreachableError):
+                await revoke_all_user_access_tokens(
+                    user_id="user-del-fail",
+                    redis=redis,
+                    ttl_seconds=3600,
+                )
 
         # Denylist entries written
         assert redis.set.await_count == 2
@@ -538,9 +677,7 @@ class TestRevokeAllUserAccessTokensOrdered:
         from app.core.security import revoke_all_user_access_tokens
 
         redis = AsyncMock()
-        redis.smembers = AsyncMock(
-            return_value={b"jti-first", b"jti-second"}
-        )
+        redis.smembers = AsyncMock(return_value=[b"jti-second", b"jti-first"])
 
         command_log: list[str] = []
 
@@ -567,6 +704,8 @@ class TestRevokeAllUserAccessTokensOrdered:
 
         assert len(set_indices) == 2
         assert len(delete_indices) == 1
-        assert set_indices[-1] < delete_indices[0], (
-            f"SET indices {set_indices} must all be before DELETE at {delete_indices}"
-        )
+        assert set_indices[-1] < delete_indices[0], f"SET indices {set_indices} must all be before DELETE at {delete_indices}"
+        assert command_log[:2] == [
+            "SET revoked:jti-first",
+            "SET revoked:jti-second",
+        ]


### PR DESCRIPTION
Closes #260

## Summary
- Makes bulk access-token revocation fail closed: zero-success or partial denylist writes raise a classified `RedisOutageError`, the `active_jtis` tracking set is preserved for retry, and the set is deleted only after every denylist write succeeds (`app/core/security.py`).
- Normalizes Redis transport failures at their boundaries with `classify_redis_error` (security primitives, Streams publish/read/ack) so HTTP-facing paths return the existing sanitized 503 + `Retry-After` (`app/core/security.py`, `app/event_bus/bus.py`, `app/event_bus/consumer.py`).
- Makes DLQ persistence precede acknowledgement: the consumer ACKs only after the DLQ append succeeds; on DLQ failure the message stays pending in the PEL for the existing XCLAIM recovery (`app/event_bus/bus.py`, `app/main.py`).
- Characterizes (without changing) the availability-first login publisher: tokens return, `event_publish_failed` logged safely, event may drop.
- Adds a serial Toxiproxy primitive/boundary matrix (4 cases: bulk-revocation outage retains tracking, Streams boundary classification, DLQ failure retains PEL until recovery) plus deterministic unit coverage.

## What is intentionally missing
- Redis–Postgres atomicity, outbox/repair-queue/sagas, scan/metrics work, and FlowId wiring/enforcement remain deferred (PR9 / follow-ups).
- Mypy project-wide debt is pre-existing (99 errors incl. unrelated modules: llm factory, event deps, auth service) and is out of gate for this change.
- Strict-TDD RED evidence for the 33 tasks is marked reconstructed (a cancelled repair session lost verbatim transcripts); runtime evidence is current and green (127 tests).

## Native review note (maintainer decision)
The Gentle AI native 4R review could not complete: two of four lens captures (resilience order 1, readability order 2) fail deterministically on the scope-changed recovery successor due to a provider capture/admission defect — reported with full evidence on Gentleman-Programming/gentle-ai issue #2618 (comments 5208301629, 5208368771); 6 capture attempts failed; outcomes were schema-compliant. Maintainer decision: deliver unmanaged by the native gate, using the independent SDD verification (verify-report PASS, 127 tests) as the verification evidence. Gates: pre-commit failed closed (no receipt); pre-push ran post-hoc with an empty publication range (allow, no receipt governance). Lineages preserved: review-36e71016a466b336 (approved, polluted candidate) and review-pr8-clean-36e71016 (reviewing, 2/4 lenses admitted).

## Design and specification references
- Engram verify #2283: `sdd/pr8-revocation-eventbus-faults/verify-report` (verdict PASS, 5/5 requirements, 9/9 scenarios, 127 passed)
- Engram archive #2286: `sdd/pr8-revocation-eventbus-faults/archive-report`
- Engram design #2278, spec #2277, tasks #2279, apply-progress #2280

## Test plan
- [x] Full sweep: `uv run pytest tests/unit/test_security.py tests/unit/test_redis_fail_closed.py tests/unit/test_event_bus.py tests/unit/test_event_bus_edge_cases.py tests/unit/test_auth_service_event_publish.py tests/integration/test_toxiproxy_revocation_event_faults.py -q -m "integration and toxiproxy or not integration"` → 127 passed
- [x] Focused Toxiproxy: 4 passed (post-startup toxic, 3.0s/5.0s bounds, cleanup)
- [x] Ruff check + format --check on all changed files; `git diff --check` clean
- [x] Conventional commit, no Co-Authored-By; diff 782 authored lines (size:exception approved)