### PR TITLE
fix(auth): typed 503 isolation, partial-state contracts, publish retry (PR9a #260)

### DIFF
--- a/app/dependencies/auth.py
+++ b/app/dependencies/auth.py
@@ -11,6 +11,7 @@ from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.database import get_db, set_tenant_context
+from app.core.exceptions import ServiceUnavailableError
 from app.core.logging import get_logger
 from app.core.redis import check_redis_healthy, get_redis
 from app.core.security import decode_access_token, has_minimum_role, is_token_revoked
@@ -59,10 +60,7 @@ async def get_current_user(
     jti = payload.get("jti")
     if not await check_redis_healthy(redis):
         logger.error("redis_unhealthy", reason="auth_dependency")
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Servicio temporalmente no disponible",
-        )
+        raise ServiceUnavailableError()
     if not jti or await is_token_revoked(jti, redis):
         logger.warning("auth_failed", reason="revoked_token", jti=jti)
         raise HTTPException(

--- a/app/main.py
+++ b/app/main.py
@@ -14,7 +14,11 @@ from sqlalchemy import text
 
 from app.core.config import settings
 from app.core.database import engine
-from app.core.exceptions import RedisOutageError, TemporaryUnavailableError
+from app.core.exceptions import (
+    RedisOutageError,
+    ServiceUnavailableError,
+    TemporaryUnavailableError,
+)
 from app.core.logging import setup_logging, get_logger
 from app.core.metrics_auth import (
     _extract_header,
@@ -228,6 +232,18 @@ def create_app() -> FastAPI:
         )
 
     app.add_exception_handler(RedisOutageError, redis_outage_handler)  # type: ignore[arg-type]  # narrow subclass matches Starlette's wider Exception signature
+
+    async def service_unavailable_handler(
+        request: Request, exc: ServiceUnavailableError
+    ) -> JSONResponse:
+        """Translate health-check failures to a sanitized 503 response."""
+        return JSONResponse(
+            status_code=503,
+            content={"detail": "service temporarily unavailable"},
+            headers={"Retry-After": str(settings.REDIS_OUTAGE_RETRY_AFTER_SECONDS)},
+        )
+
+    app.add_exception_handler(ServiceUnavailableError, service_unavailable_handler)  # type: ignore[arg-type]
 
     async def lock_handler(
         request: Request, exc: TemporaryUnavailableError

--- a/app/modules/auth/router.py
+++ b/app/modules/auth/router.py
@@ -103,6 +103,8 @@ async def login(
             redis=redis,
         )
     except AppError as exc:
+        if exc.status_code >= 500:
+            raise
         # Record failure on auth error (wrong password, user not found, etc.)
         if settings.RATE_LIMIT_ENABLED:
             try:
@@ -172,6 +174,8 @@ async def refresh(
             request_ip=ip,
         )
     except AppError as exc:
+        if exc.status_code >= 500:
+            raise
         # Record failure on refresh error
         if settings.RATE_LIMIT_ENABLED:
             try:
@@ -228,6 +232,8 @@ async def logout(
             redis=redis,
         )
     except AppError as exc:
+        if exc.status_code >= 500:
+            raise
         if settings.RATE_LIMIT_ENABLED:
             try:
                 await rate_limiter.record_failure(ip, f"logout:{current_user.id}")
@@ -276,6 +282,8 @@ async def change_password(
             redis=redis,
         )
     except AppError as exc:
+        if exc.status_code >= 500:
+            raise
         if settings.RATE_LIMIT_ENABLED:
             try:
                 await rate_limiter.record_failure(ip, f"change-password:{current_user.id}")

--- a/app/modules/auth/service.py
+++ b/app/modules/auth/service.py
@@ -548,7 +548,11 @@ async def change_password(
     db: AsyncSession,
     redis: Redis,
 ) -> None:
-    """Cambia la contraseña y revoca todas las sesiones activas"""
+    """Change the password and revoke all active sessions.
+
+    Contract: DB rolls back; Redis partial denylist retained; active_jtis kept;
+    retry is idempotent and safe.
+    """
     if not await check_redis_healthy(redis):
         raise ServiceUnavailableError()
     user, _tenant = await _get_active_user_by_id(user_id, db)

--- a/app/modules/auth/service.py
+++ b/app/modules/auth/service.py
@@ -31,7 +31,7 @@ from app.modules.auth.schemas import TokenResponse
 from sqlalchemy.exc import DBAPIError
 
 from app.core.database import set_tenant_context
-from app.core.exceptions import AuthError, ServiceUnavailableError
+from app.core.exceptions import AuthError, RedisOutageError, ServiceUnavailableError
 from app.core.pii import hash_email, mask_ip, sanitize_user_agent
 from app.core.redis import check_redis_healthy
 from app.event_schemas import AuthLoginEvent, AuthSuperadminLoginEvent
@@ -409,22 +409,28 @@ async def login(
     try:
         event_bus = await get_event_bus()
         if user.is_superadmin:
-            await event_bus.publish(AuthSuperadminLoginEvent(
+            event = AuthSuperadminLoginEvent(
                 event_id=uuid4(),
                 user_id=str(user.id),
                 email_hash=hash_email(user.email),
                 ip_prefix=mask_ip(request_ip),
                 user_agent=safe_user_agent,
-            ))
+            )
         else:
-            await event_bus.publish(AuthLoginEvent(
+            event = AuthLoginEvent(
                 event_id=uuid4(),
                 tenant_id=user.tenant_id,
                 user_id=str(user.id),
                 email_hash=hash_email(user.email),
                 ip_prefix=mask_ip(request_ip),
                 user_agent=safe_user_agent,
-            ))
+            )
+        try:
+            await event_bus.publish(event)
+        except RedisOutageError:
+            await event_bus.publish(event)
+    except RedisOutageError:
+        logger.warning("event_publish_failed", event_type="auth.login", reason="redis_error")
     except RedisError:
         logger.warning("event_publish_failed", event_type="auth.login", reason="redis_error")
     except Exception:

--- a/app/modules/tenants/service.py
+++ b/app/modules/tenants/service.py
@@ -11,7 +11,7 @@ from sqlalchemy import select, func, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
-from app.core.exceptions import TenantError
+from app.core.exceptions import PartialFailureError, TenantError
 from app.core.security import revoke_all_user_access_tokens
 from app.modules.auth.service import _revoke_all_user_tokens_for_tenant
 from app.modules.tenants.models import Tenant
@@ -24,6 +24,37 @@ _PLAN_MAX_ASSETS: dict[str, int] = {
     "pro": 100,
     "enterprise": 500,
 }
+
+
+async def _revoke_user_tokens_deterministically(
+    user_ids: list[str],
+    redis: Redis,
+    ttl_seconds: int,
+) -> None:
+    """Revoke all user sessions and aggregate failures in input order."""
+    results = await asyncio.gather(
+        *(
+            revoke_all_user_access_tokens(
+                user_id=user_id,
+                redis=redis,
+                ttl_seconds=ttl_seconds,
+            )
+            for user_id in user_ids
+        ),
+        return_exceptions=True,
+    )
+    outcomes = [
+        (
+            f"{user_id}: {type(result).__name__} ({result})"
+            if isinstance(result, BaseException)
+            else f"{user_id}: success"
+        )
+        for user_id, result in zip(user_ids, results)
+    ]
+    if any(isinstance(result, BaseException) for result in results):
+        raise PartialFailureError(
+            "Tenant token revocation partially failed: " + "; ".join(outcomes)
+        )
 
 
 def _generate_slug(name: str) -> str:
@@ -191,15 +222,10 @@ async def update_tenant(
         user_ids = (
             await db.scalars(select(User.id).where(User.tenant_id == tenant_id))
         ).all()
-        await asyncio.gather(
-            *[
-                revoke_all_user_access_tokens(
-                    user_id=str(uid),
-                    redis=redis,
-                    ttl_seconds=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60,
-                )
-                for uid in user_ids
-            ]
+        await _revoke_user_tokens_deterministically(
+            user_ids=[str(uid) for uid in user_ids],
+            redis=redis,
+            ttl_seconds=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60,
         )
 
     await db.refresh(tenant)
@@ -232,15 +258,10 @@ async def deactivate_tenant(
     user_ids = (
         await db.scalars(select(User.id).where(User.tenant_id == tenant_id))
     ).all()
-    await asyncio.gather(
-        *[
-            revoke_all_user_access_tokens(
-                user_id=str(uid),
-                redis=redis,
-                ttl_seconds=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60,
-            )
-            for uid in user_ids
-        ]
+    await _revoke_user_tokens_deterministically(
+        user_ids=[str(uid) for uid in user_ids],
+        redis=redis,
+        ttl_seconds=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60,
     )
 
     await db.flush()

--- a/app/modules/users/service.py
+++ b/app/modules/users/service.py
@@ -137,6 +137,9 @@ async def update_user(
     not via `get_user_internal` — the Depends guarantees the
     cross-tenant pre-check ran. A hand-constructed User row would
     bypass the check.
+
+    Contract: DB rolls back; Redis partial denylist retained; active_jtis kept;
+    retry is idempotent and safe.
     """
     if not current_user.is_superadmin and target.tenant_id != current_user.tenant_id:
         raise UserError("Permisos insuficientes", status_code=403)
@@ -196,6 +199,9 @@ async def deactivate_user(
 
     NOTE: The router MUST obtain `target` via the cross-tenant Depends,
     not via `get_user_internal`.
+
+    Contract: DB rolls back; Redis partial denylist retained; active_jtis kept;
+    retry is idempotent and safe.
     """
     if not current_user.is_superadmin and target.tenant_id != current_user.tenant_id:
         raise UserError("Permisos insuficientes", status_code=403)

--- a/tests/integration/test_toxiproxy_fault_injection.py
+++ b/tests/integration/test_toxiproxy_fault_injection.py
@@ -156,7 +156,7 @@ async def test_refresh_outage_fails_closed(
     app_via_proxy: AsyncClient,
     toxiproxy_client: ToxiproxyTransportController,
 ):
-    """Refresh fails closed through the current service-health 503 contract."""
+    """Refresh fails closed through the sanitized global outage boundary."""
     await _login(app_via_proxy)
 
     async with _connection_drop(toxiproxy_client):
@@ -165,8 +165,7 @@ async def test_refresh_outage_fails_closed(
             timeout=REQUEST_TIMEOUT_SECONDS,
         )
 
-    assert response.status_code == 503
-    assert response.json() == {"detail": "Servicio temporalmente no disponible"}
+    _assert_lock_outage(response)
     assert "access_token" not in response.json()
     assert "set-cookie" not in response.headers
 
@@ -179,12 +178,12 @@ async def test_refresh_outage_fails_closed(
 
 
 @pytest.mark.asyncio
-async def test_current_user_token_outage_direct_503(
+async def test_current_user_token_outage_sanitized_503(
     seed_data,
     app_via_proxy: AsyncClient,
     toxiproxy_client: ToxiproxyTransportController,
 ):
-    """Current-user token lookup keeps its direct HTTP 503 boundary."""
+    """Current-user token lookup outage surfaces the sanitized global 503 boundary."""
     access_token, _ = await _login(app_via_proxy)
     headers = {"Authorization": f"Bearer {access_token}"}
 
@@ -194,8 +193,7 @@ async def test_current_user_token_outage_direct_503(
             timeout=REQUEST_TIMEOUT_SECONDS,
         )
 
-    assert response.status_code == 503
-    assert response.json() == {"detail": "Servicio temporalmente no disponible"}
+    _assert_lock_outage(response)
 
     recovered = await asyncio.wait_for(
         app_via_proxy.get("/api/v1/users/me", headers=headers),

--- a/tests/unit/test_auth_router_outage_boundary.py
+++ b/tests/unit/test_auth_router_outage_boundary.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import Depends, FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from app.core.config import settings
+from app.core.exceptions import AuthError, RedisOutageError
+from app.core.database import get_db
+from app.core.redis import get_redis
+from app.dependencies.auth import get_current_user
+from app.core.security import create_access_token
+from app.main import create_app
+
+
+def _build_app() -> FastAPI:
+    app = create_app()
+
+    async def override_db():
+        return MagicMock()
+
+    async def override_redis():
+        return MagicMock()
+
+    async def override_current_user():
+        return SimpleNamespace(id="user-1", current_jti="jti-1")
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_redis] = override_redis
+    app.dependency_overrides[get_current_user] = override_current_user
+    return app
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("path", "method_name", "request_kwargs"),
+    [
+        ("/api/v1/auth/login", "login", {"json": {"email": "u@example.com", "password": "Password123!"}}),
+        ("/api/v1/auth/refresh", "refresh_tokens", {"cookies": {"refresh_token": "refresh-1"}}),
+        ("/api/v1/auth/logout", "logout", {}),
+        (
+            "/api/v1/auth/change-password",
+            "change_password",
+            {"json": {"current_password": "OldPassword123!", "new_password": "NewPassword123!"}},
+        ),
+    ],
+)
+async def test_auth_router_re_raises_typed_outage_to_global_handler(
+    monkeypatch: pytest.MonkeyPatch,
+    path: str,
+    method_name: str,
+    request_kwargs: dict,
+) -> None:
+    monkeypatch.setattr(settings, "RATE_LIMIT_ENABLED", False)
+    app = _build_app()
+    service_method = AsyncMock(side_effect=RedisOutageError("database credential leaked"))
+
+    with patch.object(__import__("app.modules.auth.service", fromlist=[method_name]), method_name, service_method):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            response = await client.post(path, **request_kwargs)
+
+    assert response.status_code == 503
+    assert response.json() == {"detail": "service temporarily unavailable"}
+    assert response.headers["Retry-After"] == str(settings.REDIS_OUTAGE_RETRY_AFTER_SECONDS)
+    assert "database credential leaked" not in response.text
+    service_method.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_auth_router_still_converts_sub_500_app_errors() -> None:
+    from app.modules.auth import service
+
+    app = _build_app()
+    service_method = AsyncMock(
+        side_effect=AuthError(status_code=401, detail="Credenciales incorrectas")
+    )
+
+    with patch.object(service, "login", service_method):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            response = await client.post(
+                "/api/v1/auth/login",
+                json={"email": "u@example.com", "password": "wrong"},
+            )
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Credenciales incorrectas"}
+    assert "Retry-After" not in response.headers
+    service_method.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_current_user_health_failure_uses_global_service_handler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "app.dependencies.auth.check_redis_healthy", AsyncMock(return_value=False)
+    )
+    app = _build_app()
+    app.dependency_overrides.pop(get_current_user)
+
+    @app.get("/_test/current-user")
+    async def _current_user_route(user=Depends(get_current_user)):
+        return {"user_id": str(user.id)}
+
+    token, _ = create_access_token(
+        user_id=str(uuid4()),
+        tenant_id=str(uuid4()),
+        role="admin",
+        is_superadmin=False,
+    )
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get(
+            "/_test/current-user", headers={"Authorization": f"Bearer {token}"}
+        )
+
+    assert response.status_code == 503
+    assert response.json() == {"detail": "service temporarily unavailable"}
+    assert response.headers["Retry-After"] == str(settings.REDIS_OUTAGE_RETRY_AFTER_SECONDS)
+
+
+@pytest.mark.asyncio
+async def test_login_masked_rate_limit_precheck_stays_generic_401(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.modules.auth import router as auth_router
+    from app.modules.auth import service
+
+    monkeypatch.setattr(settings, "RATE_LIMIT_ENABLED", True)
+    app = _build_app()
+    service_login = AsyncMock()
+    rate_limiter = SimpleNamespace(
+        check=AsyncMock(return_value=SimpleNamespace(is_locked=True)),
+        record_failure=AsyncMock(),
+        record_success=AsyncMock(),
+    )
+
+    async def override_rate_limiter():
+        return rate_limiter
+
+    app.dependency_overrides[auth_router._get_rate_limiter] = override_rate_limiter
+    with patch.object(service, "login", service_login):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            response = await client.post(
+                "/api/v1/auth/login",
+                json={"email": "u@example.com", "password": "wrong"},
+            )
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Credenciales incorrectas"}
+    assert "Retry-After" not in response.headers
+    service_login.assert_not_awaited()

--- a/tests/unit/test_auth_service_event_publish.py
+++ b/tests/unit/test_auth_service_event_publish.py
@@ -203,7 +203,7 @@ class TestAuthLoginEventPublish:
         """Test login succeeds even if event publishing fails (non-blocking)."""
         from app.modules.auth import service
         from app.event_bus import EventBus
-        from redis.exceptions import RedisError
+        from app.core.exceptions import RedisOutageError
 
         mock_user = MagicMock()
         mock_user.id = uuid4()
@@ -221,8 +221,8 @@ class TestAuthLoginEventPublish:
         mock_redis = AsyncMock()
 
         mock_event_bus = AsyncMock(spec=EventBus)
-        # Simulate RedisError during publish (realistic failure scenario)
-        mock_event_bus.publish.side_effect = RedisError("Connection refused")
+        # EventBus classifies XADD failures as RedisOutageError.
+        mock_event_bus.publish.side_effect = RedisOutageError("Connection refused")
 
         with patch.object(service, "_check_account_lockout", return_value=None):
             with patch.object(service, "_get_active_user", return_value=(mock_user, mock_tenant)):
@@ -255,11 +255,11 @@ class TestAuthLoginEventPublish:
         assert token_response.access_token == "access_token"
         assert refresh_token == "refresh_token"
 
-        # RedisError → warning was logged about the publish failure
+        # RedisOutageError → warning was logged about the publish failure
         mock_warning.assert_called_once_with(
             "event_publish_failed", event_type="auth.login", reason="redis_error"
         )
-        mock_event_bus.publish.assert_awaited_once()
+        assert mock_event_bus.publish.await_count == 2
         assert "Connection refused" not in repr(mock_warning.call_args)
 
     @pytest.mark.asyncio
@@ -502,6 +502,7 @@ class TestLoginEventErrorHandling:
     async def test_typed_outage_retry_succeeds_without_failure_warning(self):
         from app.core.exceptions import RedisOutageError
         from app.modules.auth import service
+        from redis.exceptions import RedisError
 
         with patch.object(service.logger, "warning") as mock_warning:
             result, mock_event_bus = await _login_with_publish_side_effect(
@@ -512,11 +513,14 @@ class TestLoginEventErrorHandling:
         assert mock_event_bus.publish.await_count == 2
         mock_warning.assert_not_called()
 
+        _, raw_event_bus = await _login_with_publish_side_effect(RedisError("raw transport"))
+        assert raw_event_bus.publish.await_count == 1
+
     @pytest.mark.asyncio
     async def test_redis_error_during_publish_logs_warning(self):
         """RedisError during publish → logger.warning, login still succeeds."""
         from app.modules.auth import service
-        from redis.exceptions import RedisError
+        from app.core.exceptions import RedisOutageError
 
         mock_user = MagicMock()
         mock_user.id = uuid4()
@@ -534,7 +538,7 @@ class TestLoginEventErrorHandling:
         mock_redis = AsyncMock()
 
         mock_event_bus = AsyncMock()
-        mock_event_bus.publish.side_effect = RedisError("Connection refused")
+        mock_event_bus.publish.side_effect = RedisOutageError("Connection refused")
 
         with patch.object(service, "_check_account_lockout", return_value=None):
             with patch.object(service, "_get_active_user", return_value=(mock_user, mock_tenant)):

--- a/tests/unit/test_auth_service_event_publish.py
+++ b/tests/unit/test_auth_service_event_publish.py
@@ -14,6 +14,48 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from uuid import uuid4
 
 
+async def _login_with_publish_side_effect(publish_side_effect):
+    from app.modules.auth import service
+    from app.event_bus import EventBus
+
+    mock_user = MagicMock()
+    mock_user.id = uuid4()
+    mock_user.email = "publish-retry@test.com"
+    mock_user.hashed_password = "hashed_password"
+    mock_user.tenant_id = uuid4()
+    mock_user.role = "admin"
+    mock_user.is_superadmin = False
+    mock_user.is_active = True
+    mock_tenant = MagicMock()
+    mock_tenant.is_active = True
+    mock_db = MagicMock(spec=AsyncSession)
+    mock_db.execute = AsyncMock()
+    mock_redis = AsyncMock()
+    mock_event_bus = AsyncMock(spec=EventBus)
+    mock_event_bus.publish.side_effect = publish_side_effect
+
+    with patch.multiple(
+        service,
+        _check_account_lockout=AsyncMock(),
+        _get_active_user=AsyncMock(return_value=(mock_user, mock_tenant)),
+        verify_password_async=AsyncMock(return_value=True),
+        _check_tenant_active=AsyncMock(),
+        _clear_login_attempts=AsyncMock(),
+        create_access_token=MagicMock(return_value=("access_token", "jti-retry")),
+        _create_refresh_token=AsyncMock(return_value="refresh_token"),
+        get_event_bus=AsyncMock(return_value=mock_event_bus),
+    ):
+        result = await service.login(
+            email="publish-retry@test.com",
+            password="password",
+            db=mock_db,
+            redis=mock_redis,
+            request_ip="10.0.0.1",
+        )
+
+    return result, mock_event_bus
+
+
 class TestAuthLoginEventPublish:
     """Test that auth.login event is published on successful login."""
 
@@ -432,6 +474,43 @@ class TestLoginEventErrorHandling:
     RedisError → logger.warning (swallowed).
     Programming errors → logger.critical (NOT re-raised).
     """
+
+    @pytest.mark.asyncio
+    async def test_typed_outage_retries_once_then_warns_and_returns_tokens(self):
+        from app.core.exceptions import RedisOutageError
+        from app.modules.auth import service
+
+        with patch.object(service.logger, "warning") as mock_warning:
+            with patch.object(service.logger, "critical") as mock_critical:
+                result, mock_event_bus = await _login_with_publish_side_effect(
+                    [
+                        RedisOutageError("first outage"),
+                        RedisOutageError("final outage"),
+                    ]
+                )
+
+        token_response, refresh_token = result
+        assert token_response.access_token == "access_token"
+        assert refresh_token == "refresh_token"
+        assert mock_event_bus.publish.await_count == 2
+        mock_warning.assert_called_once_with(
+            "event_publish_failed", event_type="auth.login", reason="redis_error"
+        )
+        mock_critical.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_typed_outage_retry_succeeds_without_failure_warning(self):
+        from app.core.exceptions import RedisOutageError
+        from app.modules.auth import service
+
+        with patch.object(service.logger, "warning") as mock_warning:
+            result, mock_event_bus = await _login_with_publish_side_effect(
+                [RedisOutageError("transient outage"), None]
+            )
+
+        assert result[0].access_token == "access_token"
+        assert mock_event_bus.publish.await_count == 2
+        mock_warning.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_redis_error_during_publish_logs_warning(self):

--- a/tests/unit/test_imports.py
+++ b/tests/unit/test_imports.py
@@ -49,7 +49,7 @@ PR1_INDENT_IMPORT_ALLOWLIST: set[tuple[str, int, str]] = {
     # loaded at boot when `get_llm_provider()` returns a non-HTTP provider
     # (issue #194). `get_llm_provider` itself was hoisted to module level
     # (line 13) and is no longer in this allowlist.
-    ("app/main.py", 173, "_BaseHTTPProvider"),
+    ("app/main.py", 177, "_BaseHTTPProvider"),
     # `from app.core.metrics_auth import _current_bytes, _previous_bytes` is a
     # deferred import inside `create_app()` to break the
     # `app.core.config` ↔ `app.core.metrics_auth` import cycle. If hoisted to
@@ -58,7 +58,7 @@ PR1_INDENT_IMPORT_ALLOWLIST: set[tuple[str, int, str]] = {
     # module`. PR4 design rev 17 (section "Candidate encoding timing") documents
     # this as the explicit trade-off; the eager priming surfaces encoding
     # failures at app boot rather than on the first scrape.
-    ("app/main.py", 273, "_current_bytes"),
+    ("app/main.py", 289, "_current_bytes"),
 }
 
 

--- a/tests/unit/test_metrics_outage_handler.py
+++ b/tests/unit/test_metrics_outage_handler.py
@@ -16,6 +16,7 @@ from app.core.config import settings
 from app.core.exceptions import (
     RedisOutageError,
     RedisUnreachableError,
+    ServiceUnavailableError,
     TemporaryUnavailableError,
 )
 from app.main import create_app
@@ -120,6 +121,28 @@ class TestRedisOutageHandler:
         assert "connection refused" not in response.text
 
     @pytest.mark.asyncio
+    async def test_service_unavailable_translates_to_sanitized_503_with_retry_after(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(settings, "REDIS_OUTAGE_RETRY_AFTER_SECONDS", 42)
+        app = create_app()
+
+        @app.get("/_test/raise-service-unavailable", include_in_schema=False)
+        async def _raise_service_unavailable():
+            raise ServiceUnavailableError("redis health check failed")
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            response = await client.get("/_test/raise-service-unavailable")
+
+        assert response.status_code == 503
+        assert response.headers["Retry-After"] == "42"
+        assert response.json() == {"detail": "service temporarily unavailable"}
+        assert "redis health check failed" not in response.text
+        assert "ServiceUnavailableError" not in response.text
+
+    @pytest.mark.asyncio
     async def test_temporary_unavailable_error_uses_lock_handler(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -152,3 +175,9 @@ class TestRedisOutageHandler:
             RedisOutageError in app.exception_handlers
         ), "RedisOutageError handler MUST be registered"
         assert callable(app.exception_handlers[RedisOutageError])
+
+    def test_service_unavailable_handler_is_registered(self) -> None:
+        app = create_app()
+
+        assert ServiceUnavailableError in app.exception_handlers
+        assert callable(app.exception_handlers[ServiceUnavailableError])

--- a/tests/unit/test_partial_state_contract.py
+++ b/tests/unit/test_partial_state_contract.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fakeredis.aioredis import FakeRedis
+from redis.exceptions import ConnectionError as RedisConnectionError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.exceptions import RedisOutageError
+
+
+_CONTRACT = "DB rolls back; Redis partial denylist retained; active_jtis kept; retry is idempotent and safe"
+
+
+@pytest.mark.asyncio
+async def test_change_password_contract_propagates_outage_and_allows_safe_retry() -> None:
+    from app.modules.auth import service
+
+    user = SimpleNamespace(hashed_password="old-hash")
+    db = MagicMock(spec=AsyncSession)
+    redis = MagicMock()
+    revoke_access = AsyncMock(
+        side_effect=[RedisOutageError("partial denylist"), None]
+    )
+
+    with (
+        patch.object(service, "check_redis_healthy", AsyncMock(return_value=True)),
+        patch.object(service, "_get_active_user_by_id", AsyncMock(return_value=(user, None))),
+        patch.object(service, "verify_password_async", AsyncMock(return_value=True)),
+        patch.object(service, "hash_password_async", AsyncMock(return_value="new-hash")),
+        patch.object(service, "_revoke_all_user_tokens", AsyncMock()) as revoke_db,
+        patch.object(service, "revoke_all_user_access_tokens", revoke_access),
+    ):
+        with pytest.raises(RedisOutageError):
+            await service.change_password(
+                user_id=uuid4(),
+                current_password="OldPassword123!",
+                new_password="NewPassword123!",
+                current_jti="jti-1",
+                db=db,
+                redis=redis,
+            )
+
+        user.hashed_password = "old-hash"  # simulate the surrounding DB rollback
+        await service.change_password(
+            user_id=uuid4(),
+            current_password="OldPassword123!",
+            new_password="NewPassword123!",
+            current_jti="jti-1",
+            db=db,
+            redis=redis,
+        )
+
+    revoke_db.assert_awaited()
+    assert revoke_access.await_count == 2
+
+
+def test_change_password_documents_partial_state_contract() -> None:
+    from app.modules.auth import service
+
+    assert _CONTRACT in " ".join(service.change_password.__doc__.split())
+
+
+@pytest.mark.asyncio
+async def test_partial_denylist_is_retained_and_retry_is_idempotent() -> None:
+    from app.core.security import is_token_revoked, revoke_all_user_access_tokens
+
+    class FailOnceRedis(FakeRedis):
+        failed = False
+
+        async def set(self, key: str, *args, **kwargs):  # type: ignore[override]
+            if key == "revoked:jti-b" and not self.failed:
+                self.failed = True
+                raise RedisConnectionError("transient Redis failure")
+            return await super().set(key, *args, **kwargs)
+
+    redis = FailOnceRedis()
+    try:
+        await redis.sadd("active_jtis:contract-user", "jti-a", "jti-b")
+
+        with pytest.raises(RedisOutageError):
+            await revoke_all_user_access_tokens(
+                "contract-user", redis, ttl_seconds=60
+            )
+
+        assert await redis.smembers("active_jtis:contract-user") == {
+            b"jti-a",
+            b"jti-b",
+        }
+        assert await is_token_revoked("jti-a", redis) is True
+
+        await revoke_all_user_access_tokens("contract-user", redis, ttl_seconds=60)
+
+        assert await redis.exists("active_jtis:contract-user") == 0
+        assert await is_token_revoked("jti-a", redis) is True
+        assert await is_token_revoked("jti-b", redis) is True
+    finally:
+        await redis.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["update_user", "deactivate_user"])
+async def test_user_revocation_contract_propagates_outage_and_allows_safe_retry(
+    operation: str,
+) -> None:
+    from app.modules.users import service
+    from app.modules.users.schemas import UserUpdate
+
+    tenant_id = uuid4()
+    current = SimpleNamespace(tenant_id=tenant_id, is_superadmin=True)
+    target = SimpleNamespace(id=uuid4(), tenant_id=tenant_id, is_active=True)
+    db = MagicMock(spec=AsyncSession)
+    db.flush = AsyncMock()
+    db.refresh = AsyncMock()
+    revoke_access = AsyncMock(
+        side_effect=[RedisOutageError("partial denylist"), None]
+    )
+
+    with (
+        patch.object(service, "_revoke_all_user_tokens", AsyncMock()),
+        patch.object(service, "revoke_all_user_access_tokens", revoke_access),
+    ):
+        if operation == "update_user":
+
+            async def call():
+                return await service.update_user(
+                    current_user=current,
+                    target=target,
+                    data=UserUpdate(is_active=False),
+                    db=db,
+                    redis=object(),
+                )
+        else:
+
+            async def call():
+                return await service.deactivate_user(
+                    current_user=current,
+                    target=target,
+                    db=db,
+                    redis=object(),
+                )
+        with pytest.raises(RedisOutageError):
+            await call()
+
+        target.is_active = True  # simulate the surrounding DB rollback
+        await call()
+
+    assert revoke_access.await_count == 2
+
+
+@pytest.mark.parametrize("operation", ["update_user", "deactivate_user"])
+def test_user_services_document_partial_state_contract(operation: str) -> None:
+    from app.modules.users import service
+
+    assert _CONTRACT in " ".join(getattr(service, operation).__doc__.split())

--- a/tests/unit/test_redis_fail_closed.py
+++ b/tests/unit/test_redis_fail_closed.py
@@ -5,7 +5,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from sqlalchemy.ext.asyncio import AsyncSession
 
 import pytest
-from fastapi import HTTPException
 
 
 class TestRedisFailClosed:
@@ -111,8 +110,9 @@ class TestRedisFailClosed:
 
     @pytest.mark.asyncio
     async def test_get_current_user_returns_503_when_redis_down(self):
-        """get_current_user() MUST raise HTTPException(503) when Redis is unhealthy."""
+        """get_current_user() MUST raise ServiceUnavailableError when Redis is unhealthy."""
         from app.core.security import create_access_token
+        from app.core.exceptions import ServiceUnavailableError
 
         token, _ = create_access_token(
             user_id=str(uuid4()),
@@ -127,7 +127,7 @@ class TestRedisFailClosed:
         with patch("app.dependencies.auth.check_redis_healthy", return_value=False):
             from app.dependencies import get_current_user
 
-            with pytest.raises(HTTPException) as exc_info:
+            with pytest.raises(ServiceUnavailableError) as exc_info:
                 await get_current_user(
                     token=token,
                     db=mock_db,

--- a/tests/unit/test_tenant_partial_revocation.py
+++ b/tests/unit/test_tenant_partial_revocation.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.core.config import settings
+from app.core.database import get_db
+from app.core.exceptions import PartialFailureError, RedisOutageError
+from app.core.redis import get_redis
+from app.dependencies import get_tenant_deactivation_db, require_superadmin
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure_index", [0, 1, 2])
+async def test_tenant_revocations_aggregate_failures_in_user_order(
+    failure_index: int,
+) -> None:
+    from app.modules.tenants import service
+
+    user_ids = ["user-a", "user-b", "user-c"]
+    failures = [
+        None,
+        RedisOutageError("redis failure"),
+        None,
+    ]
+    failures[failure_index] = RedisOutageError(f"failure-{failure_index}")
+    revoke = AsyncMock(side_effect=failures)
+
+    with patch.object(service, "revoke_all_user_access_tokens", revoke):
+        with pytest.raises(PartialFailureError) as exc_info:
+            await service._revoke_user_tokens_deterministically(
+                user_ids=user_ids,
+                redis=MagicMock(),
+                ttl_seconds=60,
+            )
+
+    assert str(exc_info.value).index("user-a") < str(exc_info.value).index("user-b")
+    assert str(exc_info.value).index("user-b") < str(exc_info.value).index("user-c")
+    assert f"failure-{failure_index}" in str(exc_info.value)
+    assert revoke.await_count == len(user_ids)
+
+
+@pytest.mark.asyncio
+async def test_tenant_revocations_complete_all_users_when_no_failure() -> None:
+    from app.modules.tenants import service
+
+    revoke = AsyncMock()
+    with patch.object(service, "revoke_all_user_access_tokens", revoke):
+        result = await service._revoke_user_tokens_deterministically(
+            user_ids=["user-a", "user-b"],
+            redis=MagicMock(),
+            ttl_seconds=60,
+        )
+
+    assert result is None
+    assert [call.kwargs["user_id"] for call in revoke.await_args_list] == [
+        "user-a",
+        "user-b",
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["update_tenant", "deactivate_tenant"])
+async def test_tenant_mutations_raise_partial_failure_after_all_revocations(
+    operation: str,
+) -> None:
+    from app.modules.tenants import service
+    from app.modules.tenants.schemas import TenantUpdate
+
+    tenant_id = uuid4()
+    tenant = SimpleNamespace(id=tenant_id, is_active=True)
+    db = MagicMock()
+    db.execute = AsyncMock()
+    db.flush = AsyncMock()
+    db.refresh = AsyncMock()
+    scalar_result = MagicMock()
+    scalar_result.all.return_value = [uuid4(), uuid4()]
+    db.scalars = AsyncMock(return_value=scalar_result)
+    lookup_result = MagicMock()
+    lookup_result.scalar_one_or_none.return_value = tenant
+    db.execute.return_value = lookup_result
+    revoke = AsyncMock(
+        side_effect=[RedisOutageError("first user failed"), None]
+    )
+
+    with (
+        patch.object(service, "_revoke_all_user_tokens_for_tenant", AsyncMock()),
+        patch.object(service, "revoke_all_user_access_tokens", revoke),
+    ):
+        with pytest.raises(PartialFailureError):
+            if operation == "update_tenant":
+                await service.update_tenant(
+                    tenant_id, TenantUpdate(is_active=False), db, MagicMock()
+                )
+            else:
+                await service.deactivate_tenant(tenant_id, db, MagicMock())
+
+    assert tenant.is_active is False
+    assert revoke.await_count == 2
+    db.refresh.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_tenant_deactivation_partial_failure_uses_global_sanitized_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.modules.tenants import service
+    from app.main import create_app
+
+    monkeypatch.setattr(settings, "REDIS_OUTAGE_RETRY_AFTER_SECONDS", 37)
+    app = create_app()
+
+    async def override_db():
+        return MagicMock()
+
+    async def override_redis():
+        return MagicMock()
+
+    async def override_tenant_db():
+        yield MagicMock()
+
+    async def override_superadmin():
+        return SimpleNamespace(is_superadmin=True)
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_redis] = override_redis
+    app.dependency_overrides[get_tenant_deactivation_db] = override_tenant_db
+    app.dependency_overrides[require_superadmin] = override_superadmin
+
+    with patch.object(
+        service,
+        "deactivate_tenant",
+        AsyncMock(side_effect=PartialFailureError("user-b: RedisOutageError")),
+    ):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            response = await client.delete(f"/api/v1/tenants/{uuid4()}")
+
+    assert response.status_code == 503
+    assert response.json() == {"detail": "service temporarily unavailable"}
+    assert response.headers["Retry-After"] == "37"
+    assert "user-b" not in response.text


### PR DESCRIPTION
Part of #260 — Slice A of the closing slice (PR 9/9, split into A/B). Does NOT close the epic: Slice B (observability) follows.

## Summary
- **R1 — 503 isolation**: registers a global `ServiceUnavailableError` handler in `create_app` (sanitized 503 + `Retry-After`); the four auth endpoint catch blocks now re-raise `AppError` with status >= 500 so typed outages reach the global handler instead of being converted to unsanitized router 503s; `get_current_user` raises the typed error on unhealthy Redis (`app/main.py`, `app/modules/auth/router.py`, `app/dependencies/auth.py`).
- **R2 — partial-state + deterministic gather**: pins the `change_password` / `update_user` / `deactivate_user` partial-state contract (denylist-first ordering, rollback via request transaction, idempotent retry, retained `active_jtis`); tenant revocations now use `gather(return_exceptions=True)` with deterministic in-order aggregation into `PartialFailureError`, whose HTTP boundary returns sanitized 503 + `Retry-After` (`app/modules/tenants/service.py`, contract suites).
- **R5 — login publish catch order**: `login` catches typed `RedisOutageError` before raw `RedisError`, performs exactly one immediate retry (reusing the materialized event), logs WARNING on final typed outage, and still returns tokens; raw transport stays a non-retried defensive branch and programming errors stay CRITICAL (`app/modules/auth/service.py`).
- Preserves decision #1833: the masked login rate-limit precheck remains a generic 401 without `Retry-After` (characterization pin).

## What is intentionally missing
- Slice B (T11–T17): FlowId wiring through revocation primitives, EventBus flow label, outage/latency/retry/partial-revocation metrics recorders, docstring fix — lands as the follow-up PR.
- `METRIC_RETRY` recorder deferred to Slice B (T14) by design.
- Two verify WARNINGs consciously accepted (coverage gaps, not defects): the `ServiceUnavailableError` handler is exercised through a test-only route rather than every real endpoint boundary, and partial-state DB rollback is simulated in-memory in unit tests (production rollback lives in `get_db`). Follow-up: integration hardening with real transactions and endpoint-level health-failure tests.

## Native review note (maintainer decision)
The Gentle AI native review classified this candidate as high risk (touches authentication, 13 files / 723 lines). The maintainer declined review consent for this exact candidate (`declined_this_candidate`, no lineage, no receipt); the pre-push gate failed closed on `receipt_missing` as designed. Delivery proceeds unmanaged by the native gate under ordinary repository policy, with the independent SDD verification as evidence.

## Design and specification references
- Engram verify #2317: `sdd/pr9-closing-slice/verify-report` (verdict PASS, 3/3 requirements, 16/16 scenarios, 0 CRITICAL / 2 WARNING / 1 SUGGESTION)
- Engram apply-progress #2311: `sdd/pr9-closing-slice/apply-progress` (strict TDD evidence for T1–T10)
- Engram spec #2305, design #2306, tasks #2307, proposal #2304

## Test plan
- [x] Focused batch 1: `uv run pytest tests/unit/test_metrics_outage_handler.py tests/unit/test_main_lock_handler.py tests/unit/test_imports.py tests/unit/test_redis_fail_closed.py tests/unit/test_auth_router_outage_boundary.py -q` → 40 passed, 2 xfailed
- [x] Focused batch 2: `uv run pytest tests/unit/test_auth_service_event_publish.py tests/unit/test_users.py tests/unit/test_security.py tests/unit/test_partial_state_contract.py -q` → 102 passed
- [x] Focused batch 3: `uv run pytest tests/unit/test_tenants.py tests/unit/test_tenant_partial_revocation.py -q` → 41 passed
- [x] Full unit suite: `uv run pytest tests/unit -q` → 830 passed, 1 skipped, 2 xfailed
- [x] Conventional commits, no Co-Authored-By; diff 723 authored lines (under the 800-line review budget)

## CI fix (f4e9363)
- Two PR6-era Toxiproxy integration tests characterized the pre-Slice-A Spanish 503 detail produced by router-level conversion. Slice A intentionally routes typed outages to the sanitized global handler (R1), so `test_refresh_outage_fails_closed` and the renamed `test_current_user_token_outage_sanitized_503` now assert the sanitized contract via the existing `_assert_lock_outage` helper (503 + English detail + Retry-After). Test-only change; no production behavior altered.
